### PR TITLE
add a more descriptive error when sound file cannot be found

### DIFF
--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -5,11 +5,13 @@ Sound library.
 from platform import system
 import typing
 import pyglet
-
+from pathlib import Path
 
 class Sound:
 
     def __init__(self, file_name: str):
+        if not Path(file_name).is_file():
+            raise FileNotFoundError(f"The sound file '{file_name}' is not a file or can't be read")
         self.file_name = file_name
         self.player = pyglet.media.load(file_name)
 


### PR DESCRIPTION
You get some difficult to read and different exceptions if you pass a file that does not exist into a sound (depending on suffix etc).  This PR gives a cleaner exception to the programmer.  Thought it would be useful to help kids realize they sent a bad path.  I do not know if Pathlib's is_file adds much overhead but it should only happen on the creation of the Sound anyway.

Stuff like this:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jvogel/Nextcloud/src/arcade/arcade/sound.py", line 16, in __init__
    self.player = pyglet.media.load(file_name)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/__init__.py", line 133, in load
    loaded_source = decoder.decode(file, filename, streaming)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/wave.py", line 109, in decode
    return WaveSource(filename, file)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/wave.py", line 54, in __init__
    file = open(filename, 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'foo'
>>> sound.Sound('foo.ogg')
Exception ignored in: <function WaveSource.__del__ at 0x7f9510adb598>
Traceback (most recent call last):
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/wave.py", line 79, in __del__
    self._file.close()
AttributeError: 'WaveSource' object has no attribute '_file'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jvogel/Nextcloud/src/arcade/arcade/sound.py", line 16, in __init__
    self.player = pyglet.media.load(file_name)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/__init__.py", line 133, in load
    loaded_source = decoder.decode(file, filename, streaming)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/ffmpeg.py", line 1041, in decode
    return FFmpegSource(filename, file)
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/ffmpeg.py", line 460, in __init__
    self._file = ffmpeg_open_filename(asbytes_filename(filename))
  File "/home/jvogel/.pyenv/versions/arcade/lib/python3.7/site-packages/pyglet/media/codecs/ffmpeg.py", line 143, in ffmpeg_open_filename
    raise FFmpegException('Error opening file ' + filename.decode("utf8"))
pyglet.media.codecs.ffmpeg.FFmpegException: Error opening file foo.ogg
```
Becomes: 
```
>>> sound.Sound('foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jvogel/Nextcloud/src/arcade/arcade/sound.py", line 14, in __init__
    raise FileNotFoundError(f"The sound file '{file_name}' is not a file or can't be read")
FileNotFoundError: The sound file 'foo' is not a file or can't be read
```
