### PR TITLE
explicity state delta time is in seconds

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -83,7 +83,7 @@ class Window(pyglet.window.Window):
         """
         Move everything. For better consistency in naming, use ``on_update`` instead.
 
-        :param float delta_time: Time interval since the last time the function was called.
+        :param float delta_time: Time interval since the last time the function was called in seconds.
 
         """
         try:


### PR DESCRIPTION
This tripped me up when reading the docs, some game libraries do this in milliseconds.  After seeing the issue also related to it I just made it explicit in the documentation like @pvcraven said in #452.