### PR TITLE
Issue #748 - Fixed bug when setting shader uniform arrays

### DIFF
--- a/arcade/gl/uniform.py
+++ b/arcade/gl/uniform.py
@@ -122,7 +122,7 @@ class Uniform:
             self._program_id, self._location, gl_getter, c_array, length
         )
         self.setter = Uniform._create_setter_func(
-            self._location, gl_setter, c_array, length, count, ptr, is_matrix
+            self._location, gl_setter, c_array, length, self._array_length, count, ptr, is_matrix
         )
 
     @staticmethod
@@ -146,7 +146,7 @@ class Uniform:
 
     @staticmethod
     def _create_setter_func(
-        location, gl_setter, c_array, length, count, ptr, is_matrix
+        location, gl_setter, c_array, length, array_length, count, ptr, is_matrix
     ):
         """ Create setters for OpenGL data. """
         if is_matrix:
@@ -154,21 +154,21 @@ class Uniform:
             def setter_func(value):  # type: ignore #conditional function variants must have identical signature
                 """ Set OpenGL matrix uniform data. """
                 c_array[:] = value
-                gl_setter(location, count, gl.GL_FALSE, ptr)
+                gl_setter(location, array_length, gl.GL_FALSE, ptr)
 
         elif length == 1 and count == 1:
 
             def setter_func(value):  # type: ignore #conditional function variants must have identical signature
                 """ Set OpenGL uniform data value. """
                 c_array[0] = value
-                gl_setter(location, count, ptr)
+                gl_setter(location, array_length, ptr)
 
         elif length > 1 and count == 1:
 
             def setter_func(values):  # type: ignore #conditional function variants must have identical signature
                 """ Set list of OpenGL uniform data. """
                 c_array[:] = values
-                gl_setter(location, count, ptr)
+                gl_setter(location, array_length, ptr)
 
         else:
             raise NotImplementedError("Uniform type not yet supported.")


### PR DESCRIPTION
Here is my proposed fix for the issue described in #748. 

The size value obtained from glGetActiveUniform is used as the count argument for glUniformXXv, allowing for the entire uniform array to be set, and causing no change in behavior for uniforms that are not arrays, as glGetActiveUniform will return size 1 for them.