### PR TITLE
Solves issue #752

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -571,6 +571,7 @@ class Sprite:
         if new_value != self._width:
             self.clear_spatial_hashes()
             self._point_list_cache = None
+            self._points = None
             self._width = new_value
             self.add_spatial_hashes()
 
@@ -588,6 +589,7 @@ class Sprite:
         if new_value != self._height:
             self.clear_spatial_hashes()
             self._point_list_cache = None
+            self._points = None
             self._height = new_value
             self.add_spatial_hashes()
 

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -20,6 +20,7 @@ from arcade import calculate_hit_box_points_simple
 from arcade import calculate_hit_box_points_detailed
 from arcade.resources import resolve_resource_path
 
+
 def _lerp_color(start_color: Color, end_color: Color, u: float) -> Color:
     return (
         int(lerp(start_color[0], end_color[0], u)),
@@ -61,6 +62,7 @@ class Matrix3x3:
 
     def shear(self, sx: float, sy: float):
         return self.multiply([1.0, sy, 0.0, sx, 1.0, 0.0, 0.0, 0.0, 1.0])
+
 
 class Texture:
     """


### PR DESCRIPTION
Updating sprite width/height was not changing it's hitbox. Now it is.

Working with to the code example posted by @eruvanos :

The old spaceship sprite before width change:
![width old](https://user-images.githubusercontent.com/40523203/94427950-30c3f880-0190-11eb-84bf-320e73271fe6.png)

And after self.sprite.width changed to 198:
![width changed](https://user-images.githubusercontent.com/40523203/94427968-3de0e780-0190-11eb-8200-d9e6763615de.png)

Also, assertions:

`        assert hit'`
`        assert self.sprite.right == self.sprite.center_x + 90`

 are now resolved to True.
