### PR TITLE
Improve support for a number of TMX/Tiled features

### DIFF
--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -471,6 +471,10 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
                 if tile.tileset.tile_offset is not None:
                     offset_x = tile.tileset.tile_offset.x* scaling or 0
                     offset_y = tile.tileset.tile_offset.y* scaling or 0
+                if layer.offset is not None:
+                    offset_x += layer.offset.x * scaling or 0
+                    offset_y += layer.offset.y * scaling or 0
+
                 tile_width = map_object.tile_size[0] * scaling
                 tile_height = map_object.tile_size[1] * scaling
                 sprite_center_x = my_sprite.width / 2

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -507,12 +507,16 @@ def _process_image_layer(map_object: pytiled_parser.objects.TileMap,
     map_source = map_object.tmx_file
     map_directory = os.path.dirname(map_source)
     image_file = _get_image_source(layer, base_directory, map_directory)
-    sprite = Sprite(image_file,scaling, 0,  0, hit_box_algorithm="None")
+    sprite = Sprite(image_file, scaling, 0, 0, hit_box_algorithm="None")
     sprite.center_x = sprite.width // 2
     sprite.center_y = sprite.height // 2
     if layer.offset:
+        tile_height = map_object.tile_size[1]
+        if map_object.orientation == "staggered":
+            tile_height //= 2
+        map_height = map_object.map_size.height * tile_height
         sprite.center_x += layer.offset.x
-        sprite.center_y += layer.offset.y
+        sprite.center_y += map_height - sprite.height - layer.offset.y
 
     sprite_list.append(sprite)
     return sprite_list

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -445,7 +445,6 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
                         ) -> SpriteList:
     sprite_list: SpriteList = SpriteList(use_spatial_hash=use_spatial_hash)
     map_array = layer.layer_data
-
     # Loop through the layer and add in the wall list
     for row_index, row in enumerate(map_array):
         for column_index, item in enumerate(row):
@@ -470,11 +469,20 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
                 offset_x = 0
                 offset_y = 0
                 if tile.tileset.tile_offset is not None:
-                    offset_x = tile.tileset.tile_offset.x or 0
-                    offset_y = tile.tileset.tile_offset.y or 0
-                my_sprite.center_x = (offset_x * scaling) + column_index * (map_object.tile_size[0] * scaling) + my_sprite.width / 2
-                my_sprite.center_y = (map_object.map_size.height - row_index - 1) \
-                    * (map_object.tile_size[1] * scaling) + my_sprite.height / 2 - (offset_y * scaling)
+                    offset_x = tile.tileset.tile_offset.x* scaling or 0
+                    offset_y = tile.tileset.tile_offset.y* scaling or 0
+                tile_width = map_object.tile_size[0] * scaling
+                tile_height = map_object.tile_size[1] * scaling
+                sprite_center_x = my_sprite.width / 2
+                if map_object.orientation == "staggered": #assuiming staggeraxis y and index odd
+                    if row_index % 2 == 1:
+                        offset_x += tile_width/2
+                    tile_height = tile_height/2
+                    offset_y += tile_height
+                my_sprite.center_x = offset_x + column_index * tile_width + sprite_center_x
+                tile_y_index = map_object.map_size.height - row_index - 1
+                my_sprite_center_y = my_sprite.height / 2
+                my_sprite.center_y = tile_y_index * tile_height + my_sprite_center_y - offset_y
 
                 # Opacity
                 opacity = layer.opacity
@@ -484,7 +492,6 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
                 sprite_list.append(my_sprite)
 
     return sprite_list
-
 
 def process_layer(map_object: pytiled_parser.objects.TileMap,
                   layer_name: str,

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -467,9 +467,14 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
             if my_sprite is None:
                 print(f"Warning: Could not create sprite number {item} in layer '{layer.name}' {tile.image.source}")
             else:
-                my_sprite.center_x = column_index * (map_object.tile_size[0] * scaling) + my_sprite.width / 2
+                offset_x = 0
+                offset_y = 0
+                if tile.tileset.tile_offset is not None:
+                    offset_x = tile.tileset.tile_offset.x or 0
+                    offset_y = tile.tileset.tile_offset.y or 0
+                my_sprite.center_x = (offset_x * scaling) + column_index * (map_object.tile_size[0] * scaling) + my_sprite.width / 2
                 my_sprite.center_y = (map_object.map_size.height - row_index - 1) \
-                    * (map_object.tile_size[1] * scaling) + my_sprite.height / 2
+                    * (map_object.tile_size[1] * scaling) + my_sprite.height / 2 - (offset_y * scaling)
 
                 # Opacity
                 opacity = layer.opacity

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -166,13 +166,13 @@ def _get_image_info_from_tileset(tile):
 
     return image_x, image_y, width, height
 
-def _get_image_source(tile: pytiled_parser.objects.Tile,
+def _get_image_source(tile: Union[pytiled_parser.objects.Tile, pytiled_parser.objects.ImageLayer],
                       base_directory: Optional[str],
                       map_directory: Optional[str]):
     image_file = None
     if tile.image:
         image_file = tile.image.source
-    elif tile.tileset.image:
+    elif isinstance(tile, pytiled_parser.objects.Tile) and tile.tileset.image:
         image_file = tile.tileset.image.source
 
     if not image_file:
@@ -497,6 +497,26 @@ def _process_tile_layer(map_object: pytiled_parser.objects.TileMap,
 
     return sprite_list
 
+def _process_image_layer(map_object: pytiled_parser.objects.TileMap,
+                        layer: pytiled_parser.objects.TileLayer,
+                        scaling: float = 1,
+                        base_directory: str = "",
+                        ) -> SpriteList:
+    sprite_list: SpriteList = SpriteList()
+
+    map_source = map_object.tmx_file
+    map_directory = os.path.dirname(map_source)
+    image_file = _get_image_source(layer, base_directory, map_directory)
+    sprite = Sprite(image_file,scaling, 0,  0, hit_box_algorithm="None")
+    sprite.center_x = sprite.width // 2
+    sprite.center_y = sprite.height // 2
+    if layer.offset:
+        sprite.center_x += layer.offset.x
+        sprite.center_y += layer.offset.y
+
+    sprite_list.append(sprite)
+    return sprite_list
+
 def process_layer(map_object: pytiled_parser.objects.TileMap,
                   layer_name: str,
                   scaling: float = 1,
@@ -572,6 +592,14 @@ def process_layer(map_object: pytiled_parser.objects.TileMap,
                                      hit_box_algorithm,
                                      hit_box_detail
                                      )
+
+    elif isinstance(layer, pytiled_parser.objects.ImageLayer):
+        return _process_image_layer(map_object,
+                                     layer,
+                                     scaling,
+                                     base_directory,
+                                     )
+
 
     print(f"Warning, layer '{layer_name}' has unexpected type. '{type(layer)}'")
     return SpriteList()


### PR DESCRIPTION
We made use of an isometric map in our PyWeek entry https://github.com/r1chardj0n3s/masa-01 which required some improvements both to pytiled-parser (PR https://github.com/Beefy-Swain/pytiled_parser/pull/24 ) and to arcade itself both for some issues around positioning of tiles in isometric layout, but also to add support for image layers.