### PR TITLE
Added support to specify SpriteList.draw blending mode

### DIFF
--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -959,6 +959,9 @@ class SpriteList:
 
         :param filter: Optional parameter to set OpenGL filter, such as
                        `gl.GL_NEAREST` to avoid smoothing.
+
+        :param blend_function: Optional parameter to set the OpenGL blend function used for drawing the sprite list, such as
+                        'arcade.Window.ctx.BLEND_ADDITIVE' or 'arcade.Window.ctx.BLEND_DEFAULT'
         """
         if len(self.sprite_list) == 0:
             return
@@ -977,7 +980,10 @@ class SpriteList:
             self._calculate_sprite_buffer()
 
         self.ctx.enable(self.ctx.BLEND)
-        self.ctx.blend_func = self.ctx.BLEND_DEFAULT
+        if "blend_function" in kwargs:
+            self.ctx.blend_func = kwargs["blend_function"]
+        else:
+            self.ctx.blend_func = self.ctx.BLEND_DEFAULT
 
         self._texture.use(0)
 


### PR DESCRIPTION
This feature is in reference to issue #769 . Support has been added to specify a optional argument blend_function when calling SpriteListl.draw, that will set the OpenGL blending function to the one specififed in the argument.