### PR TITLE
allow stretchy resizable window support

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -58,7 +58,8 @@ class Window(pyglet.window.Window):
                  resizable: bool = False,
                  update_rate: Optional[float] = 1 / 60,
                  antialiasing: bool = True,
-                 screen: pyglet.canvas.Screen = None):
+                 screen: pyglet.canvas.Screen = None,
+                 stretch_game_with_window:bool=False):
         """
         Construct a new window
 
@@ -70,6 +71,7 @@ class Window(pyglet.window.Window):
         :param float update_rate: How frequently to update the window.
         :param bool antialiasing: Should OpenGL's anti-aliasing be enabled?
         """
+        self.stretch_game_with_window = stretch_game_with_window
         if antialiasing:
             config = pyglet.gl.Config(major_version=3,
                                       minor_version=3,
@@ -343,10 +345,13 @@ class Window(pyglet.window.Window):
         # unscaled_viewport = self.get_viewport_size()
         # scaling = unscaled_viewport[0] / width
 
-        self.set_viewport(original_viewport[0],
-                          original_viewport[0] + width,
-                          original_viewport[2],
-                          original_viewport[2] + height)
+        if not self.stretch_game_with_window:
+            self.set_viewport(original_viewport[0],
+                              original_viewport[0] + width,
+                              original_viewport[2],
+                              original_viewport[2] + height)
+        else:
+            self.set_viewport(*original_viewport)
 
     def set_min_size(self, width: float, height: float):
         """ Wrap the Pyglet window call to set minimum size

--- a/arcade/examples/gui_elements_stretchy_window.py
+++ b/arcade/examples/gui_elements_stretchy_window.py
@@ -1,0 +1,128 @@
+"""
+Show how to use GUI elements.
+
+You can run this example with:
+python -m arcade.examples.gui_elements_example
+
+To style, see the style example or use a yaml file.
+See:
+https://github.com/pvcraven/arcade/blob/development/arcade/resources/style/default.yml
+and the UIStyle.from_file() command.
+
+"""
+import arcade
+
+import arcade.gui
+from arcade.gui import UIManager
+
+
+class MyFlatButton(arcade.gui.UIFlatButton):
+    """
+    To capture a button click, subclass the button and override on_click.
+    """
+    def on_click(self):
+        """ Called when user lets off button """
+        print("Click flat button. ")
+
+class MyGhostFlatButton(arcade.gui.UIGhostFlatButton):
+    """
+    For this subclass, we create a custom init, that takes in another
+    parameter, the UI text box. We use that parameter and print the contents
+    of the text entry box when the ghost button is clicked.
+    """
+
+    def __init__(self, center_x, center_y, input_box):
+        super().__init__(
+            'GhostFlatButton',
+            center_x=center_x,
+            center_y=center_y,
+            width=250,
+            # height=20
+        )
+        self.input_box = input_box
+
+    def on_click(self):
+        """ Called when user lets off button """
+        print(f"Click ghost flat button. {self.input_box.text}")
+
+
+class MyView(arcade.View):
+    """
+    Main view. Really the only view in this example. """
+    def __init__(self):
+        super().__init__()
+
+        self.ui_manager = UIManager()
+
+    def on_draw(self):
+        """ Draw this view. GUI elements are automatically drawn. """
+        arcade.start_render()
+
+    def on_show_view(self):
+        """ Called once when view is activated. """
+        self.setup()
+        arcade.set_background_color(arcade.color.BLACK)
+
+    def on_hide_view(self):
+        self.ui_manager.unregister_handlers()
+
+    def setup(self):
+        """ Set up this view. """
+        self.ui_manager.purge_ui_elements()
+
+        y_slot = self.window.height // 4
+        left_column_x = self.window.width // 4
+        right_column_x = 3 * self.window.width // 4
+
+        # left side elements
+        self.ui_manager.add_ui_element(arcade.gui.UILabel(
+            'UILabel',
+            center_x=left_column_x,
+            center_y=y_slot * 3,
+        ))
+
+        ui_input_box = arcade.gui.UIInputBox(
+            center_x=left_column_x,
+            center_y=y_slot * 2,
+            width=300
+        )
+        ui_input_box.text = 'UIInputBox'
+        ui_input_box.cursor_index = len(ui_input_box.text)
+        self.ui_manager.add_ui_element(ui_input_box)
+
+        button_normal = arcade.load_texture(':resources:gui_basic_assets/red_button_normal.png')
+        hovered_texture = arcade.load_texture(':resources:gui_basic_assets/red_button_hover.png')
+        pressed_texture = arcade.load_texture(':resources:gui_basic_assets/red_button_press.png')
+        button = arcade.gui.UIImageButton(
+            center_x=left_column_x,
+            center_y=y_slot * 1,
+            normal_texture=button_normal,
+            hover_texture=hovered_texture,
+            press_texture=pressed_texture,
+            text='UIImageButton'
+        )
+        self.ui_manager.add_ui_element(button)
+
+        # right side elements
+        button = MyFlatButton(
+            'FlatButton',
+            center_x=right_column_x,
+            center_y=y_slot * 1,
+            width=250,
+            # height=20
+        )
+        self.ui_manager.add_ui_element(button)
+
+        button = MyGhostFlatButton(
+            center_x=right_column_x,
+            center_y=y_slot * 2,
+            input_box=ui_input_box
+        )
+        self.ui_manager.add_ui_element(button)
+
+
+if __name__ == '__main__':
+    window = arcade.Window(title='ARCADE_GUI',stretch_game_with_window=True,resizable=True)
+    view = MyView()
+    window.show_view(view)
+    arcade.run()

--- a/arcade/gui/manager.py
+++ b/arcade/gui/manager.py
@@ -232,7 +232,7 @@ class UIManager(EventDispatcher):
         """
 
         # apply x,y transformation for stretched applications
-        x,y = transform_xy_to_game_coordinates(x,y)
+        x,y = self.transform_xy_to_game_coordinates(x,y)
 
         self.dispatch_ui_event(UIEvent(MOUSE_PRESS, x=x, y=y, button=button, modifiers=modifiers))
 
@@ -243,7 +243,7 @@ class UIManager(EventDispatcher):
         """
 
         # apply x,y transformation for stretched applications
-        x,y = transform_xy_to_game_coordinates(x,y)
+        x,y = self.transform_xy_to_game_coordinates(x,y)
 
         self.dispatch_ui_event(UIEvent(MOUSE_RELEASE, x=x, y=y, button=button, modifiers=modifiers))
 
@@ -254,7 +254,7 @@ class UIManager(EventDispatcher):
         """
 
         # apply x,y transformation for stretched applications
-        x,y = transform_xy_to_game_coordinates(x,y)
+        x,y = self.transform_xy_to_game_coordinates(x,y)
 
         self.dispatch_ui_event(UIEvent(MOUSE_SCROLL,
                                        x=x,
@@ -270,7 +270,7 @@ class UIManager(EventDispatcher):
         """
 
         # apply x,y transformation for stretched applications
-        x, y = transform_xy_to_game_coordinates(x, y)
+        x, y = self.transform_xy_to_game_coordinates(x, y)
 
         self.dispatch_ui_event(UIEvent(MOUSE_MOTION,
                                        x=x,

--- a/arcade/gui/manager.py
+++ b/arcade/gui/manager.py
@@ -220,12 +220,20 @@ class UIManager(EventDispatcher):
                     self.hovered_element = None
 
             ui_element.on_ui_event(event)
+    def transform_xy_to_game_coordinates(self,x,y):
+        # apply x,y transformation for stretched applications
+        xv1,xv2,yv1,yv2 = self.window.get_viewport() # load viewport rectangle
+        return xv1 + (x/self.window.width)*(xv2-xv1), yv1 + (y / self.window.height) * (yv2 - yv1)
 
     def on_mouse_press(self, x: float, y: float, button: int, modifiers: int):
         """
         Dispatches :py:meth:`arcade.View.on_mouse_press()` as :py:class:`arcade.gui.UIElement`
         with type :py:attr:`arcade.gui.MOUSE_PRESS`
         """
+
+        # apply x,y transformation for stretched applications
+        x,y = transform_xy_to_game_coordinates(x,y)
+
         self.dispatch_ui_event(UIEvent(MOUSE_PRESS, x=x, y=y, button=button, modifiers=modifiers))
 
     def on_mouse_release(self, x: float, y: float, button: int, modifiers: int):
@@ -233,6 +241,10 @@ class UIManager(EventDispatcher):
         Dispatches :py:meth:`arcade.View.on_mouse_release()` as :py:class:`arcade.gui.UIElement`
         with type :py:attr:`arcade.gui.MOUSE_RELEASE`
         """
+
+        # apply x,y transformation for stretched applications
+        x,y = transform_xy_to_game_coordinates(x,y)
+
         self.dispatch_ui_event(UIEvent(MOUSE_RELEASE, x=x, y=y, button=button, modifiers=modifiers))
 
     def on_mouse_scroll(self, x: int, y: int, scroll_x: int, scroll_y: int):
@@ -240,6 +252,10 @@ class UIManager(EventDispatcher):
         Dispatches :py:meth:`arcade.View.on_mouse_scroll()` as :py:class:`arcade.gui.UIElement`
         with type :py:attr:`arcade.gui.MOUSE_SCROLL`
         """
+
+        # apply x,y transformation for stretched applications
+        x,y = transform_xy_to_game_coordinates(x,y)
+
         self.dispatch_ui_event(UIEvent(MOUSE_SCROLL,
                                        x=x,
                                        y=y,
@@ -252,6 +268,10 @@ class UIManager(EventDispatcher):
         Dispatches :py:meth:`arcade.View.on_mouse_motion()` as :py:class:`arcade.gui.UIElement`
         with type :py:attr:`arcade.gui.MOUSE_MOTION`
         """
+
+        # apply x,y transformation for stretched applications
+        x, y = transform_xy_to_game_coordinates(x, y)
+
         self.dispatch_ui_event(UIEvent(MOUSE_MOTION,
                                        x=x,
                                        y=y,


### PR DESCRIPTION
### this pr solves issue #791 (which i had submitted) which regards the impossibility of making stretchy resizable games that use the built in arcade gui.
in a game I'm writing I needed this to be supported, and in general I think this is an important option to have for games where the relation between the spirits' sizes to the screen's size is a critical part of the game (for example pong, space invaders, etc.). currently games where you want a change in the window's size to lead to a proportionate scaling of the game, so that the game fits exactly in the window, call the function window.set_viewport with some constant values on every window resize. the current problem with this method is that the pyglet module, witch passes the mouse event object to the gui manager, pass the xy coordinates in window coordinates, instead of passing them in the game coordinates. this is the gist of issue #791. I couldn't find a fix for this besides a basic translation-scaling transformation on the mouse events coordinates, this is what I did in the first commit of this pr. the second commit is meant to make the option of making you're game stretch along with the window more accessible. and the last commit is some example to help illustrate what I'm talking about.

_p.s. when the aspect ratio of the window changes all the game art gets proportionally smushed, in my game only **(and not in this pr)** I solved this by not allowing the screen size to change aspect ratio:_
```
# in class MainGaime(Window)
def on_resize(self, width: float = 0, height: float = 0):
     self.height = int(width*self.aspect_ratio)
```