### PR TITLE
added support for pyinstaller on linux

### DIFF
--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -41,4 +41,11 @@ elif is_darwin:
     raise NotImplementedError("Arcade does not support pyinstaller on Mac yet")
 
 elif is_unix:
-    raise NotImplementedError("Arcade does not support pyinstaller on Unix yet")
+    datas = [
+        (hook_path.parent.parent.joinpath("resources"), "./arcade/resources"),
+    ]
+
+    binaries = [
+        (hook_path.parent.parent.parent.joinpath("pymunk/libchipmunk.so"), "."),
+        (hook_path.parent.parent.joinpath("soloud/libsoloud.so"), "./arcade/soloud"),
+    ]


### PR DESCRIPTION
This will enable bundling games with pyinstaller on linux. I tested it with a fairly simple game prototype and bundling and execution ran without any errors or warnings. However, in the bundled version, draw_text uses a monospace font. So there might still be something missing.