### PR TITLE
Tetris example bug

### DIFF
--- a/arcade/examples/tetris.py
+++ b/arcade/examples/tetris.py
@@ -196,8 +196,8 @@ class MyGame(arcade.Window):
         """ Rotate the stone, check collision. """
         if not self.game_over and not self.paused:
             new_stone = rotate_counterclockwise(self.stone)
-            if self.stone_x + len(self.stone) > COLUMN_COUNT - 1:
-                self.stone_x -= len(self.stone)
+            if self.stone_x + len(new_stone[0]) >= COLUMN_COUNT:
+                self.stone_x = COLUMN_COUNT - len(new_stone[0])
             if not check_collision(self.board, new_stone, (self.stone_x, self.stone_y)):
                 self.stone = new_stone
 

--- a/arcade/examples/tetris.py
+++ b/arcade/examples/tetris.py
@@ -196,6 +196,8 @@ class MyGame(arcade.Window):
         """ Rotate the stone, check collision. """
         if not self.game_over and not self.paused:
             new_stone = rotate_clockwise(self.stone)
+            if self.stone_x + len(self.stone) > COLUMN_COUNT - 1:
+                self.stone_x -= len(self.stone)
             if not check_collision(self.board, new_stone, (self.stone_x, self.stone_y)):
                 self.stone = new_stone
 

--- a/arcade/examples/tetris.py
+++ b/arcade/examples/tetris.py
@@ -76,7 +76,7 @@ def create_textures():
 texture_list = create_textures()
 
 
-def rotate_clockwise(shape):
+def rotate_counterclockwise(shape):
     """ Rotates a matrix clockwise """
     return [[shape[y][x] for y in range(len(shape))] for x in range(len(shape[0]) - 1, -1, -1)]
 
@@ -195,7 +195,7 @@ class MyGame(arcade.Window):
     def rotate_stone(self):
         """ Rotate the stone, check collision. """
         if not self.game_over and not self.paused:
-            new_stone = rotate_clockwise(self.stone)
+            new_stone = rotate_counterclockwise(self.stone)
             if self.stone_x + len(self.stone) > COLUMN_COUNT - 1:
                 self.stone_x -= len(self.stone)
             if not check_collision(self.board, new_stone, (self.stone_x, self.stone_y)):


### PR DESCRIPTION
Fixes bug from issue #795.

After a stone is rotated the width and horizontal position are used to verify the rotation does not cause parts of the stone to exceed the number of columns. If rotation causes a part of the stone to exceed the number of columns the horizontal position is moved left so that the right most part of the stone is in the last column.

**Before Rotation**
![screenshot-before-cropped](https://user-images.githubusercontent.com/6276885/104102744-21eee680-5253-11eb-8d31-4ee8966597ab.png) 

**After Rotation**
![screenshot-after-cropped](https://user-images.githubusercontent.com/6276885/104102747-25826d80-5253-11eb-8be3-6108377d72cc.png)


Renamed rotate_clockwise method to rotate_counterclockwise.