### PR TITLE
fixed bug in __setitem__ that shortened the sprite_list

### DIFF
--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -16,6 +16,7 @@ import logging
 import math
 import array
 import time
+from random import shuffle
 
 from PIL import Image
 
@@ -407,6 +408,17 @@ class SpriteList:
         Reverses the current list inplace
         """
         self.sprite_list.reverse()
+        for idx, sprite in enumerate(self.sprite_list):
+            self.sprite_idx[sprite] = idx
+
+        self._vao1 = None
+        
+
+    def shuffle(self):
+        """
+        Shuffles the current list inplace
+        """
+        shuffle(self.sprite_list)
         for idx, sprite in enumerate(self.sprite_list):
             self.sprite_idx[sprite] = idx
 

--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -322,9 +322,8 @@ class SpriteList:
     def __setitem__(self, key: int, value: Sprite):
         self._vao1 = None
 
-        item_to_be_removed = self.sprite_list[key]
-
         if self._use_spatial_hash:
+            item_to_be_removed = self.sprite_list[key]
             self.spatial_hash.remove_object(item_to_be_removed)
             self.spatial_hash.insert_object_for_box(value)
 

--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -323,7 +323,6 @@ class SpriteList:
         self._vao1 = None
 
         item_to_be_removed = self.sprite_list[key]
-        value.sprite_lists.remove(item_to_be_removed)
 
         if self._use_spatial_hash:
             self.spatial_hash.remove_object(item_to_be_removed)


### PR DESCRIPTION
Fixed bug in __setitem__ that removed the item and made the sprite list shrink. Old version broke Solitaire example. This patch fixes that issue.