### PR TITLE
Allow Texture to take None as a hitbox argument

### DIFF
--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -89,7 +89,7 @@ class Texture:
 
         :param str name: Name of texture. Used for caching, so must be unique for each texture.
         :param PIL.Image.Image image: Image to use as a texture.
-        :param str hit_box_algorithm: One of 'None', 'Simple' or 'Detailed'. \
+        :param str hit_box_algorithm: One of None, 'None', 'Simple' or 'Detailed'. \
         Defaults to 'Simple'. Use 'Simple' for the :data:`PhysicsEngineSimple`, \
         :data:`PhysicsEnginePlatformer` \
         and 'Detailed' for the :data:`PymunkPhysicsEngine`.

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -124,9 +124,15 @@ class Texture:
 
         if hit_box_algorithm != "Simple" and \
            hit_box_algorithm != "Detailed" and \
-           hit_box_algorithm != "None":
-           raise ValueError("hit_box_algorithm must be 'Simple', 'Detailed', or 'None'.")
-        self._hit_box_algorithm = hit_box_algorithm
+           hit_box_algorithm != "None" and \
+           hit_box_algorithm != None:
+           raise ValueError(
+               "hit_box_algorithm must be 'Simple', 'Detailed', 'None'"
+               ", or an actual None value."
+           )
+
+        # preserve old behavior in case any users subclassed Texture
+        self._hit_box_algorithm = hit_box_algorithm or "None"
 
         self._hit_box_detail = hit_box_detail
 

--- a/tests/unit2/test_textures.py
+++ b/tests/unit2/test_textures.py
@@ -1,5 +1,6 @@
 import os
 import arcade
+from arcade import Texture
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
@@ -43,3 +44,19 @@ def test_textures():
     window.test()
     window.close()
     arcade.cleanup_texture_cache()
+
+
+def test_texture_constructor_allows_none_and_none_string():
+    """
+    Test constructor accepting both None and the old style 'None'
+    """
+    Texture(
+        name="allowsnonehitbox",
+        hit_box_algorithm=None
+    )
+
+    Texture(
+        name="old_behavior_preserved",
+        hit_box_algorithm="None"
+    )
+


### PR DESCRIPTION
The changes maintain backward compatibility for anyone who subclassed Texture by setting `self._hit_box_algorithm` to `"None"` when an actual None value is passed.

If we announce it ahead of time, we could drop support for `"None"` in favor of true None without any changes to the existing logic because:
- nothing in arcade outside of `Texture`'s `hit_box_points` property seems to access `self._hit_box_algorithm` (at least on the development branch)
- [the logic for `hit_box_points`  defaults to the None case if `self._hit_box_algorithm` isn't set to `"Simple"` or `"Detailed"`](https://github.com/pythonarcade/arcade/blob/daff5b3ca47138057d0002336a42448bf4f5fed5/arcade/texture.py#L154):
```py
    @property
    def hit_box_points(self):
        if self._hit_box_points is not None:
            return self._hit_box_points
        else:
            if self._hit_box_algorithm == "Simple":
                self._hit_box_points = calculate_hit_box_points_simple(self.image)
            elif self._hit_box_algorithm == "Detailed":
                self._hit_box_points = calculate_hit_box_points_detailed(self.image, self._hit_box_detail)
            else:
                p1 = (-self.image.width / 2, -self.image.height / 2)
                p2 = (self.image.width / 2, -self.image.height / 2)
                p3 = (self.image.width / 2, self.image.height / 2)
                p4 = (-self.image.width / 2, self.image.height / 2)

                self._hit_box_points = p1, p2, p3, p4

            return self._hit_box_points
```

I also added a simple test, but could build something more elaborate for the constructor if you'd like.

closes #843 