### PR TITLE
Update setup.py so Arcade will work on Replit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 if sys.platform == "darwin":
     required_python_version=">=3.6,<3.9"
 else:
-    required_python_version=">=3.6,<3.10"
+    required_python_version=">=3.6"
 
 exec(open("arcade/version.py").read())
 


### PR DESCRIPTION
I am trying to use Arcade with my students on Replit.com.
Replit will let PyGame work, so Arcade should work.
When I try to load Arcade I get the following error:
The current project's Python requirement (^3.8) is not compatible with some of the required packages Python requirement:
  - arcade requires Python >=3.6,<3.10
Replit does not like the "<3.10".
I do not think there is any need to have "<3.10" in Arcade and if you were willing to remove it, then Arcade should be able to work on Replit.

Here is an example Replit that will run PyGame but not load Arcade correctly:
https://replit.com/@mrcoxall/Python-Arcade-1