### PR TITLE
Tile map custom class

### DIFF
--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -41,9 +41,6 @@ class PymunkPhysicsEngine:
     MOMENT_INF = float('inf')
 
     def __init__(self, gravity=(0, 0), damping: float = 1.0, maximum_incline_on_ground: float = 0.708):
-        """ 
-
-        """
         # -- Pymunk
         self.space = pymunk.Space()
         self.space.gravity = gravity

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -55,17 +55,29 @@ class PymunkPhysicsEngine:
                    mass: float = 1,
                    friction: float = 0.2,
                    elasticity: Optional[float] = None,
-                   moment=None,
-                   body_type=DYNAMIC,
-                   damping=None,
-                   gravity=None,
-                   max_velocity=None,
-                   max_horizontal_velocity=None,
-                   max_vertical_velocity=None,
+                   moment_of_intertia: Optional[float] =None,
+                   body_type: int =DYNAMIC,
+                   damping: Optoinal[float] =None,
+                   gravity: Union[pymunk.Vec2d, Tuple[float, float], arcade.math.Vec2] =None,
+                   max_velocity: int =None,
+                   max_horizontal_velocity: int =None,
+                   max_vertical_velocity: int =None,
                    radius: float = 0,
                    collision_type: str = "default",
                    ):
-        """ Add a sprite to the physics engine. """
+        """ Add a sprite to the physics engine. 
+            :param sprite: The sprite to add
+            :param mass: The mass of the object. Defaults to 1
+            :param friction: The friction the object has. Defaults to 0.2
+            :param elasticity: Not sure for this one #TODO insert what this is about
+            :param moment_of_intertia: The moment of inertia, or force needed to change angular momentum. Providing infinite makes this object stuck in its rotation.
+            :param body_type: The type of the body. Defaults to Dynamic, meaning, the body can move, rotate etc. providing STATIC makes it fixed to the world.
+            :param damping: See class docs
+            :param gravity: See class docs
+            :param max_velocity: The maximum velocity of the object.
+            :param max_horizontal_velocity: maximum velocity on the x axis
+            :param max_vertical_velocity: maximum velocity on the y axis
+        """
 
         if damping is not None:
             sprite.pymunk.damping = damping
@@ -95,12 +107,12 @@ class PymunkPhysicsEngine:
         # Get a number associated with the string of collision_type
         collision_type_id = self.collision_types.index(collision_type)
 
-        # Default to a box moment
-        if moment is None:
-            moment = pymunk.moment_for_box(mass, (sprite.width, sprite.height))
+        # Default to a box moment_of_intertia
+        if moment_of_intertia is None:
+            moment_of_intertia = pymunk.moment_for_box(mass, (sprite.width, sprite.height))
 
         # Create the physics body
-        body = pymunk.Body(mass, moment, body_type=body_type)
+        body = pymunk.Body(mass, moment_of_intertia, body_type=body_type)
 
         # Set the body's position
         body.position = pymunk.Vec2d(sprite.center_x, sprite.center_y)
@@ -185,10 +197,10 @@ class PymunkPhysicsEngine:
                         mass: float = 1,
                         friction: float = 0.2,
                         elasticity: Optional[float] = None,
-                        moment=None,
-                        body_type=DYNAMIC,
-                        damping=None,
-                        collision_type=None
+                        moment_of_intertia: Optional[float] =None,
+                        body_type: int =DYNAMIC,
+                        damping: Optional[float] =None,
+                        collision_type: Optional[str] =None
                         ):
         """ Add all sprites in a sprite list to the physics engine. """
 
@@ -197,7 +209,7 @@ class PymunkPhysicsEngine:
                             mass=mass,
                             friction=friction,
                             elasticity=elasticity,
-                            moment=moment,
+                            moment_of_intertia=moment_of_intertia,
                             body_type=body_type,
                             damping=damping,
                             collision_type=collision_type)
@@ -211,36 +223,36 @@ class PymunkPhysicsEngine:
         if sprite in self.non_static_sprite_list:
             self.non_static_sprite_list.remove(sprite)
 
-    def get_sprite_for_shape(self, shape) -> Optional[Sprite]:
+    def get_sprite_for_shape(self, shape: Optional[Shape]) -> Optional[Sprite]:
         """ Given a shape, what sprite is associated with it? """
         for sprite in self.sprites:
             if self.sprites[sprite].shape is shape:
                 return sprite
         return None
 
-    def get_sprites_from_arbiter(self, arbiter):
+    def get_sprites_from_arbiter(self, arbiter: pymunk.Arbiter) -> Tuple[Sprite]:
         """ Given a collision arbiter, return the sprites associated with the collision. """
         shape1, shape2 = arbiter.shapes
         sprite1 = self.get_sprite_for_shape(shape1)
         sprite2 = self.get_sprite_for_shape(shape2)
         return sprite1, sprite2
 
-    def is_on_ground(self, sprite):
+    def is_on_ground(self, sprite: Sprite) -> bool:
         """ Return true of sprite is on top of something. """
         grounding = self.check_grounding(sprite)
         return grounding['body'] is not None
 
-    def apply_impulse(self, sprite, impulse):
+    def apply_impulse(self, sprite: Sprite, impulse: Tuple[float, float]):
         """ Apply an impulse force on a sprite """
         physics_object = self.get_physics_object(sprite)
         physics_object.body.apply_impulse_at_local_point(impulse)
 
-    def set_position(self, sprite, position):
+    def set_position(self, sprite: Sprite, position: Union[pymunk.Vec2d, Tuple[float, float]]):
         """ Apply an impulse force on a sprite """
         physics_object = self.get_physics_object(sprite)
         physics_object.body.position = position
 
-    def set_velocity(self, sprite, velocity):
+    def set_velocity(self, sprite: Sprite, velocity: Tuple[float, float]):
         """ Apply an impulse force on a sprite """
         physics_object = self.get_physics_object(sprite)
         physics_object.body.velocity = velocity
@@ -352,19 +364,19 @@ class PymunkPhysicsEngine:
         """ Get the shape/body for a sprite. """
         return self.sprites[sprite]
 
-    def apply_force(self, sprite, force):
+    def apply_force(self, sprite: Sprite, force: Tuple[float, float]):
         """ Apply force to a Sprite. """
         physics_object = self.sprites[sprite]
         physics_object.body.apply_force_at_local_point(force, (0, 0))
 
-    def set_horizontal_velocity(self, sprite, velocity):
+    def set_horizontal_velocity(self, sprite: Sprite, velocity: float):
         """ Set a sprite's velocity """
         physics_object = self.sprites[sprite]
         cv = physics_object.body.velocity
         new_cv = (velocity, cv[1])
         physics_object.body.velocity = new_cv
 
-    def set_friction(self, sprite, friction):
+    def set_friction(self, sprite: Sprite, friction: float):
         """ Apply force to a Sprite. """
         physics_object = self.sprites[sprite]
         physics_object.shape.friction = friction

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -28,6 +28,11 @@ class PymunkPhysicsObject:
 class PymunkPhysicsEngine:
     """
     Pymunk Physics Engine
+
+    :param gravity: The direction where gravity is pointing
+    :param damping: The amount of speed which is kept to the next tick. a value of 1.0 means no speed loss, while 0.9 has 10% loss of speed etc.
+    :param maximum_incline_on_ground: The maximum incline the ground can have, before is_on_ground() becomes False
+        default = 0.708 or a little bit over 45° angle
     """
 
     DYNAMIC = pymunk.Body.DYNAMIC
@@ -37,12 +42,7 @@ class PymunkPhysicsEngine:
 
     def __init__(self, gravity=(0, 0), damping: float = 1.0, maximum_incline_on_ground: float = 0.708):
         """ 
-            Creates a new physics engine, based on pymunk
-            
-            :param gravity The direction where gravity is pointing
-            :param damping The dampning of the sprites
-            :param maximum_incline_on_ground The maximum incline the ground can have, before is_on_ground() becomes False
-                default = 0.708 or a little bit over 45° angle
+
         """
         # -- Pymunk
         self.space = pymunk.Space()

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -122,6 +122,7 @@ class TileMap:
             scaling - A float providing layer specific Sprite scaling.
             hit_box_algorithm - A string for the hit box algorithm to use for the Sprite's in this layer.
             hit_box_detail - A float specifying the level of detail for each Sprite's hitbox
+            custom_class - All objects in the layer are created from this class instead of Sprite. Must be subclass of Sprite.
 
             For example:
 
@@ -131,6 +132,7 @@ class TileMap:
                     "Platforms": {
                         "use_spatial_hash": True,
                         "scaling": 2.5,
+                        "custom_class": Platform,
                     },
                 }
 

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -123,6 +123,7 @@ class TileMap:
             hit_box_algorithm - A string for the hit box algorithm to use for the Sprite's in this layer.
             hit_box_detail - A float specifying the level of detail for each Sprite's hitbox
             custom_class - All objects in the layer are created from this class instead of Sprite. Must be subclass of Sprite.
+            custom_class_args - Custom arguments, passed into the constructor of the custom_class
 
             For example:
 
@@ -133,6 +134,9 @@ class TileMap:
                         "use_spatial_hash": True,
                         "scaling": 2.5,
                         "custom_class": Platform,
+                        "custom_class_args": {
+                            "health": 100
+                        }
                     },
                 }
 
@@ -182,6 +186,7 @@ class TileMap:
             "hit_box_algorithm": self.hit_box_algorithm,
             "hit_box_detail": self.hit_box_detail,
             "custom_class": Sprite,
+            "custom_class_args": {}
         }
 
         for layer in self.tiled_map.layers:
@@ -341,6 +346,7 @@ class TileMap:
         hit_box_algorithm: str = "Simple",
         hit_box_detail: float = 4.5,
         custom_class: type = Sprite,
+        custom_class_args: Dict[str, Any] = {},
     ) -> Sprite:
         """Given a tile from the parser, try and create a Sprite from it."""
 
@@ -365,6 +371,7 @@ class TileMap:
                 flipped_diagonally=tile.flipped_diagonally,
                 hit_box_algorithm=hit_box_algorithm,
                 hit_box_detail=hit_box_detail,
+                **custom_class_args,
             )
 
         if tile.properties is not None and len(tile.properties) > 0:
@@ -585,6 +592,7 @@ class TileMap:
         hit_box_algorithm: str = "Simple",
         hit_box_detail: float = 4.5,
         custom_class: type = Sprite,
+        custom_class_args: Dict[str, Any] = {},
     ) -> SpriteList:
 
         sprite_list: SpriteList = SpriteList(use_spatial_hash=use_spatial_hash)
@@ -612,7 +620,8 @@ class TileMap:
                     scaling=scaling,
                     hit_box_algorithm=hit_box_algorithm,
                     hit_box_detail=hit_box_detail,
-                    custom_class=custom_class
+                    custom_class=custom_class,
+                    custom_class_args=custom_class_args
                 )
 
                 if my_sprite is None:

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -179,6 +179,7 @@ class TileMap:
             "use_spatial_hash": self.use_spatial_hash,
             "hit_box_algorithm": self.hit_box_algorithm,
             "hit_box_detail": self.hit_box_detail,
+            "custom_class": Sprite,
         }
 
         for layer in self.tiled_map.layers:
@@ -337,6 +338,7 @@ class TileMap:
         scaling: float = 1.0,
         hit_box_algorithm: str = "Simple",
         hit_box_detail: float = 4.5,
+        custom_class: type = Sprite,
     ) -> Sprite:
         """Given a tile from the parser, try and create a Sprite from it."""
 
@@ -349,7 +351,7 @@ class TileMap:
             my_sprite: Sprite = AnimatedTimeBasedSprite(image_file, scaling)
         else:
             image_x, image_y, width, height = _get_image_info_from_tileset(tile)
-            my_sprite = Sprite(
+            my_sprite = custom_class(
                 image_file,
                 scaling,
                 image_x,
@@ -580,6 +582,7 @@ class TileMap:
         use_spatial_hash: Optional[bool] = None,
         hit_box_algorithm: str = "Simple",
         hit_box_detail: float = 4.5,
+        custom_class: type = Sprite,
     ) -> SpriteList:
 
         sprite_list: SpriteList = SpriteList(use_spatial_hash=use_spatial_hash)
@@ -607,6 +610,7 @@ class TileMap:
                     scaling=scaling,
                     hit_box_algorithm=hit_box_algorithm,
                     hit_box_detail=hit_box_detail,
+                    custom_class=custom_class
                 )
 
                 if my_sprite is None:

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -657,6 +657,8 @@ class TileMap:
         use_spatial_hash: Optional[bool] = None,
         hit_box_algorithm: str = "Simple",
         hit_box_detail: float = 4.5,
+        custom_class: type = Sprite,
+        custom_class_args: Dict[str, Any] = {},
     ) -> Tuple[Optional[SpriteList], Optional[List[TiledObject]]]:
 
         if not scaling:
@@ -677,6 +679,8 @@ class TileMap:
                     scaling=scaling,
                     hit_box_algorithm=hit_box_algorithm,
                     hit_box_detail=hit_box_detail,
+                    custom_class=custom_class,
+                    custom_class_args=custom_class_args,
                 )
 
                 x = cur_object.coordinates.x * scaling


### PR DESCRIPTION
fixes #942 
changed tile map to accept a custom_class layer attribue (default Sprite). When reading in the tilemaps, all Tiles of that layer will be created from that class.