### PR TITLE
Cache generated textures

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -7,6 +7,8 @@ https://www.gamedev.net/articles/programming/general-and-gameplay-programming/sp
 
 import math
 
+from arcade.texture import build_cache_name
+
 try:
     import dataclasses
 except ModuleNotFoundError:
@@ -1295,10 +1297,29 @@ class SpriteCircle(Sprite):
     def __init__(self, radius: int, color: Color, soft: bool = False):
         super().__init__()
 
+        diameter = radius * 2
+
+        # determine the texture's cache name
         if soft:
-            self.texture = make_soft_circle_texture(radius * 2, color)
+            cache_name = build_cache_name("circle_texture_soft", diameter, color[0], color[1], color[2])
         else:
-            self.texture = make_circle_texture(radius * 2, color)
+            cache_name = build_cache_name("circle_texture", diameter, color[0], color[1], color[2], 255, 0)
+
+        # use the named texture if it was already made
+        if cache_name in load_texture.texture_cache:
+            texture = load_texture.texture_cache[cache_name]
+
+        # generate the texture if it's not in the cache
+        else:
+            if soft:
+                texture = make_soft_circle_texture(diameter, color, name=cache_name)
+            else:
+                texture = make_circle_texture(diameter, color, name=cache_name)
+
+            load_texture.texture_cache[cache_name] = texture
+
+        # apply results to the new sprite
+        self.texture = texture
         self._points = self.texture.hit_box_points
 
 

--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -1277,9 +1277,21 @@ class SpriteSolidColor(Sprite):
         """
         super().__init__()
 
-        image = PIL.Image.new("RGBA", (width, height), color)
-        self.texture = Texture(f"Solid-{color[0]}-{color[1]}-{color[2]}", image)
-        self._points = self.texture.hit_box_points
+        cache_name = build_cache_name("Solid", width, height, color[0], color[1], color[2])
+
+        # use existing texture if it exists
+        if cache_name in load_texture.texture_cache:
+            texture = load_texture.texture_cache[cache_name]
+
+        # otherwise, generate a filler sprite and add it to the cache
+        else:
+            image = PIL.Image.new("RGBA", (width, height), color)
+            texture = Texture(cache_name, image)
+            load_texture.texture_cache[cache_name] = texture
+
+        # apply chosen texture to the current sprite
+        self.texture = texture
+        self._points = texture.hit_box_points
 
 
 class SpriteCircle(Sprite):

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -8,7 +8,7 @@ import PIL.Image
 import PIL.ImageOps
 import PIL.ImageDraw
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 from typing import List
 from typing import Union
 
@@ -547,24 +547,40 @@ def load_spritesheet(file_name: Union[str, Path],
     return texture_list
 
 
-def make_circle_texture(diameter: int, color: Color) -> Texture:
+def build_cache_name(*args: Any) -> str:
+    """
+    Generate cache names from the given parameters
+
+    This is mostly useful when generating textures with many parameters
+
+    :param args:
+    :return:
+    """
+    return "-".join([f"{arg}" for arg in args])
+
+
+def make_circle_texture(diameter: int, color: Color, name: str = None) -> Texture:
     """
     Return a Texture of a circle with the given diameter and color.
 
     :param int diameter: Diameter of the circle and dimensions of the square :class:`Texture` returned.
     :param Color color: Color of the circle.
+    :param str name: Custom or pre-chosen name for this texture
 
     :returns: New :class:`Texture` object.
     """
+
+    name = name or build_cache_name("circle_texture", diameter, color[0], color[1], color[2])
+
     bg_color = (0, 0, 0, 0)  # fully transparent
     img = PIL.Image.new("RGBA", (diameter, diameter), bg_color)
     draw = PIL.ImageDraw.Draw(img)
     draw.ellipse((0, 0, diameter - 1, diameter - 1), fill=color)
-    name = "{}:{}:{}".format("circle_texture", diameter, color)  # name must be unique for caching
     return Texture(name, img)
 
 
-def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int = 255, outer_alpha: int = 0) -> Texture:
+def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int = 255, outer_alpha: int = 0,
+                             name: str = None) -> Texture:
     """
     Return a :class:`Texture` of a circle with the given diameter and color, fading out at its edges.
 
@@ -572,12 +588,16 @@ def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int = 25
     :param Color color: Color of the circle.
     :param int center_alpha: Alpha value of the circle at its center.
     :param int outer_alpha: Alpha value of the circle at its edges.
+    :param str name: Custom or pre-chosen name for this texture
 
     :returns: New :class:`Texture` object.
     :rtype: arcade.Texture
     """
     # TODO: create a rectangle and circle (and triangle? and arbitrary poly where client passes
     # in list of points?) particle?
+    name = name or build_cache_name("soft_circle_texture", diameter, color[0], color[1], color[3], center_alpha,
+                                    outer_alpha)  # name must be unique for caching
+
     bg_color = (0, 0, 0, 0)  # fully transparent
     img = PIL.Image.new("RGBA", (diameter, diameter), bg_color)
     draw = PIL.ImageDraw.Draw(img)
@@ -587,8 +607,7 @@ def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int = 25
         alpha = int(lerp(center_alpha, outer_alpha, radius / max_radius))
         clr = (color[0], color[1], color[2], alpha)
         draw.ellipse((center - radius, center - radius, center + radius - 1, center + radius - 1), fill=clr)
-    name = "{}:{}:{}:{}:{}".format("soft_circle_texture", diameter, color, center_alpha,
-                                   outer_alpha)  # name must be unique for caching
+
     return Texture(name, img)
 
 

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -611,7 +611,8 @@ def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int = 25
     return Texture(name, img)
 
 
-def make_soft_square_texture(size: int, color: Color, center_alpha: int = 255, outer_alpha: int = 0) -> Texture:
+def make_soft_square_texture(size: int, color: Color, center_alpha: int = 255, outer_alpha: int = 0,
+                             name: str = None) -> Texture:
     """
     Return a :class:`Texture` of a square with the given diameter and color, fading out at its edges.
 
@@ -619,9 +620,12 @@ def make_soft_square_texture(size: int, color: Color, center_alpha: int = 255, o
     :param Color color: Color of the square.
     :param int center_alpha: Alpha value of the square at its center.
     :param int outer_alpha: Alpha value of the square at its edges.
+    :param str name: Custom or pre-chosen name for this texture
 
     :returns: New :class:`Texture` object.
     """
+    name = name or build_cache_name("gradientsquare", size, color, center_alpha,
+                                   outer_alpha)  # name must be unique for caching
 
     bg_color = (0, 0, 0, 0)  # fully transparent
     img = PIL.Image.new("RGBA", (size, size), bg_color)
@@ -632,8 +636,6 @@ def make_soft_square_texture(size: int, color: Color, center_alpha: int = 255, o
         clr = (color[0], color[1], color[2], alpha)
         # draw.ellipse((center-radius, center-radius, center+radius, center+radius), fill=clr)
         draw.rectangle((cur_size, cur_size, size - cur_size, size - cur_size), clr, None)
-    name = "{}:{}:{}:{}:{}".format("gradientsquare", size, color, center_alpha,
-                                   outer_alpha)  # name must be unique for caching
     return Texture(name, img)
 
 

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -547,16 +547,18 @@ def load_spritesheet(file_name: Union[str, Path],
     return texture_list
 
 
-def build_cache_name(*args: Any) -> str:
+def build_cache_name(*args: Any, separator: str="-") -> str:
     """
     Generate cache names from the given parameters
 
     This is mostly useful when generating textures with many parameters
 
-    :param args:
-    :return:
+    :param args: params to format
+    :param separator: separator character or string between params
+
+    :returns: Formatted cache string representing passed parameters
     """
-    return "-".join([f"{arg}" for arg in args])
+    return separator.join([f"{arg}" for arg in args])
 
 
 def make_circle_texture(diameter: int, color: Color, name: str = None) -> Texture:


### PR DESCRIPTION
Fixes #973 and should improve performance and memory usage in many cases.

I think further optimizations for `SpriteSolidColor` (stretching images to cover rectangles of any size and increasing hitbox) should be put in another PR. The current changes cover #973 and already increase performance whenever someone is creating a lot of `SpriteCircle`s and `SpriteSolidColor`s. 

I think the changes are suitable for release in a minor version with performance improvements. Although the internal sprite cache names were never promised to be part of the stable external API, I tried to generally keep the type prefix for each generated name (ex: "circle_texture_soft") unchanged in case someone might need to search for it during debugging.

Let me know if I should squash down commits.