### PR TITLE
Fix typo in PymunkPhysicsEngine.add_sprite arg name introduced in 2.6.2

### DIFF
--- a/arcade/examples/pymunk_demo_top_down.py
+++ b/arcade/examples/pymunk_demo_top_down.py
@@ -158,7 +158,7 @@ class MyWindow(arcade.Window):
         # by damping.
         self.physics_engine.add_sprite(self.player_sprite,
                                        friction=0.6,
-                                       moment_of_intertia=PymunkPhysicsEngine.MOMENT_INF,
+                                       moment_of_inertia=PymunkPhysicsEngine.MOMENT_INF,
                                        damping=0.01,
                                        collision_type="player",
                                        max_velocity=400)

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -58,7 +58,7 @@ class PymunkPhysicsEngine:
                    mass: float = 1,
                    friction: float = 0.2,
                    elasticity: Optional[float] = None,
-                   moment_of_inertia: Optional[float] =None,
+                   moment_of_inertia: Optional[float] =None,  # correct spelling, easy to google for further explanation
                    body_type: int =DYNAMIC,
                    damping: Optional[float] =None,
                    gravity: Union[pymunk.Vec2d, Tuple[float, float], Vec2] =None,
@@ -67,7 +67,9 @@ class PymunkPhysicsEngine:
                    max_vertical_velocity: int =None,
                    radius: float = 0,
                    collision_type: Optional[str] = "default",
-                   moment_of_intertia: Optional[float] = None
+                   # the next two arguments are for backwards compatibility with prior versions
+                   moment_of_intertia: Optional[float] = None,  # typo keyword, used by 2.6.2 and 2.6.3
+                   moment: Optional[float] = None  # used prior to 2.6.2
                    ):
         """ Add a sprite to the physics engine. 
             :param sprite: The sprite to add
@@ -84,6 +86,7 @@ class PymunkPhysicsEngine:
             :param radius:
             :param collision_type:
             :param moment_of_intertia: Deprecated alias of moment_of_inertia compatible with a typo introduced in 2.6.2
+            :param moment: Deprecated alias of moment_of_inertia compatible with versions <= 2.6.1
         """
 
         if damping is not None:
@@ -114,8 +117,9 @@ class PymunkPhysicsEngine:
         # Get a number associated with the string of collision_type
         collision_type_id = self.collision_types.index(collision_type)
 
-        # Backwards compatibility for a typo introduced in 2.6.2
-        moment_of_inertia = moment_of_intertia or moment_of_inertia
+        # Backwards compatibility for a typo introduced in 2.6.2 and for versions under 2.6.1
+        # The current version is checked first, then the most common older form, then the typo
+        moment_of_inertia = moment_of_inertia or moment or moment_of_intertia
 
         # Default to a box moment_of_inertia
         if moment_of_inertia is None:

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -58,7 +58,7 @@ class PymunkPhysicsEngine:
                    mass: float = 1,
                    friction: float = 0.2,
                    elasticity: Optional[float] = None,
-                   moment_of_intertia: Optional[float] =None,
+                   moment_of_inertia: Optional[float] =None,
                    body_type: int =DYNAMIC,
                    damping: Optional[float] =None,
                    gravity: Union[pymunk.Vec2d, Tuple[float, float], Vec2] =None,
@@ -67,13 +67,14 @@ class PymunkPhysicsEngine:
                    max_vertical_velocity: int =None,
                    radius: float = 0,
                    collision_type: Optional[str] = "default",
+                   moment_of_intertia: Optional[float] = None
                    ):
         """ Add a sprite to the physics engine. 
             :param sprite: The sprite to add
             :param mass: The mass of the object. Defaults to 1
             :param friction: The friction the object has. Defaults to 0.2
             :param elasticity: How bouncy this object is. 0 is no bounce. Values of 1.0 and higher may behave badly.
-            :param moment_of_intertia: The moment of inertia, or force needed to change angular momentum. Providing infinite makes this object stuck in its rotation.
+            :param moment_of_inertia: The moment of inertia, or force needed to change angular momentum. Providing infinite makes this object stuck in its rotation.
             :param body_type: The type of the body. Defaults to Dynamic, meaning, the body can move, rotate etc. providing STATIC makes it fixed to the world.
             :param damping: See class docs
             :param gravity: See class docs
@@ -82,6 +83,7 @@ class PymunkPhysicsEngine:
             :param max_vertical_velocity: maximum velocity on the y axis
             :param radius:
             :param collision_type:
+            :param moment_of_intertia: Deprecated alias of moment_of_inertia compatible with a typo introduced in 2.6.2
         """
 
         if damping is not None:
@@ -112,12 +114,15 @@ class PymunkPhysicsEngine:
         # Get a number associated with the string of collision_type
         collision_type_id = self.collision_types.index(collision_type)
 
-        # Default to a box moment_of_intertia
-        if moment_of_intertia is None:
-            moment_of_intertia = pymunk.moment_for_box(mass, (sprite.width, sprite.height))
+        # Backwards compatibility for a typo introduced in 2.6.2
+        moment_of_inertia = moment_of_intertia or moment_of_inertia
+
+        # Default to a box moment_of_inertia
+        if moment_of_inertia is None:
+            moment_of_inertia = pymunk.moment_for_box(mass, (sprite.width, sprite.height))
 
         # Create the physics body
-        body = pymunk.Body(mass, moment_of_intertia, body_type=body_type)
+        body = pymunk.Body(mass, moment_of_inertia, body_type=body_type)
 
         # Set the body's position
         body.position = pymunk.Vec2d(sprite.center_x, sprite.center_y)
@@ -214,7 +219,7 @@ class PymunkPhysicsEngine:
                             mass=mass,
                             friction=friction,
                             elasticity=elasticity,
-                            moment_of_intertia=moment_of_intertia,
+                            moment_of_inertia=moment_of_intertia,
                             body_type=body_type,
                             damping=damping,
                             collision_type=collision_type)

--- a/tests/unit2/test_pymunk.py
+++ b/tests/unit2/test_pymunk.py
@@ -1,3 +1,4 @@
+import pytest
 import arcade
 
 
@@ -20,3 +21,36 @@ def test_pymunk():
 
     physics_engine.step(1.0)
     assert(my_sprite.center_y == -300.0)
+
+
+@pytest.mark.parametrize("moment_of_inertia_arg_name",
+                         (
+                             "moment_of_inertia",
+                             # deprecated kwargs for backward-compatibility
+                             "moment",
+                             "moment_of_intertia"
+                         ))
+def test_pymunk_add_sprite_moment_backwards_compatibility(moment_of_inertia_arg_name):
+    """
+    Ensure that all supported kwarg aliases for moment of inertia work
+    """
+    physics_engine = arcade.PymunkPhysicsEngine(damping=1.0, gravity=(0,0))
+
+    sprite = arcade.SpriteSolidColor(32, 32, arcade.color.RED)
+
+    # Choose a non-default value that we can check was set
+    kwargs = {moment_of_inertia_arg_name: arcade.PymunkPhysicsEngine.MOMENT_INF}
+
+    physics_engine.add_sprite(sprite, **kwargs)
+
+    set_moment = physics_engine.get_physics_object(sprite).body.moment
+
+    assert set_moment == arcade.PymunkPhysicsEngine.MOMENT_INF
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This closes #977 by:
1. Replacing the keyword with the correct spelling, `moment_of_inertia`
2. Adding a backward-compatible alias keyword, `moment_of_intertia`, that is marked as deprecated in docstrings.
4. Adding an `or` to choose whichever of them has been defined, if any, to pass to pymunk

It has been tested locally by running `arcade/examples/pymunk_demo_topdown.py` with both keywords. Both worked. 

