### PR TITLE
Fix broken text object

### DIFF
--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -38,7 +38,7 @@ class Text:
             font_size=font_size,
             anchor_x=anchor_x,
             anchor_y=anchor_y,
-            color=color,
+            color=get_four_byte_color(color),
             width=width,
             align=align,
             bold=bold,
@@ -54,7 +54,9 @@ class Text:
         self._label.text = value
 
     def draw(self):
-        self._label.draw()
+        window = arcade.get_window()
+        with window.ctx.pyglet_rendering():
+            self._label.draw()
 
 
 def load_font(font_name):

--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -36,8 +36,12 @@ def attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames:
     doesn't seem to make sense entirely. Comments are an attempt
     to make sense of the original code.
 
+    If it can't resolve a definite path, it will return the original
+    argument for pyglet to attempt to resolve. This is consistent with
+    the original behavior of this code before it was encapsulated.
+
     :param Union[str, Tuple[str, ...]] font_name:
-    :return:
+    :return: Either a resolved path or the original tuple
     """
     if font_name:
 
@@ -110,8 +114,16 @@ class Text:
         italic: bool = False,
         anchor_x: str = "left",
         anchor_y: str = "baseline",
+        multiline: bool = False,
         rotation: float = 0
     ):
+
+        if align != "center" and align != "left" and align != "right":
+            raise ValueError("The 'align' parameter must be equal to 'left', 'right', or 'center'.")
+
+        if align != "left":
+            multiline = True
+
         adjusted_font = attempt_font_name_resolution(font_name)
         self._label = pyglet.text.Label(
             text=text,
@@ -125,7 +137,8 @@ class Text:
             width=width,
             align=align,
             bold=bold,
-            italic=italic
+            italic=italic,
+            multiline=multiline
         )
         self.rotation = rotation
 

--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -51,7 +51,7 @@ def attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames:
         elif isinstance(font_name, tuple):
             font_list = font_name
         else:
-            raise TypeError("font_name parameter must be a string, or a list of strings that specify a font name.")
+            raise TypeError("font_name parameter must be a string, or a tuple of strings that specify a font name.")
 
         for font in font_list:
             try:

--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -164,6 +164,7 @@ class Text:
     def draw(self):
         _draw_label_with_rotation(self._label, self.rotation)
 
+
 def draw_text(
     text: str,
     start_x: float,

--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -73,18 +73,22 @@ def _draw_label_with_rotation(label: pyglet.text.Label, rotation: float) -> None
 
     Helper for drawing pyglet labels with rotation within arcade.
 
-    Originally part of draw_text in this module, now abstracted so that
-    the OOP version, arcade.Text, can also make use of it.
+    Originally part of draw_text in this module, now abstracted and improved
+    so that both arcade.Text and arcade.draw_text can make use of it.
 
     :param pyglet.text.Label label: a pyglet label to wrap and draw
     :param float rotation: rotate this many degrees from horizontal around anchor
     :return:
     """
+
+    # raw pyglet draw functions need this context helper inside arcade
     window = arcade.get_window()
     with window.ctx.pyglet_rendering():
 
+        # execute view matrix magic to rotate cleanly
         if rotation:
             # original_view = window.view
+
             angle_radians = math.radians(rotation)
             x = label.x
             y = label.y
@@ -96,6 +100,13 @@ def _draw_label_with_rotation(label: pyglet.text.Label, rotation: float) -> None
             window.view = final_view
 
         label.draw()
+
+        # restore original position if we used view matrix magic
+        if rotation:
+            # linters might warn that this is used before assignment,
+            # but it's actually valid since we only use it when it was
+            # previously assigned.
+            label.x, label.y = x, y
 
 
 class Text:

--- a/arcade/text_pyglet.py
+++ b/arcade/text_pyglet.py
@@ -64,6 +64,36 @@ def attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames:
     return font_name
 
 
+def _draw_label_with_rotation(label: pyglet.text.Label, rotation: float) -> None:
+    """
+
+    Helper for drawing pyglet labels with rotation within arcade.
+
+    Originally part of draw_text in this module, now abstracted so that
+    the OOP version, arcade.Text, can also make use of it.
+
+    :param pyglet.text.Label label: a pyglet label to wrap and draw
+    :param float rotation: rotate this many degrees from horizontal around anchor
+    :return:
+    """
+    window = arcade.get_window()
+    with window.ctx.pyglet_rendering():
+
+        if rotation:
+            # original_view = window.view
+            angle_radians = math.radians(rotation)
+            x = label.x
+            y = label.y
+            label.x = 0
+            label.y = 0
+            rview = Mat4().rotate(angle_radians, x=0, y=0, z=1)
+            tview = Mat4().translate(x=x, y=y, z=0)
+            final_view = rview @ tview
+            window.view = final_view
+
+        label.draw()
+
+
 class Text:
 
     def __init__(
@@ -80,7 +110,7 @@ class Text:
         italic: bool = False,
         anchor_x: str = "left",
         anchor_y: str = "baseline",
-        rotation: float = 0,  # TODO: Look into, why this field is not used
+        rotation: float = 0
     ):
         adjusted_font = attempt_font_name_resolution(font_name)
         self._label = pyglet.text.Label(
@@ -95,8 +125,9 @@ class Text:
             width=width,
             align=align,
             bold=bold,
-            italic=italic,
+            italic=italic
         )
+        self.rotation = rotation
 
     @property
     def value(self) -> str:
@@ -107,10 +138,7 @@ class Text:
         self._label.text = value
 
     def draw(self):
-        window = arcade.get_window()
-        with window.ctx.pyglet_rendering():
-            self._label.draw()
-
+        _draw_label_with_rotation(self._label, self.rotation)
 
 def draw_text(
     text: str,
@@ -185,22 +213,7 @@ def draw_text(
     label.y = start_y
     label.color = color
 
-    window = arcade.get_window()
-    with arcade.get_window().ctx.pyglet_rendering():
-
-        if rotation:
-            # original_view = window.view
-            angle_radians = math.radians(rotation)
-            x = label.x
-            y = label.y
-            label.x = 0
-            label.y = 0
-            rview = Mat4().rotate(angle_radians, x=0, y=0, z=1)
-            tview = Mat4().translate(x=x, y=y, z=0)
-            final_view = rview @ tview
-            window.view = final_view
-
-        label.draw()
+    _draw_label_with_rotation(label, rotation)
 
 
 # TODO: maybe remove, as this is invalid


### PR DESCRIPTION
Closes #992. Documentation for `arcade.Text` and `arcade.draw_text` is omitted in this PR because it's covered by #985, which I can finish after this is merged.

Closes the original ticket by doing the following:
1. call `get_four_byte_color` in `arcade.Text`'s constructor to ensure pyglet will accept the color
2. encapsulate and generalize the gl context helper code to draw pyglet labels so `Text` draw function not only works, but supports rotation on both `arcade.Text` and `arcade.draw_text`

To bring the two ways of drawing text to parity, this PR also:
1. encapsulates the font lookup behavior so they both use the same function to resolve the font name tuple
2. Adds missing support for some keyword arguments to `arcade.Text` such as rotation and multiline. 

`arcade.draw_text` appears to work just as it did before, but I haven't run profiling to verify in detail. The screenshot of the text test screen below appears to have identical output to the tip of `development` on my system, including the Different Font text not being any different from the rest:

![debugger_latest](https://user-images.githubusercontent.com/36696816/136173857-2fcd52e8-95a2-48b5-a0db-31b120e63cdc.PNG)

I can try to make a version of that test using `arcade.Text` if you think it would be good idea.