### PR TITLE
Quick fix for omitted constructor docstrings on objects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,9 @@ runpy.run_path('../util/update_quick_index.py', run_name='__main__')
 
 autodoc_inherit_docstrings = False
 
+# quick fix for #1005 to enable constructor docstrings to be used
+autoclass_content = 'both'
+
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../arcade'))
 


### PR DESCRIPTION
Closes #1005 in the quickest way possible, and fixing SpriteList, TiledMap, and Texture's omitted constructor annotations in the doc. There might be side effects if classes have single-line constructor docstrings or document something in both places. 

A quick glance at a local build with `python -m http.server` doesn't show too much out of the ordinary, but I need fresher eyes to take a look at this.