### PR TITLE
Move constructor param doc to class docstrings

### DIFF
--- a/arcade/context.py
+++ b/arcade/context.py
@@ -31,7 +31,7 @@ class ArcadeContext(Context):
     and is mainly for more advanced usage**
 
     :param pyglet.window.Window window: The pyglet window
-    :param str gc_mode: The gabage collection mode for opengl objects.
+    :param str gc_mode: The garbage collection mode for opengl objects.
                         ``auto`` (default) is just what we would expect in python
                         while ``context_gc`` requires you to call ``Context.gc()``.
                         The latter can be useful when using multiple threads when

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -29,19 +29,19 @@ class ArcadeContext(Context):
 
     **This is part of the low level rendering API in arcade
     and is mainly for more advanced usage**
+
+    :param pyglet.window.Window window: The pyglet window
+    :param str gc_mode: The gabage collection mode for opengl objects.
+                        ``auto`` (default) is just what we would expect in python
+                        while ``context_gc`` requires you to call ``Context.gc()``.
+                        The latter can be useful when using multiple threads when
+                        it's not clear what thread will gc the object.
     """
 
     atlas_size = 512, 512
 
     def __init__(self, window: pyglet.window.Window, gc_mode: str = "auto"):
-        """
-        :param pyglet.window.Window window: The pyglet window
-        :param str gc_mode: The gabage collection mode for opengl objects.
-                            ``auto`` (default) is just what we would expect in python
-                            while ``context_gc`` requires you to call ``Context.gc()``.
-                            The latter can be useful when using multiple threads when
-                            it's not clear what thread will gc the object.
-        """
+
         super().__init__(window, gc_mode=gc_mode)
 
         # Enabled blending by default

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -17,6 +17,12 @@ class Buffer:
     element data (vertex indexing), uniform block data etc.
 
     Buffer objects should be created using :py:meth:`arcade.gl.Context.buffer`
+
+    :param Context ctx: The context this buffer belongs to
+    :param Any data: The data this buffer should contain.
+                     It can be bytes or any object supporting the buffer protocol.
+    :param int reserve: Create a buffer of a specific byte size
+    :param str usage: A hit of this buffer is ``static`` or ``dynamic`` (can mostly be ignored)
     """
 
     __slots__ = "_ctx", "_glo", "_size", "_usage", "__weakref__"
@@ -29,13 +35,7 @@ class Buffer:
     def __init__(
         self, ctx: "Context", data: Optional[Any] = None, reserve: int = 0, usage: str = "static"
     ):
-        """
-        :param Context ctx: The context this buffer belongs to
-        :param Any data: The data this buffer should contain.
-                         It can be bytes or any object supporting the buffer protocol.
-        :param int reserve: Create a buffer of a specific byte size
-        :param str usage: A hit of this buffer is ``static`` or ``dynamic`` (can mostly be ignored)
-        """
+
         self._ctx = ctx
         self._glo = glo = gl.GLuint()
         self._size = -1

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -60,11 +60,7 @@ class Framebuffer:
     def __init__(
         self, ctx: "Context", *, color_attachments=None, depth_attachment=None
     ):
-        """
-        :param Context ctx: The context this framebuffer belongs to
-        :param List[arcade.gl.Texture] color_attachments: List of color attachments.
-        :param arcade.gl.Texture depth_attachment: A depth attachment (optional)
-        """
+
         self._ctx = ctx
         if not color_attachments:
             raise ValueError("Framebuffer must at least have one color attachment")

--- a/arcade/gl/glsl.py
+++ b/arcade/gl/glsl.py
@@ -18,15 +18,14 @@ class ShaderSource:
 
     NOTE: We do assume the source is neat enough to be parsed
     this way and don't contain several statements on one line.
+
+    :param Context ctx: The context this framebuffer belongs to
+    :param List[arcade.gl.Texture] color_attachments: List of color attachments.
+    :param arcade.gl.Texture depth_attachment: A depth attachment (optional)
     """
 
     def __init__(self, source: str, source_type: gl.GLenum):
-        """Create a shader source wrapper.
-
-        :param str source: The shader source
-        :param gl.GLenum: The shader type (vertex, fragment, geometry etc)
-        :param str path: Path to the shader file if relevant
-        """
+        """Create a shader source wrapper."""
         self._source = source.strip()
         self._type = source_type
         self._lines = self._source.split("\n") if source else []

--- a/arcade/gl/program.py
+++ b/arcade/gl/program.py
@@ -36,6 +36,14 @@ class Program:
     Example::
 
         program['MyUniform'] = value
+
+    :param Context ctx: The context this program belongs to
+    :param str vertex_shader: vertex shader source
+    :param str fragment_shader: fragment shader source
+    :param str geometry_shader: geometry shader source
+    :param str tess_control_shader: tessellation control shader source
+    :param str tess_evaluation_shader: tessellation evaluation shader source
+    :param List[str] out_attributes: List of out attributes used in transform feedback.
     """
 
     __slots__ = (
@@ -60,16 +68,8 @@ class Program:
         tess_evaluation_shader: str = None,
         out_attributes: List[str] = None,
     ):
-        """Create a Program.
+        """Create a Program."""
 
-        :param Context ctx: The context this program belongs to
-        :param str vertex_shader: vertex shader source
-        :param str fragment_shader: fragment shader source
-        :param str geometry_shader: geometry shader source
-        :param str tess_control_shader: tessellation control shader source
-        :param str tess_evaluation_shader: tessellation evaluation shader source
-        :param List[str] out_attributes: List of out attributes used in transform feedback.
-        """
         self._ctx = ctx
         self._glo = glo = gl.glCreateProgram()
         self._out_attributes = out_attributes or []

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -20,6 +20,9 @@ class Texture:
     A texture can also be created with different datatypes such as
     float, integer or unsigned integer.
 
+    NOTE: Currently does not support multisample textures even
+    though ``_samples`` is set.
+
     The best way to create a texture instance is through :py:meth:`arcade.gl.Context.texture`
 
     Supported ``dtype`` values are::
@@ -46,6 +49,8 @@ class Texture:
     :param Tuple[gl.GLuint,gl.GLuint] filter: The minification/magnification filter of the texture
     :param gl.GLuint wrap_x: Wrap mode x
     :param gl.GLuint wrap_y: Wrap mode y
+    :param int target: The texture type
+    :param bool depth: creates a depth texture if `True`
     """
 
     __slots__ = (
@@ -95,22 +100,7 @@ class Texture:
         target=gl.GL_TEXTURE_2D,
         depth=False,
     ):
-        """
-        A texture can be created with or without initial data.
-        NOTE: Currently does not support multisample textures even
-        thought ``samples`` is exposed.
 
-        :param Context ctx: The context the object belongs to
-        :param Tuple[int,int] size: The size of the texture
-        :param int components: The number of components (1: R, 2: RG, 3: RGB, 4: RGBA)
-        :param str dtype: The data type of each component: f1, f2, f4 / i1, i2, i4 / u1, u2, u4
-        :param Any data: The byte data of the texture. bytes or anything supporting the buffer protocol.
-        :param Tuple[gl.GLuint, gl.GLuint] filter: The minification/magnification filter of the texture
-        :param gl.GLuint wrap_x: Wrap mode x
-        :param gl.GLuint wrap_y: Wrap mode y
-        :param int target: The texture type
-        :param bool depth: creates a depth texture if `True`
-        """
         self._ctx = ctx
         self._width, self._height = size
         self._dtype = dtype

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -87,7 +87,15 @@ SHADER_TYPE_NAMES = {
 
 
 class AttribFormat:
-    """Describes a format for a single attribute"""
+    """"
+    Represents an attribute in a BufferDescription or a Program.
+
+    :param str name: Name of the attribute
+    :param gl.GLEnum gl_type: The OpenGL type such as GL_FLOAT, GL_HALF_FLOAT etc.
+    :param int bytes_per_component: Number of bytes a single component takes
+    :param int offset: (Optional offset for BufferDescription)
+    :param int location: (Optional location for program attribute)
+    """
 
     __slots__ = (
         "name",
@@ -101,14 +109,6 @@ class AttribFormat:
     def __init__(
         self, name, gl_type, components, bytes_per_component, offset=0, location=0
     ):
-        """Represents an attribute in a BufferDescription or a Program.
-
-        :param str name: Name of the attribute
-        :param gl.GLEnum gl_type: The OpenGL type such as GL_FLOAT, GL_HALF_FLOAT etc.
-        :param int bytes_per_component: Number of bytes a single component takes
-        :param int offset: (Optional offset for BufferDescription)
-        :param int location: (Optional location for program attribute)
-        """
         self.name = name  # type: str
         self.gl_type = gl_type  # type: gl.GLenum
         self.components = components  # type: int

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -304,17 +304,19 @@ class BufferDescription:
 
 
 class TypeInfo:
+    """
+    Describes an opengl type
+
+    :param name: the string representation of this type
+    :param enum: The enum of this type
+    :param gl_type: the base enum of this type
+    :param gl_size: byte size if the gl_type
+    :param components: Number of components for this enum
+    """
     __slots__ = "name", "enum", "gl_type", "gl_size", "components"
 
     def __init__(self, name, enum, gl_type, gl_size, components):
-        """Describes an opengl type
 
-        :param name: the string representation of this type
-        :param enum: The enum of this type
-        :param gl_type: the base enum of this type
-        :param gl_size: byte size if the gl_type
-        :param components: Number of components for this enum
-        """
         self.name = name  # type: str
         self.enum = enum  # type: gl.GLenum
         self.gl_type = gl_type  # type: gl.GLenum

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -210,13 +210,7 @@ class BufferDescription:
         normalized: Iterable[str] = None,
         instanced: bool = False,
     ):
-        """
-        :param Buffer buffer: The buffer to describe
-        :param str formats: The format of each attribute
-        :param list attributes: List of attributes names (strings)
-        :param list normalized: list of attribute names that should be normalized
-        :param bool instanced: ``True`` if this is per instance data
-        """
+
         #: The :py:class:`~arcade.gl.Buffer` this description object describes
         self.buffer = buffer  # type: Buffer
         #: List of string attributes

--- a/arcade/gl/uniform.py
+++ b/arcade/gl/uniform.py
@@ -5,7 +5,13 @@ from .exceptions import ShaderException
 
 
 class Uniform:
-    """A Program uniform"""
+    """
+    A Program uniform
+
+    :param int location: The location of the uniform in the program
+    :param str name: Name of the uniform in the program
+    :param gl.GLenum data_type: The data type of the uniform (GL_FLOAT
+    """
 
     _uniform_getters = {
         gl.GLint: gl.glGetUniformiv,
@@ -83,12 +89,7 @@ class Uniform:
     )
 
     def __init__(self, program_id, location, name, data_type, array_length):
-        """Create a Uniform
 
-        :param int location: The location of the uniform in the program
-        :param str name: Name of the uniform in the program
-        :param gl.GLenum data_type: The data type of the uniform (GL_FLOAT
-        """
         self._program_id = program_id
         self._location = location
         self._name = name

--- a/arcade/gui/constructs.py
+++ b/arcade/gui/constructs.py
@@ -9,6 +9,12 @@ from arcade.gui.widgets import UILayout, UIAnchorWidget, UITextArea, UIFlatButto
 class UIMessageBox(UIMouseFilterMixin, UIAnchorWidget):
     """
     A simple dialog box that pops up a message with buttons to close.
+
+    :param width: Width of the message box
+    :param height: Height of the message box
+    :param message_text:
+    :param buttons: List of strings, which are shown as buttons
+    :param callback: Callback function, will receive the text of the clicked button
     """
 
     def __init__(self,
@@ -18,15 +24,6 @@ class UIMessageBox(UIMouseFilterMixin, UIAnchorWidget):
                  message_text: str,
                  buttons=("Ok",),
                  callback=None):
-        """
-        A simple dialog box that pops up a message with buttons to close.
-
-        :param width: Width of the message box
-        :param height: Height of the message box
-        :param message_text:
-        :param buttons: List of strings, which are shown as buttons
-        :param callback: Callback function, will receive the text of the clicked button
-        """
 
         space = 10
 

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -202,6 +202,14 @@ class AStarBarrierList:
     """
     Class that manages a list of barriers that can be encountered during
     A* path finding.
+
+    :param Sprite moving_sprite: Sprite that will be moving
+    :param SpriteList blocking_sprites: Sprites that can block movement
+    :param int grid_size: Size of the grid, in pixels
+    :param int left: Left border of playing field
+    :param int right: Right border of playing field
+    :param int bottom: Bottom of playing field
+    :param int top: Top of playing field
     """
     def __init__(self,
                  moving_sprite: Sprite,
@@ -211,15 +219,6 @@ class AStarBarrierList:
                  right: int,
                  bottom: int,
                  top: int):
-        """
-        :param Sprite moving_sprite: Sprite that will be moving
-        :param SpriteList blocking_sprites: Sprites that can block movement
-        :param int grid_size: Size of the grid, in pixels
-        :param int left: Left border of playing field
-        :param int right: Right border of playing field
-        :param int bottom: Bottom of playing field
-        :param int top: Top of playing field
-        """
 
         self.grid_size = grid_size
         self.bottom = int(bottom // grid_size)

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -34,6 +34,30 @@ class Texture:
     Class that represents a texture.
     Usually created by the :class:`load_texture` or :class:`load_textures` commands.
 
+    :param str name: Name of texture. Used for caching, so must be unique for each texture.
+    :param PIL.Image.Image image: Image to use as a texture.
+    :param str hit_box_algorithm: One of None, 'None', 'Simple' or 'Detailed'. \
+    Defaults to 'Simple'. Use 'Simple' for the :data:`PhysicsEngineSimple`, \
+    :data:`PhysicsEnginePlatformer` \
+    and 'Detailed' for the :data:`PymunkPhysicsEngine`.
+
+        .. figure:: ../images/hit_box_algorithm_none.png
+           :width: 40%
+
+           hit_box_algorithm = "None"
+
+        .. figure:: ../images/hit_box_algorithm_simple.png
+           :width: 55%
+
+           hit_box_algorithm = "Simple"
+
+        .. figure:: ../images/hit_box_algorithm_detailed.png
+           :width: 75%
+
+           hit_box_algorithm = "Detailed"
+
+    :param float hit_box_detail: Float, defaults to 4.5. Used with 'Detailed' to hit box
+
     Attributes:
         :name: Unique name of the texture. Used by load_textures for caching.
                If you are manually creating a texture, you can just set this
@@ -41,6 +65,8 @@ class Texture:
         :image: A :py:class:`PIL.Image.Image` object.
         :width: Width of the texture in pixels.
         :height: Height of the texture in pixels.
+
+
     """
 
     def __init__(self,
@@ -49,33 +75,7 @@ class Texture:
                  hit_box_algorithm: Optional[str] = "Simple",
                  hit_box_detail: float = 4.5):
         """
-        Create a texture, given a PIL Image object.
-
-        :param str name: Name of texture. Used for caching, so must be unique for each texture.
-        :param PIL.Image.Image image: Image to use as a texture.
-        :param str hit_box_algorithm: One of None, 'None', 'Simple' or 'Detailed'. \
-        Defaults to 'Simple'. Use 'Simple' for the :data:`PhysicsEngineSimple`, \
-        :data:`PhysicsEnginePlatformer` \
-        and 'Detailed' for the :data:`PymunkPhysicsEngine`.
-
-            .. figure:: ../images/hit_box_algorithm_none.png
-               :width: 40%
-
-               hit_box_algorithm = "None"
-
-            .. figure:: ../images/hit_box_algorithm_simple.png
-               :width: 55%
-
-               hit_box_algorithm = "Simple"
-
-            .. figure:: ../images/hit_box_algorithm_detailed.png
-               :width: 75%
-
-               hit_box_algorithm = "Detailed"
-
-        :param float hit_box_detail: Float, defaults to 4.5. Used with 'Detailed' to hit box
-
-        """
+        Create a texture, given a PIL Image object. """
         from arcade.sprite import Sprite
         from arcade.sprite_list import SpriteList
 
@@ -556,7 +556,7 @@ def build_cache_name(*args: Any, separator: str = "-") -> str:
     :param args: params to format
     :param separator: separator character or string between params
 
-    :returns: Formatted cache string representing passed parameters
+    :return: Formatted cache string representing passed parameters
     """
     return separator.join([f"{arg}" for arg in args])
 

--- a/arcade/texture_atlas.py
+++ b/arcade/texture_atlas.py
@@ -44,7 +44,16 @@ LOG = logging.getLogger(__name__)
 
 
 class AtlasRegion:
-    """Stores information about an allocated region"""
+    """
+    Stores information about where a texture is located
+
+    :param str atlas: The atlas this region belongs to
+    :param str texture: The arcade texture
+    :param int x: The x position of the texture
+    :param int y: The y position of the texture
+    :param int width: The width of the texture in pixels
+    :param int height: The height of the texture in pixels
+    """
 
     __slots__ = (
         "atlas",
@@ -67,15 +76,6 @@ class AtlasRegion:
         width: int,
         height: int,
     ):
-        """Represents a region a texture is located.
-
-        :param str atlas: The atlas this region belongs to
-        :param str texture: The arcade texture
-        :param int x: The x position of the texture
-        :param int y: The y position of the texture
-        :param int width: The width of the texture in pixels
-        :param int height: The height of the texture in pixels
-        """
         self.atlas = atlas
         self.texture = texture
         self.x = x
@@ -107,6 +107,8 @@ class AtlasRegion:
 
 class TextureAtlas:
     """
+    A texture atlas with a size in a context.
+
     A texture atlas is a large texture containing several textures
     so OpenGL can easily batch draw thousands or hundreds of thousands
     of sprites on one draw operation.
@@ -119,6 +121,12 @@ class TextureAtlas:
     texture each sprite is using. The actual texture coordinates
     are located in a float32 texture this atlas is responsible for
     keeping up to date.
+
+    :param Tuple[int, int] size: The width and height of the atlas in pixels
+    :param int border: Currently no effect; Should always be 1 to avoid textures bleeding
+    :param Sequence[arcade.Texture] textures: The texture for this atlas
+    :param bool auto_resize: Automatically resize the atlas when full
+    :param Context ctx: The context for this atlas (will use window context if left empty)
     """
 
     def __init__(
@@ -130,18 +138,7 @@ class TextureAtlas:
         auto_resize: bool = True,
         ctx: "ArcadeContext" = None,
     ):
-        """
-        Creates a texture atlas with a size in a context.
 
-        The border value should ideally be 1 (default) to avoid
-        interpolation bleeding between the textures.
-
-        :param Tuple[int, int] size: The width and height of the atlas in pixels
-        :param int border: Currently as no effect. It should always be 1.
-        :param Sequence[arcade.Texture] textures: The texture for this atlas
-        :param bool auto_resize: Automatically resize the atlas when full
-        :param Context ctx: The context for this atlas (will use window context if left empty)
-        """
         self._ctx = ctx or arcade.get_window().ctx
         self._max_size = self._ctx.limits.MAX_VIEWPORT_DIMS
         self._size: Tuple[int, int] = size

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -87,6 +87,49 @@ class TileMap:
     For examples on how to use this class, see:
     https://api.arcade.academy/en/latest/examples/platform_tutorial/step_09.html
 
+
+    :param Union[str, Path] map_file: A JSON map file for a Tiled map to initialize from
+    :param float scaling: Global scaling to apply to all Sprites.
+    :param Dict[str, Dict[str, Any]] layer_options: Extra parameters for each layer.
+    :param Optional[bool] use_spatial_hash: If set to True, this will make moving a sprite
+           in the SpriteList slower, but it will speed up collision detection
+           with items in the SpriteList. Great for doing collision detection
+           with static walls/platforms.
+    :param str hit_box_algorithm: One of 'None', 'Simple' or 'Detailed'.
+    :param float hit_box_detail: Float, defaults to 4.5. Used with 'Detailed' to hit box.
+
+
+    The `layer_options` parameter can be used to specify per layer arguments.
+
+    The available options for this are:
+
+        use_spatial_hash - A boolean to enable spatial hashing on this layer's SpriteList.
+        scaling - A float providing layer specific Sprite scaling.
+        hit_box_algorithm - A string for the hit box algorithm to use for the Sprite's in this layer.
+        hit_box_detail - A float specifying the level of detail for each Sprite's hitbox
+        custom_class - All objects in the layer are created from this class instead of Sprite.
+                       Must be subclass of Sprite.
+        custom_class_args - Custom arguments, passed into the constructor of the custom_class
+
+        For example:
+
+        code-block::
+
+            layer_options = {
+                "Platforms": {
+                    "use_spatial_hash": True,
+                    "scaling": 2.5,
+                    "custom_class": Platform,
+                    "custom_class_args": {
+                        "health": 100
+                    }
+                },
+            }
+
+    The keys and their values in each layer are passed to the layer processing functions
+    using the `**` operator on the dictionary.
+
+
     Attributes:
         :tiled_map: The pytiled-parser map object. This can be useful for implementing features
                     that aren't supported by this class by accessing the raw map data directly.
@@ -115,44 +158,7 @@ class TileMap:
         Given a .json file, this will read in a Tiled map file, and
         initialize a new TileMap object.
 
-        The `layer_options` parameter can be used to specify per layer arguments.
-        The available options for this are:
 
-            use_spatial_hash - A boolean to enable spatial hashing on this layer's SpriteList.
-            scaling - A float providing layer specific Sprite scaling.
-            hit_box_algorithm - A string for the hit box algorithm to use for the Sprite's in this layer.
-            hit_box_detail - A float specifying the level of detail for each Sprite's hitbox
-            custom_class - All objects in the layer are created from this class instead of Sprite.
-                           Must be subclass of Sprite.
-            custom_class_args - Custom arguments, passed into the constructor of the custom_class
-
-            For example:
-
-            code-block::
-
-                layer_options = {
-                    "Platforms": {
-                        "use_spatial_hash": True,
-                        "scaling": 2.5,
-                        "custom_class": Platform,
-                        "custom_class_args": {
-                            "health": 100
-                        }
-                    },
-                }
-
-        The keys and their values in each layer are passed to the layer processing functions
-        using the `**` operator on the dictionary.
-
-        :param Union[str, Path] map_file: The JSON map file.
-        :param float scaling: Global scaling to apply to all Sprites.
-        :param Dict[str, Dict[str, Any]] layer_options: Extra parameters for each layer.
-        :param Optional[bool] use_spatial_hash: If set to True, this will make moving a sprite
-               in the SpriteList slower, but it will speed up collision detection
-               with items in the SpriteList. Great for doing collision detection
-               with static walls/platforms.
-        :param str hit_box_algorithm: One of 'None', 'Simple' or 'Detailed'.
-        :param float hit_box_detail: Float, defaults to 4.5. Used with 'Detailed' to hit box.
         """
 
         # If we should pull from local resources, replace with proper path

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -157,8 +157,6 @@ class TileMap:
         """
         Given a .json file, this will read in a Tiled map file, and
         initialize a new TileMap object.
-
-
         """
 
         # If we should pull from local resources, replace with proper path


### PR DESCRIPTION
Closes #1005 , with the exception of anything in `arcade.experimental` and `arcade.examples`. I ran flake8 and mypy, and they report no issues.

After running a local build, a spot check of documentation changed also doesn't seem to show anything out of the ordinary.

VSCodium appears to display the relevant docstrings with limited formatting. [According to discord disccusion with Clepto](https://discord.com/channels/458662222697070613/705076586986078350/899870845969776680), this is normal and full RST support is unlikely to be added to the VSCode/VSCodium family.