### PR TITLE
Replace `pvcraven` links with `pythonarcade` ones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Suggest Improvements
 
 Open up issues:
 
-https://github.com/pvcraven/arcade/issues
+https://github.com/pythonarcade/arcade/issues
 
 Fix Bugs or Implement Features
 ------------------------------

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Arcade is built on top of Pyglet and OpenGL.
 .. image:: https://img.shields.io/pypi/dm/arcade
     :alt: PyPI - Downloads
 
-.. image:: https://img.shields.io/github/commit-activity/m/pvcraven/arcade
+.. image:: https://img.shields.io/github/commit-activity/m/pythonarcade/arcade
     :alt: GitHub commit activity
 
 .. image:: https://img.shields.io/pypi/l/arcade

--- a/doc/development/enhancement_list.rst
+++ b/doc/development/enhancement_list.rst
@@ -10,13 +10,13 @@ library by working on one of these, please re-open the issue.
 Drawing
 -------
 
-* `Issue 283 <https://github.com/pvcraven/arcade/issues/283>`_
+* `Issue 283 <https://github.com/pythonarcade/arcade/issues/283>`_
   Add ability to draw overlapping polygons with same transparency.
-* `Issue 421 <https://github.com/pvcraven/arcade/issues/421>`_
+* `Issue 421 <https://github.com/pythonarcade/arcade/issues/421>`_
   Add support for drawing rounded rectangles.
-* `Issue 433 <https://github.com/pvcraven/arcade/issues/433>`_
+* `Issue 433 <https://github.com/pythonarcade/arcade/issues/433>`_
   Add support for bitmapped fonts.
-* `Issue 595 <https://github.com/pvcraven/arcade/issues/595>`_
+* `Issue 595 <https://github.com/pythonarcade/arcade/issues/595>`_
   Optimize drawing functions by caching them
 * Add support for Pyglet's ImageMouseCursors
 
@@ -28,20 +28,20 @@ GUI
 Sprites
 -------
 
-* `Issue 291 <https://github.com/pvcraven/arcade/issues/291>`_
+* `Issue 291 <https://github.com/pythonarcade/arcade/issues/291>`_
   Load a spritesheet with a texture_region map.
-* `Issue 377 <https://github.com/pvcraven/arcade/issues/377>`_
+* `Issue 377 <https://github.com/pythonarcade/arcade/issues/377>`_
   Support basic sprite animations like rotate, flicker, disappear, etc.
-* `Issue 380 <https://github.com/pvcraven/arcade/issues/380>`_
+* `Issue 380 <https://github.com/pythonarcade/arcade/issues/380>`_
   Add ability to specify a point the sprite rotates around.
-* `Issue 419 <https://github.com/pvcraven/arcade/issues/419>`_
+* `Issue 419 <https://github.com/pythonarcade/arcade/issues/419>`_
   Create function to get sprites at a particular point.
-* `Issue 498 <https://github.com/pvcraven/arcade/issues/498>`_
+* `Issue 498 <https://github.com/pythonarcade/arcade/issues/498>`_
   Add lighting effects.
 * Add bloom effects.
-* `Issue 523 <https://github.com/pvcraven/arcade/issues/523>`_
+* `Issue 523 <https://github.com/pythonarcade/arcade/issues/523>`_
   Add sprite trigger/example for on_enter / on_exit.
-* `Issue 289 <https://github.com/pvcraven/arcade/issues/289>`_
+* `Issue 289 <https://github.com/pythonarcade/arcade/issues/289>`_
   Be able to get Sprite position and velocity as vectors.
 * Be able to load an animated gif as an animated time-based sprite.
 * Be able to load an Aesprite image directly (Piggy-back of Pyglet support)
@@ -49,37 +49,37 @@ Sprites
 Physics Engine
 --------------
 
-* `Issue 499 <https://github.com/pvcraven/arcade/issues/499>`_
+* `Issue 499 <https://github.com/pythonarcade/arcade/issues/499>`_
   Create PyMunk + TMX example.
-* `Issue 500 <https://github.com/pvcraven/arcade/issues/500>`_
+* `Issue 500 <https://github.com/pythonarcade/arcade/issues/500>`_
   Show 'rope' effect.
-* `Issue 524 <https://github.com/pvcraven/arcade/issues/524>`_
+* `Issue 524 <https://github.com/pythonarcade/arcade/issues/524>`_
   Add example for "push back".
 * Create a simplified front-end to the PyMunk physics engine
 
 Event Processing
 ----------------
 
-* `Issue 593 <https://github.com/pvcraven/arcade/issues/593>`_
+* `Issue 593 <https://github.com/pythonarcade/arcade/issues/593>`_
   Add support for signals
 
 Documentation
 -------------
 
-* `Issue 452 <https://github.com/pvcraven/arcade/issues/452>`_
+* `Issue 452 <https://github.com/pythonarcade/arcade/issues/452>`_
   Documentation Request - explain how delta_time works to help learners fully
   understand both how and why.
 
 Examples
 --------
 
-* `Issue 345 <https://github.com/pvcraven/arcade/issues/345>`_
+* `Issue 345 <https://github.com/pythonarcade/arcade/issues/345>`_
   Create example showing how to manage multiple windows.
-* `Issue 397 <https://github.com/pvcraven/arcade/issues/397>`_
+* `Issue 397 <https://github.com/pythonarcade/arcade/issues/397>`_
   Add example code showing how to do parallax.
-* `Issue 446 <https://github.com/pvcraven/arcade/issues/446>`_
+* `Issue 446 <https://github.com/pythonarcade/arcade/issues/446>`_
   Add more procedural generation examples.
-* `Issue 464 <https://github.com/pvcraven/arcade/issues/464>`_
+* `Issue 464 <https://github.com/pythonarcade/arcade/issues/464>`_
   Add example for checkers-like game.
 
 This enhancement is not currently in process. Please re-open if you'd like to work on it. A full list of desired enhancements is available at:

--- a/doc/development/how_to_contribute.rst
+++ b/doc/development/how_to_contribute.rst
@@ -33,6 +33,6 @@ Then you can improve these parts of the project:
 A list of enhancements people have requested is available on the :ref:`enhancement_list` page.
 
 .. _Python Arcade SubReddit: https://www.reddit.com/r/pythonarcade
-.. _Github Issue List: https://github.com/pvcraven/arcade/issues
+.. _Github Issue List: https://github.com/pythonarcade/arcade/issues
 .. _reStructuredText: http://www.sphinx-doc.org/en/stable/rest.html
 .. _docstrings: http://www.pythonforbeginners.com/basics/python-docstrings

--- a/doc/development/how_to_submit_changes.rst
+++ b/doc/development/how_to_submit_changes.rst
@@ -9,7 +9,7 @@ the `Github Issue List`_.
 Next, `create your own fork`_ of the Arcade library.
 The Arcade library is at:
 
-https://github.com/pvcraven/arcade
+https://github.com/pythonarcade/arcade
 
 Follow the :ref:`how-to-compile` on how to build the code.
 
@@ -21,5 +21,5 @@ If you aren't familiar with how to do pull requests, the
 `Stack Overflow discussion on pull requests`_ is good.
 
 .. _Stack Overflow discussion on pull requests: http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
-.. _Github Issue List: https://github.com/pvcraven/arcade/issues
+.. _Github Issue List: https://github.com/pythonarcade/arcade/issues
 .. _create your own fork: http://stackoverflow.com/questions/6286571/are-git-forks-actually-git-clones/6286877#6286877

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -152,7 +152,7 @@ The Python Arcade Library
             <h2>Source Code</h2>
           </div>
           <ul>
-            <li><a href="https://github.com/pvcraven/arcade">GitHub</a></li>
+            <li><a href="https://github.com/pythonarcade/arcade">GitHub</a></li>
             <li><a href="development/release_notes.html">Release Notes</a></li>
             <li><a href="enhancement_list/enhancement_list.html">Enhancement List</a></li>
           </ul>

--- a/doc/install/source.rst
+++ b/doc/install/source.rst
@@ -5,11 +5,11 @@ First step is to clone the repository:
 
 .. code-block:: bash
 
-    git clone https://github.com/pvcraven/arcade.git
+    git clone https://github.com/pythonarcade/arcade.git
 
 Or download from:
 
-    https://github.com/pvcraven/arcade/archive/master.zip
+    https://github.com/pythonarcade/arcade/archive/master.zip
 
 Next, we'll create a linked install. This will allow you to change files in the
 arcade directory, and is great


### PR DESCRIPTION
Originally, Arcade’s repo was located at <https://github.com/pvcraven/arcade/>. Now, that link redirects to <https://github.com/pythonarcade/arcade/>.

Before this change, the docs would sometimes use the old location and sometimes use the new location. This change makes most of the docs use the new location.

One file that still sometimes uses the old location is `doc/development/release_notes.rst`. Release notes for older versions use the old location and release notes for newer versions use the new location.

Fixes #1062.