### PR TITLE
Add "section" support to Arcade views

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -93,6 +93,9 @@ from .window_commands import set_window
 from .window_commands import start_render
 from .window_commands import unschedule
 
+from .camera import Camera
+from .sections import Section, SectionManager
+
 from .application import MOUSE_BUTTON_LEFT
 from .application import MOUSE_BUTTON_MIDDLE
 from .application import MOUSE_BUTTON_RIGHT
@@ -311,7 +314,6 @@ from .text_pillow import (
     DEFAULT_FONT_NAMES,
 )
 
-from .camera import Camera
 
 # --- Generated __all__ ---
 
@@ -356,6 +358,8 @@ __all__ = ['AStarBarrierList',
            'RGBA',
            'Rect',
            'RectList',
+           'Section',
+           'SectionManager',
            'Scene',
            'Shape',
            'ShapeElementList',

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -18,7 +18,7 @@ from arcade import set_viewport
 from arcade import set_window
 from arcade.context import ArcadeContext
 from arcade.arcade_types import Color
-from arcade.sections import SectionManager
+from arcade import SectionManager
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -592,6 +592,8 @@ class Window(pyglet.window.Window):
         )
         self._current_view.on_show()
         self._current_view.on_show_view()
+        if self._current_view.has_sections:
+            self._current_view.on_show_view()
 
         # Note: After the View has been pushed onto pyglet's stack of event handlers (via push_handlers()), pyglet
         # will still call the Window's event handlers. (See pyglet's EventDispatcher.dispatch_event() implementation
@@ -610,6 +612,7 @@ class Window(pyglet.window.Window):
 
         self._current_view.on_hide_view()
         if self._current_view.has_sections:
+            self._current_view.section_manager.on_hide_view()
             self.remove_handlers(self._current_view.section_manager)
         self.remove_handlers(self._current_view)
         self._current_view = None

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -587,7 +587,7 @@ class Window(pyglet.window.Window):
             **{
                 et: getattr(new_view, et, None)
                 for et in self.event_types
-                if et != 'on_show' and hasattr(new_view, et)
+                if et != 'on_show' and et not in self.section_manager_events and hasattr(new_view, et)
             }
         )
         self._current_view.on_show()

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -579,15 +579,16 @@ class Window(pyglet.window.Window):
         if new_view.has_sections:
             self.push_handlers(
                 **{
-                    et: getattr(new_view.section_manager, et, None)
-                    for et in self.section_manager_events
-                 }
+                    event_type: getattr(new_view.section_manager, event_type, None)
+                    for event_type in self.section_manager_events
+                }
             )
         self.push_handlers(
             **{
-                et: getattr(new_view, et, None)
-                for et in self.event_types
-                if et != 'on_show' and et not in self.section_manager_events and hasattr(new_view, et)
+                event_type: getattr(new_view, event_type, None)
+                for event_type in self.event_types
+                if event_type != 'on_show' and event_type not in self.section_manager_events
+                and hasattr(new_view, event_type)
             }
         )
         self._current_view.on_show()

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -18,6 +18,7 @@ from arcade import set_viewport
 from arcade import set_window
 from arcade.context import ArcadeContext
 from arcade.arcade_types import Color
+from arcade.sections import SectionManager
 
 LOG = logging.getLogger(__name__)
 
@@ -72,24 +73,25 @@ class Window(pyglet.window.Window):
     :param bool enable_polling: Enabled input polling capability. This makes the ``keyboard`` and ``mouse``
                                 attributes available for use.
     """
+
     def __init__(
-        self,
-        width: int = 800,
-        height: int = 600,
-        title: str = 'Arcade Window',
-        fullscreen: bool = False,
-        resizable: bool = False,
-        update_rate: Optional[float] = 1 / 60,
-        antialiasing: bool = True,
-        gl_version: Tuple[int, int] = (3, 3),
-        screen: pyglet.canvas.Screen = None,
-        style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
-        visible: bool = True,
-        vsync: bool = False,
-        gc_mode: str = "context_gc",
-        center_window: bool = False,
-        samples: int = 4,
-        enable_polling: bool = True
+            self,
+            width: int = 800,
+            height: int = 600,
+            title: str = 'Arcade Window',
+            fullscreen: bool = False,
+            resizable: bool = False,
+            update_rate: Optional[float] = 1 / 60,
+            antialiasing: bool = True,
+            gl_version: Tuple[int, int] = (3, 3),
+            screen: pyglet.canvas.Screen = None,
+            style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
+            visible: bool = True,
+            vsync: bool = False,
+            gc_mode: str = "context_gc",
+            center_window: bool = False,
+            samples: int = 4,
+            enable_polling: bool = True
     ):
         # In certain environments we can't have antialiasing/MSAA enabled.
         # Detect replit environment
@@ -171,6 +173,12 @@ class Window(pyglet.window.Window):
             self.keyboard = None
             self.mouse = None
 
+        # Events that the section manager should handle (instead of the View) if sections are present in a View
+        self.section_manager_events = ('on_mouse_motion', 'on_mouse_drag', 'on_mouse_press',
+                                       'on_mouse_release', 'on_mouse_scroll', 'on_mouse_enter',
+                                       'on_mouse_leave', 'on_key_press', 'on_key_release', 'on_draw',
+                                       'on_update', 'update', 'on_resize')
+
     @property
     def current_view(self) -> Optional["View"]:
         """
@@ -192,10 +200,10 @@ class Window(pyglet.window.Window):
         return self._ctx
 
     def clear(
-        self,
-        color: Optional[Color] = None,
-        normalized: bool = False,
-        viewport: Tuple[int, int, int, int] = None,
+            self,
+            color: Optional[Color] = None,
+            normalized: bool = False,
+            viewport: Tuple[int, int, int, int] = None,
     ):
         """Clears the window with the configured background color
         set through :py:attr:`arcade.Window.background_color`.
@@ -562,10 +570,19 @@ class Window(pyglet.window.Window):
         # remove previously shown view's handlers
         if self._current_view is not None:
             self._current_view.on_hide_view()
+            if self._current_view.has_sections:
+                self.remove_handlers(self._current_view.section_manager)
             self.remove_handlers(self._current_view)
 
         # push new view's handlers
         self._current_view = new_view
+        if new_view.has_sections:
+            self.push_handlers(
+                **{
+                    et: getattr(new_view.section_manager, et, None)
+                    for et in self.section_override_methods
+                 }
+            )
         self.push_handlers(
             **{
                 et: getattr(new_view, et, None)
@@ -592,6 +609,8 @@ class Window(pyglet.window.Window):
             return
 
         self._current_view.on_hide_view()
+        if self._current_view.has_sections:
+            self.remove_handlers(self._current_view.section_manager)
         self.remove_handlers(self._current_view)
         self._current_view = None
 
@@ -719,6 +738,16 @@ class View:
             self.window = window
 
         self.key: Optional[int] = None
+        self.section_manager: SectionManager = SectionManager(self)
+
+    @property
+    def has_sections(self) -> bool:
+        """ Return if the View has sections """
+        return self.section_manager.has_sections
+
+    def add_section(self, section) -> bool:
+        """ Adds a section to this View """
+        return self.section_manager.add_section(section)
 
     def update(self, delta_time: float):
         """To be overridden"""

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -174,10 +174,10 @@ class Window(pyglet.window.Window):
             self.mouse = None
 
         # Events that the section manager should handle (instead of the View) if sections are present in a View
-        self.section_manager_events = ('on_mouse_motion', 'on_mouse_drag', 'on_mouse_press',
+        self.section_manager_events = {'on_mouse_motion', 'on_mouse_drag', 'on_mouse_press',
                                        'on_mouse_release', 'on_mouse_scroll', 'on_mouse_enter',
                                        'on_mouse_leave', 'on_key_press', 'on_key_release', 'on_draw',
-                                       'on_update', 'update', 'on_resize')
+                                       'on_update', 'update', 'on_resize'}
 
     @property
     def current_view(self) -> Optional["View"]:
@@ -580,7 +580,7 @@ class Window(pyglet.window.Window):
             self.push_handlers(
                 **{
                     et: getattr(new_view.section_manager, et, None)
-                    for et in self.section_override_methods
+                    for et in self.section_manager_events
                  }
             )
         self.push_handlers(
@@ -745,9 +745,13 @@ class View:
         """ Return if the View has sections """
         return self.section_manager.has_sections
 
-    def add_section(self, section) -> bool:
-        """ Adds a section to this View """
-        return self.section_manager.add_section(section)
+    def add_section(self, section, at_index: Optional[int] = None) -> None:
+        """
+        Adds a section to the view Section Manager.
+        :param section: the section to add to this section manager
+        :param at_index: inserts the section at that index. If None at the end
+        """
+        return self.section_manager.add_section(section, at_index)
 
     def update(self, delta_time: float):
         """To be overridden"""

--- a/arcade/camera.py
+++ b/arcade/camera.py
@@ -26,7 +26,7 @@ class Camera:
         self,
         viewport_width: int = 0,
         viewport_height: int = 0,
-        window: Optional[arcade.Window] = None,
+        window: Optional["arcade.Window"] = None,
     ):
         # Reference to Context, used to update projection matrix
         self._window = window or arcade.get_window()

--- a/arcade/examples/section_examples.py
+++ b/arcade/examples/section_examples.py
@@ -1,0 +1,174 @@
+"""
+This shows how sections work with a very small example
+
+What's key here is to understand how sections can isolate code that otherwise
+ goes packed together in the view.
+Also, note that events are received on each section only based on the
+ section configuration. This way you don't have to check every time if the mouse
+ position is on top of some area.
+
+"""
+import arcade
+from arcade.sections import Section
+
+INFO_BAR_HEIGHT = 40
+PANEL_WIDTH = 200
+SPRITE_SPEED = 1
+
+
+class Ball(arcade.SpriteCircle):
+
+    def __init__(self, radius, color):
+        super().__init__(radius, color)
+
+        self.bounce_count = 0
+
+    @property
+    def speed(self):
+        return round((abs(self.change_x) + abs(self.change_y)) * 60, 2)
+
+
+class InfoBar(Section):
+
+    @property
+    def ball(self):
+        return self.view.map.ball
+
+    def on_draw(self):
+        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
+                                          self.bottom, arcade.color.GRAY)
+        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
+                                           self.bottom, arcade.color.WHITE)
+        arcade.draw_text(f'Ball bounce count: {self.ball.bounce_count}', self.left + 20,
+                         self.top - self.height / 1.6, arcade.color.BLUE)
+
+        arcade.draw_text(f'Ball change in axis: {(self.ball.change_x, self.ball.change_y)}',
+                         self.left + 220, self.top - self.height / 1.6, arcade.color.BLUE)
+        arcade.draw_text(f'Ball speed: {self.ball.speed} pixels/second',
+                         self.left + 480, self.top - self.height / 1.6, arcade.color.BLUE)
+
+    def on_resize(self, width: int, height: int):
+        # stick to the top
+        self.width = width
+        self.bottom = height - self.view.info_bar.height
+
+
+class Panel(Section):
+
+    def __init__(self, left: float, bottom: float, width: float, height: float, **kwargs):
+        super().__init__(left, bottom, width, height, **kwargs)
+
+        self.button_stop = self.new_button(arcade.color.PUMPKIN)
+        self.button_toogle_info_bar = self.new_button(arcade.color.YELLOW)
+
+    @staticmethod
+    def new_button(color):
+        return arcade.SpriteSolidColor(100, 50, color)
+
+    def draw_button_stop(self):
+        arcade.draw_text('Press button to stop the ball', self.left + 10, self.top - 40, arcade.color.BLACK, 9)
+        self.button_stop.draw()
+
+    def draw_button_toogle_info_bar(self):
+        arcade.draw_text('Press to toogle info_bar', self.left + 10, self.top - 140, arcade.color.BLACK, 9)
+        self.button_toogle_info_bar.draw()
+
+    def on_draw(self):
+        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
+                                          self.bottom, arcade.color.BROWN)
+        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
+                                           self.bottom, arcade.color.WHITE)
+        self.draw_button_stop()
+        self.draw_button_toogle_info_bar()
+
+    def on_mouse_press(self, x: float, y: float, button: int, modifiers: int):
+        if self.button_stop.collides_with_point((x, y)):
+            self.view.map.ball.stop()
+        elif self.button_toogle_info_bar.collides_with_point((x, y)):
+            self.view.info_bar.enabled = not self.view.info_bar.enabled
+
+    def on_resize(self, width: int, height: int):
+        # stick to the right
+        self.left = width - self.width
+        self.height = height - self.view.info_bar.height
+        self.button_stop.position = self.left + self.width / 2, self.top - 80
+        self.button_toogle_info_bar.position = self.left + self.width / 2, self.top - 180
+
+
+class Map(Section):
+
+    def __init__(self, left: float, bottom: float, width: float, height: float, **kwargs):
+        super().__init__(left, bottom, width, height, **kwargs)
+
+        self.ball = Ball(20, arcade.color.RED)
+        self.ball.position = 60, 60
+        self.sprite_list = arcade.SpriteList()
+        self.sprite_list.append(self.ball)
+
+        self.pressed_key = None
+
+    def on_update(self, delta_time: float):
+
+        if self.pressed_key:
+            if self.pressed_key == arcade.key.UP:
+                self.ball.change_y += SPRITE_SPEED
+            elif self.pressed_key == arcade.key.RIGHT:
+                self.ball.change_x += SPRITE_SPEED
+            elif self.pressed_key == arcade.key.DOWN:
+                self.ball.change_y -= SPRITE_SPEED
+            elif self.pressed_key == arcade.key.LEFT:
+                self.ball.change_x -= SPRITE_SPEED
+
+        self.sprite_list.update()
+
+        if self.ball.top >= self.top or self.ball.bottom <= self.bottom:
+            self.ball.change_y *= -1
+            self.ball.bounce_count += 1
+        if self.ball.left <= self.left or self.ball.right >= self.right:
+            self.ball.change_x *= -1
+            self.ball.bounce_count += 1
+
+    def on_draw(self):
+        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
+                                           self.bottom, arcade.color.WHITE)
+        self.sprite_list.draw()
+
+    def on_key_press(self, symbol: int, modifiers: int):
+        self.pressed_key = symbol
+
+    def on_key_release(self, _symbol: int, _modifiers: int):
+        self.pressed_key = None
+
+    def on_resize(self, width: int, height: int):
+        self.width = width - self.view.panel.width
+        self.height = height - self.view.info_bar.height
+
+
+class GameView(arcade.View):
+
+    def __init__(self):
+        super().__init__()
+        self.info_bar = InfoBar(0, self.window.height - INFO_BAR_HEIGHT, self.window.width, INFO_BAR_HEIGHT)
+        self.panel = Panel(self.window.width - PANEL_WIDTH, 0, PANEL_WIDTH, self.window.height - INFO_BAR_HEIGHT)
+        self.map = Map(0, 0, self.window.width - PANEL_WIDTH, self.window.height - INFO_BAR_HEIGHT,
+                       accept_keyboard_events=True)
+
+        self.section_manager.add_section(self.info_bar)
+        self.section_manager.add_section(self.panel)
+        self.section_manager.add_section(self.map)
+
+    def on_draw(self):
+        arcade.start_render()
+
+
+def main():
+    window = arcade.Window(resizable=True)
+    game = GameView()
+
+    window.show_view(game)
+
+    arcade.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -1,0 +1,280 @@
+from typing import Optional, List
+
+from arcade import Camera, draw_lrtb_rectangle_outline
+from arcade.color import WHITE
+
+
+class Section:
+    """
+    A Section represents a rectangular portion of the viewport
+    Events are dispatched to the section based on it's position on the screen.
+    """
+
+    def __init__(self, view, left: float, bottom: float, width: float, height: float, *,
+                 keyboard_primary: bool = False, prevent_dispatch: bool = True):
+        # parent view
+        self.view = view
+
+        # section options
+        self._keyboard_primary: bool = keyboard_primary
+        self.prevent_dispatch: bool = prevent_dispatch
+
+        # section position into the current viewport
+        # if screen is resized it's upto the user to move or resize each section
+        self.left: float = left
+        self.bottom: float = bottom
+        self.width: float = width
+        self.height: float = height
+
+        # optional section camera
+        self.camera: Optional[Camera] = None
+
+    @property
+    def right(self) -> float:
+        """ Right edge of this section """
+        return self.left + self.width
+
+    @property
+    def top(self) -> float:
+        """ Top edge of this section """
+        return self.bottom + self.height
+
+    @property
+    def window(self):
+        """ The view window """
+        return self.view.window
+
+    @property
+    def keyboard_primary(self) -> bool:
+        """ Sets if this section receives the keyboard events """
+        return self._keyboard_primary
+
+    @keyboard_primary.setter
+    def keyboard_primary(self, value) -> None:
+        if value is True:
+            self.view.section_manager.remove_keyboard_primary()
+            self._keyboard_primary = True
+        else:
+            self._keyboard_primary = value
+
+    def overlaps_with(self, section) -> bool:
+        """ Checks if this section overlaps with another section """
+        return not (self.right < section.left or self.left > section.right or self.top < section.bottom or self.bottom > section.top)
+
+    def mouse_is_on_top(self, x: float, y: float) -> bool:
+        """ Check if the current mouse position is on top of this section """
+        return self.left <= x <= self.right and self.bottom <= y <= self.top
+
+    # Following methods are just the usual view methods + on_mouse_enter / on_mouse_leave
+
+    def on_draw(self):
+        pass
+
+    def on_update(self, delta_time: float):
+        pass
+
+    def update(self, delta_time: float):
+        pass
+
+    def on_resize(self, width: int, height: int):
+        pass
+
+    def on_mouse_press(self, x: float, y: float, button: int, modifiers: int):
+        pass
+
+    def on_mouse_release(self, x: float, y: float, button: int, modifiers: int):
+        pass
+
+    def on_mouse_motion(self, x: float, y: float, dx: float, dy: float):
+        pass
+
+    def on_mouse_scroll(self, x: int, y: int, scroll_x: int, scroll_y: int):
+        pass
+
+    def on_mouse_drag(self, x: float, y: float, dx: float, dy: float, _buttons: int, _modifiers: int):
+        pass
+
+    def on_mouse_enter(self, x: float, y: float):
+        pass
+
+    def on_mouse_leave(self, x: float, y: float):
+        pass
+
+    def on_key_press(self, symbol: int, modifiers: int):
+        pass
+
+    def on_key_release(self, _symbol: int, _modifiers: int):
+        pass
+
+
+class SectionManager:
+    """
+    This manages the different Sections a View has.
+    Actions such as dispatching the eventos to the correct Section, draw order, etc.
+    """
+
+    def __init__(self, view):
+        self.view = view  # the view this section manager belongs to
+        self.sections: List[Section] = []  # a list of the current sections for this view
+
+        # generic camera to reset after a custom camera is use
+        self.camera: Camera = Camera(self.view.window.width, self.view.window.height)
+
+        # Holds the section the mouse is currently on top
+        self.mouse_over_section: Optional[Section] = None
+
+        # debug tool to just draw some rectangles over the section borders
+        self.debug: bool = False
+
+    @property
+    def has_sections(self) -> bool:
+        """ Returns true if sections are available """
+        return bool(self.sections)
+
+    def add_section(self, new_section: "Section") -> bool:
+        """
+        Ads a section to this Section Manger.
+        It checks if the new section overlaps with other sections.
+        """
+        for section in self.sections:
+            if new_section.overlaps_with(section):
+                return False
+        self.sections.append(new_section)
+        return True
+
+    def on_update(self, delta_time: float):
+        """ Called on each event loop. First dispatch the view event, then the section ones. """
+        self.view.on_update(delta_time)
+        for section in self.sections:
+            section.on_update(delta_time)
+
+    def update(self, delta_time: float):
+        """ Called on each event loop. First dispatch the view event, then the section ones. """
+        self.view.update(delta_time)
+        for section in self.sections:
+            section.update(delta_time)
+
+    def on_draw(self):
+        """
+        Called on each event loop. First dispatch the view event, then the section ones.
+        It automatically calls camera.use() for each section that has a camera and resets
+         the camera effects by calling the default SectionManager camera afterwards if needed.
+        """
+        self.view.on_draw()
+        for section in self.sections:
+            if section.camera:
+                section.camera.use()  # call the camera use of the current section before section.on_draw
+            section.on_draw()
+            if section.camera:
+                self.camera.use()  # reset to the default camera after the section is draw if needed
+            if self.debug:
+                draw_lrtb_rectangle_outline(section.left, section.right,
+                                            section.top, section.bottom, WHITE)
+
+    def on_resize(self, width: int, height: int):
+        """ Called when the windows is resized. First dispatch the view event, then the section ones. """
+        self.camera.resize(width, height)  # resize the default camera
+        self.view.on_resize(width, height)
+        for section in self.sections:
+            section.on_resize(width, height)
+
+    def get_keyboard_primary(self) -> Optional[Section]:
+        """ Returns the section that has keyboard_primary set """
+        for section in self.sections:
+            if section.keyboard_primary:
+                return section
+        return None
+
+    def remove_keyboard_primary(self) -> None:
+        """ Removes the keyboard events handling from all sections """
+        for section in self.sections:
+            section._keyboard_primary = False
+
+    def get_section(self, x: float, y: float) -> Optional[Section]:
+        """ Returns a section based on a position """
+        for section in self.sections:
+            if section.mouse_is_on_top(x, y):
+                return section
+        return None
+
+    def dispatch_mouse_event(self, event: str, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        """ Generic method to dispatch mouse events to the correct Section """
+        # check if the affected section has been already computed
+        section = kwargs.get('current_section')
+        if section:
+            # remove the section from the kwargs so it arrives clean to the event handler
+            del kwargs['current_section']
+        else:
+            section = self.get_section(x, y)  # get the section from mouse position
+        if section:
+            method = getattr(section, event, None)  # get the method to call from the section
+            if method:
+                result = method(x, y, *args, **kwargs)  # call the section method
+            if (method and result is True) or section.prevent_dispatch:
+                # if the method returns EVENT_HANDLED (True) then avoid propagating the event.
+                # if the section prevents dispatching events to the view return
+                return True
+        method = getattr(self.view, event, None)  # get the method from the view
+        if method:
+            return method(x, y, *args, **kwargs)  # call the view method
+
+    def dispatch_keyboard_event(self, event, *args, **kwargs) -> Optional[bool]:
+        """ Generic method to dispatch keyboard events to the correct Section """
+        section = self.get_keyboard_primary()  # get the section that receives keyboard events if any
+        if section:
+            method = getattr(section, event, None)  # get the method to call from the section
+            if method:
+                result = method(*args, **kwargs)  # call the section method
+            if (method and result is True) or section.prevent_dispatch:
+                # if the method returns EVENT_HANDLED (True) then avoid propagating the event.
+                # if the section prevents dispatching events to the view return
+                return True
+        method = getattr(self.view, event, None)  # get the method from the view
+        if method:
+            return method(*args, **kwargs)  # call the view method
+
+    def on_mouse_press(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_mouse_event('on_mouse_press', x, y, *args, **kwargs)
+
+    def on_mouse_release(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_mouse_event('on_mouse_release', x, y, *args, **kwargs)
+
+    def on_mouse_motion(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        before_section = self.mouse_over_section
+        current_section = self.get_section(x, y)
+        if before_section is not current_section:
+            self.mouse_over_section = current_section
+            if before_section:
+                # dispatch on_mouse_leave to before_section (result from this call is ignored)
+                self.dispatch_mouse_event('on_mouse_leave', x, y, current_section=before_section)
+            if current_section:
+                # dispatch on_mouse_enter to current_section (result from this call is ignored)
+                self.dispatch_mouse_event('on_mouse_enter', x, y, current_section=current_section)
+        if current_section is not None:
+            kwargs['current_section'] = current_section
+        return self.dispatch_mouse_event('on_mouse_motion', x, y, *args, **kwargs)
+
+    def on_mouse_scroll(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_mouse_event('on_mouse_scroll', x, y, *args, **kwargs)
+
+    def on_mouse_drag(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_mouse_event('on_mouse_drag', x, y, *args, **kwargs)
+
+    def on_mouse_enter(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        current_section = self.get_section(x, y)
+        self.mouse_over_section = current_section  # set the section the mouse is over
+        # pass the correct section to the dispatch event so it is not computed again
+        kwargs['current_section'] = current_section
+        return self.dispatch_mouse_event('on_mouse_enter', x, y, *args, **kwargs)
+
+    def on_mouse_leave(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        if self.mouse_over_section:
+            # clear the section the mouse is over as it's out of the screen
+            kwargs['current_section'], self.mouse_over_section = self.mouse_over_section, None
+            return self.dispatch_mouse_event('on_mouse_leave', x, y, *args, **kwargs)
+
+    def on_key_press(self, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_keyboard_event('on_key_press', *args, **kwargs)
+
+    def on_key_release(self, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_keyboard_event('on_key_release', *args, **kwargs)

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -172,7 +172,8 @@ class Section:
         """ returns section coordinates from screen coordinates """
         return screen_x - self.left, screen_y - self.bottom
 
-    # Following methods are just the usual view methods + on_mouse_enter / on_mouse_leave
+    # Following methods are just the usual view methods
+    #  + on_mouse_enter / on_mouse_leave / on_show_section / on_hide_section
 
     def on_draw(self):
         pass
@@ -223,24 +224,22 @@ class Section:
 class SectionManager:
     """
     This manages the different Sections a View has.
-    Actions such as dispatching the eventos to the correct Section, draw order, etc.
+    Actions such as dispatching the events to the correct Section, draw order, etc.
     """
 
     def __init__(self, view):
         self.view = view  # the view this section manager belongs to
 
         # store sections in update/event order and in draw order
-        self._sections: List[Section] = []  # a list of the current sections for this view
+        self._sections: List[Section] = []  # a list of the current sections for this in update/event order
         self._sections_draw: List[Section] = []  # the list of current sections in draw order
 
         # generic camera to reset after a custom camera is use
+        # this camera is set to the whole viewport
         self.camera: Camera = Camera(self.view.window.width, self.view.window.height)
 
         # Holds the section the mouse is currently on top
         self.mouse_over_section: Optional[Section] = None
-
-        # debug tool to just draw some rectangles over the section borders
-        self.debug: bool = False
 
     @property
     def sections(self) -> List[Section]:
@@ -296,6 +295,8 @@ class SectionManager:
 
     def clear_sections(self):
         """ Removes all sections """
+        for section in self.sections:
+            section._view = None
         self._sections = []
         self._sections_draw = []
 
@@ -427,6 +428,10 @@ class SectionManager:
         return self.dispatch_mouse_event('on_mouse_release', x, y, *args, **kwargs)
 
     def on_mouse_motion(self, x: float, y: float, *args, **kwargs) -> Optional[bool]:
+        """
+        This method dispatches the on_mouse_motion and also calculates
+         if on_mouse_enter/leave should be fired
+        """
         before_section = self.mouse_over_section
         current_section = self.get_section(x, y)
         if before_section is not current_section:


### PR DESCRIPTION
See issue #1070 

In a simple game, the whole viewport is used to display the game "map". In more advanced games it's fairly normal to have this viewport divided into "sections". Areas where different information is displayed. For example you can have a menu at the top, some info panel at the right and the game main "screen" (the "map") covering the rest of the viewport.

When dealing with such circumstances, in the current state of arcade is somehow complicated to isolate events occurring in the different sections of the viewport.

What I propose is to enhance the View object to incorporate the optional ability to add Sections. The user can then define a Section defining a left, bottom, width and height inside the screen dimensions (or bigger). Then the view's SectionManager will automatically redirect any events to that Section without interfering with other sections or the View itself.

This is completely optional and if the user chooses to not use Sections then arcade "code flow" is not affected

**Sections feature list:**
- Divide the screen into logical components (Sections) each receiving the mouse events that occur within the the space the section occupies and keyboard events based on configuration.
- Sections provide four new events: `on_show_section` / `on_hide_section` and `on_mouse_enter` / `on_mouse_leave` so you can better build upon sections logic.
- Sections can be enabled or disabled. You can also plug sections from one View to another.
- Section can be modal: modal sections receive events first and draws last and also stops the following sections from updating.
- Sections can be resized and receive the `on_resize` event from the parent `View`
- Sections can prevent dispatching events to the other Sections (`prevent_dispatch` accepts and Iterable of event names)
- Sections can prevent dispatching events to the underlying View (`prevent_dispatch_view` accepts and Iterable of event names)
- Section can receive mouse coordinates in either viewport coordinates or section related coordinates.
- Section camera switch is automated (if a section uses a certain `Camera`, this camera will be disabled when drawing another section)


The PR includes an example showing the main features