### PR TITLE
added pymunk sample tiled map to resources

### DIFF
--- a/arcade/resources/tiled_maps/pymunk_test_map.json
+++ b/arcade/resources/tiled_maps/pymunk_test_map.json
@@ -107,893 +107,893 @@
          "tiles":[
                 {
                  "id":0,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/boxCrate.png",
+                 "image":"..\/images\/tiles\/boxCrate.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":1,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/boxCrate_double.png",
+                 "image":"..\/images\/tiles\/boxCrate_double.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":2,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/boxCrate_single.png",
+                 "image":"..\/images\/tiles\/boxCrate_single.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":3,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/brickBrown.png",
+                 "image":"..\/images\/tiles\/brickBrown.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":4,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/brickGrey.png",
+                 "image":"..\/images\/tiles\/brickGrey.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":5,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/brickTextureWhite.png",
+                 "image":"..\/images\/tiles\/brickTextureWhite.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":6,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/bridgeA.png",
+                 "image":"..\/images\/tiles\/bridgeA.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":7,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/bridgeB.png",
+                 "image":"..\/images\/tiles\/bridgeB.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":8,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/bush.png",
+                 "image":"..\/images\/tiles\/bush.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":9,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/cactus.png",
+                 "image":"..\/images\/tiles\/cactus.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":10,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirt.png",
+                 "image":"..\/images\/tiles\/dirt.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":11,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCenter.png",
+                 "image":"..\/images\/tiles\/dirtCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":12,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCenter_rounded.png",
+                 "image":"..\/images\/tiles\/dirtCenter_rounded.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":13,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCliff_left.png",
+                 "image":"..\/images\/tiles\/dirtCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":14,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCliff_right.png",
+                 "image":"..\/images\/tiles\/dirtCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":15,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/dirtCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":16,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/dirtCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":17,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCorner_left.png",
+                 "image":"..\/images\/tiles\/dirtCorner_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":18,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtCorner_right.png",
+                 "image":"..\/images\/tiles\/dirtCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":19,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHalf.png",
+                 "image":"..\/images\/tiles\/dirtHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":20,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHalf_left.png",
+                 "image":"..\/images\/tiles\/dirtHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":21,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHalf_mid.png",
+                 "image":"..\/images\/tiles\/dirtHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":22,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHalf_right.png",
+                 "image":"..\/images\/tiles\/dirtHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":23,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHill_left.png",
+                 "image":"..\/images\/tiles\/dirtHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":24,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtHill_right.png",
+                 "image":"..\/images\/tiles\/dirtHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":25,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtLeft.png",
+                 "image":"..\/images\/tiles\/dirtLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":26,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtMid.png",
+                 "image":"..\/images\/tiles\/dirtMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":27,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/dirtRight.png",
+                 "image":"..\/images\/tiles\/dirtRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":28,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/doorClosed_mid.png",
+                 "image":"..\/images\/tiles\/doorClosed_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":29,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/doorClosed_top.png",
+                 "image":"..\/images\/tiles\/doorClosed_top.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":30,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grass.png",
+                 "image":"..\/images\/tiles\/grass.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":31,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grass_sprout.png",
+                 "image":"..\/images\/tiles\/grass_sprout.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":32,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCenter.png",
+                 "image":"..\/images\/tiles\/grassCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":33,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCenter_round.png",
+                 "image":"..\/images\/tiles\/grassCenter_round.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":34,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCliff_left.png",
+                 "image":"..\/images\/tiles\/grassCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":35,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCliff_right.png",
+                 "image":"..\/images\/tiles\/grassCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":36,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/grassCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":37,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/grassCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":38,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCorner_left.png",
+                 "image":"..\/images\/tiles\/grassCorner_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":39,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassCorner_right.png",
+                 "image":"..\/images\/tiles\/grassCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":40,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHalf.png",
+                 "image":"..\/images\/tiles\/grassHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":41,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHalf_left.png",
+                 "image":"..\/images\/tiles\/grassHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":42,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHalf_mid.png",
+                 "image":"..\/images\/tiles\/grassHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":43,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHalf_right.png",
+                 "image":"..\/images\/tiles\/grassHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":44,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHill_left.png",
+                 "image":"..\/images\/tiles\/grassHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":45,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassHill_right.png",
+                 "image":"..\/images\/tiles\/grassHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":46,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassLeft.png",
+                 "image":"..\/images\/tiles\/grassLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":47,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassMid.png",
+                 "image":"..\/images\/tiles\/grassMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":48,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/grassRight.png",
+                 "image":"..\/images\/tiles\/grassRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":49,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/ladderMid.png",
+                 "image":"..\/images\/tiles\/ladderMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":50,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/ladderTop.png",
+                 "image":"..\/images\/tiles\/ladderTop.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":51,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/lava.png",
+                 "image":"..\/images\/tiles\/lava.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":52,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/lavaTop_high.png",
+                 "image":"..\/images\/tiles\/lavaTop_high.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":53,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/lavaTop_low.png",
+                 "image":"..\/images\/tiles\/lavaTop_low.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":54,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/leverLeft.png",
+                 "image":"..\/images\/tiles\/leverLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":55,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/leverMid.png",
+                 "image":"..\/images\/tiles\/leverMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":56,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/leverRight.png",
+                 "image":"..\/images\/tiles\/leverRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":57,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/lockRed.png",
+                 "image":"..\/images\/tiles\/lockRed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":58,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/lockYellow.png",
+                 "image":"..\/images\/tiles\/lockYellow.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":59,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/mushroomRed.png",
+                 "image":"..\/images\/tiles\/mushroomRed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":60,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planet.png",
+                 "image":"..\/images\/tiles\/planet.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":61,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCenter.png",
+                 "image":"..\/images\/tiles\/planetCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":62,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCenter_rounded.png",
+                 "image":"..\/images\/tiles\/planetCenter_rounded.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":63,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCliff_left.png",
+                 "image":"..\/images\/tiles\/planetCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":64,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCliff_right.png",
+                 "image":"..\/images\/tiles\/planetCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":65,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/planetCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":66,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/planetCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":67,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCorner_left.png",
+                 "image":"..\/images\/tiles\/planetCorner_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":68,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetCorner_right.png",
+                 "image":"..\/images\/tiles\/planetCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":69,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHalf.png",
+                 "image":"..\/images\/tiles\/planetHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":70,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHalf_left.png",
+                 "image":"..\/images\/tiles\/planetHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":71,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHalf_mid.png",
+                 "image":"..\/images\/tiles\/planetHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":72,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHalf_right.png",
+                 "image":"..\/images\/tiles\/planetHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":73,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHill_left.png",
+                 "image":"..\/images\/tiles\/planetHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":74,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetHill_right.png",
+                 "image":"..\/images\/tiles\/planetHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":75,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetLeft.png",
+                 "image":"..\/images\/tiles\/planetLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":76,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetMid.png",
+                 "image":"..\/images\/tiles\/planetMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":77,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/planetRight.png",
+                 "image":"..\/images\/tiles\/planetRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":78,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/plantPurple.png",
+                 "image":"..\/images\/tiles\/plantPurple.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":79,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/rock.png",
+                 "image":"..\/images\/tiles\/rock.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":80,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sand.png",
+                 "image":"..\/images\/tiles\/sand.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":81,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCenter.png",
+                 "image":"..\/images\/tiles\/sandCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":82,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCenter_rounded.png",
+                 "image":"..\/images\/tiles\/sandCenter_rounded.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":83,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCliff_left.png",
+                 "image":"..\/images\/tiles\/sandCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":84,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCliff_right.png",
+                 "image":"..\/images\/tiles\/sandCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":85,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/sandCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":86,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/sandCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":87,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCorner_leftg.png"
+                 "image":"..\/images\/tiles\/sandCorner_leftg.png"
                 },
                 {
                  "id":88,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandCorner_right.png",
+                 "image":"..\/images\/tiles\/sandCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":89,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHalf.png",
+                 "image":"..\/images\/tiles\/sandHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":90,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHalf_left.png",
+                 "image":"..\/images\/tiles\/sandHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":91,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHalf_mid.png",
+                 "image":"..\/images\/tiles\/sandHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":92,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHalf_right.png",
+                 "image":"..\/images\/tiles\/sandHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":93,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHill_left.png",
+                 "image":"..\/images\/tiles\/sandHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":94,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandHill_right.png",
+                 "image":"..\/images\/tiles\/sandHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":95,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandLeft.png",
+                 "image":"..\/images\/tiles\/sandLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":96,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandMid.png",
+                 "image":"..\/images\/tiles\/sandMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":97,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/sandRight.png",
+                 "image":"..\/images\/tiles\/sandRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":98,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/signExit.png",
+                 "image":"..\/images\/tiles\/signExit.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":99,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/signLeft.png",
+                 "image":"..\/images\/tiles\/signLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":100,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/signRight.png",
+                 "image":"..\/images\/tiles\/signRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":101,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snow.png",
+                 "image":"..\/images\/tiles\/snow.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":102,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snow_pile.png",
+                 "image":"..\/images\/tiles\/snow_pile.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":103,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCenter.png",
+                 "image":"..\/images\/tiles\/snowCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":104,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCenter_rounded.png",
+                 "image":"..\/images\/tiles\/snowCenter_rounded.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":105,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCliff_left.png",
+                 "image":"..\/images\/tiles\/snowCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":106,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCliff_right.png",
+                 "image":"..\/images\/tiles\/snowCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":107,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/snowCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":108,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/snowCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":109,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCorner_left.png",
+                 "image":"..\/images\/tiles\/snowCorner_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":110,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowCorner_right.png",
+                 "image":"..\/images\/tiles\/snowCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":111,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHalf.png",
+                 "image":"..\/images\/tiles\/snowHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":112,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHalf_left.png",
+                 "image":"..\/images\/tiles\/snowHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":113,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHalf_mid.png",
+                 "image":"..\/images\/tiles\/snowHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":114,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHalf_right.png",
+                 "image":"..\/images\/tiles\/snowHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":115,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHill_left.png",
+                 "image":"..\/images\/tiles\/snowHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":116,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowHill_right.png",
+                 "image":"..\/images\/tiles\/snowHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":117,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowLeft.png",
+                 "image":"..\/images\/tiles\/snowLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":118,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowMid.png",
+                 "image":"..\/images\/tiles\/snowMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":119,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/snowRight.png",
+                 "image":"..\/images\/tiles\/snowRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":120,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/spikes.png",
+                 "image":"..\/images\/tiles\/spikes.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":121,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stone.png",
+                 "image":"..\/images\/tiles\/stone.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":122,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCenter.png",
+                 "image":"..\/images\/tiles\/stoneCenter.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":123,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCenter_rounded.png",
+                 "image":"..\/images\/tiles\/stoneCenter_rounded.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":124,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCliff_left.png",
+                 "image":"..\/images\/tiles\/stoneCliff_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":125,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCliff_right.png",
+                 "image":"..\/images\/tiles\/stoneCliff_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":126,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCliffAlt_left.png",
+                 "image":"..\/images\/tiles\/stoneCliffAlt_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":127,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCliffAlt_right.png",
+                 "image":"..\/images\/tiles\/stoneCliffAlt_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":128,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCorner_left.png",
+                 "image":"..\/images\/tiles\/stoneCorner_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":129,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneCorner_right.png",
+                 "image":"..\/images\/tiles\/stoneCorner_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":130,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHalf.png",
+                 "image":"..\/images\/tiles\/stoneHalf.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":131,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHalf_left.png",
+                 "image":"..\/images\/tiles\/stoneHalf_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":132,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHalf_mid.png",
+                 "image":"..\/images\/tiles\/stoneHalf_mid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":133,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHalf_right.png",
+                 "image":"..\/images\/tiles\/stoneHalf_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":134,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHill_left.png",
+                 "image":"..\/images\/tiles\/stoneHill_left.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":135,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneHill_right.png",
+                 "image":"..\/images\/tiles\/stoneHill_right.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":136,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneLeft.png",
+                 "image":"..\/images\/tiles\/stoneLeft.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":137,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneMid.png",
+                 "image":"..\/images\/tiles\/stoneMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":138,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/stoneRight.png",
+                 "image":"..\/images\/tiles\/stoneRight.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":139,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/switchGreen.png",
+                 "image":"..\/images\/tiles\/switchGreen.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":140,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/switchGreen_pressed.png",
+                 "image":"..\/images\/tiles\/switchGreen_pressed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":141,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/switchRed.png",
+                 "image":"..\/images\/tiles\/switchRed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":142,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/switchRed_pressed.png",
+                 "image":"..\/images\/tiles\/switchRed_pressed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":143,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/torch1.png",
+                 "image":"..\/images\/tiles\/torch1.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":144,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/torch2.png",
+                 "image":"..\/images\/tiles\/torch2.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":145,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/torchOff.png",
+                 "image":"..\/images\/tiles\/torchOff.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":146,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/water.png",
+                 "image":"..\/images\/tiles\/water.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":147,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/waterTop_high.png",
+                 "image":"..\/images\/tiles\/waterTop_high.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":148,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/tiles\/waterTop_low.png",
+                 "image":"..\/images\/tiles\/waterTop_low.png",
                  "imageheight":128,
                  "imagewidth":128
                 }],
@@ -1016,157 +1016,157 @@
          "tiles":[
                 {
                  "id":0,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinBronze.png",
+                 "image":"..\/images\/items\/coinBronze.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":1,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinGold.png",
+                 "image":"..\/images\/items\/coinGold.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":2,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinGold_ll.png",
+                 "image":"..\/images\/items\/coinGold_ll.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":3,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinGold_lr.png",
+                 "image":"..\/images\/items\/coinGold_lr.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":4,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinGold_ul.png",
+                 "image":"..\/images\/items\/coinGold_ul.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":5,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinGold_ur.png",
+                 "image":"..\/images\/items\/coinGold_ur.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":6,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinSilver.png",
+                 "image":"..\/images\/items\/coinSilver.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":7,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/coinSilver_test.png",
+                 "image":"..\/images\/items\/coinSilver_test.png",
                  "imageheight":64,
                  "imagewidth":64
                 },
                 {
                  "id":8,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagGreen_down.png",
+                 "image":"..\/images\/items\/flagGreen_down.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":9,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagGreen1.png",
+                 "image":"..\/images\/items\/flagGreen1.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":10,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagGreen2.png",
+                 "image":"..\/images\/items\/flagGreen2.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":11,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagRed_down.png",
+                 "image":"..\/images\/items\/flagRed_down.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":12,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagRed1.png",
+                 "image":"..\/images\/items\/flagRed1.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":13,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagRed2.png",
+                 "image":"..\/images\/items\/flagRed2.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":14,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagYellow_down.png",
+                 "image":"..\/images\/items\/flagYellow_down.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":15,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagYellow1.png",
+                 "image":"..\/images\/items\/flagYellow1.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":16,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/flagYellow2.png",
+                 "image":"..\/images\/items\/flagYellow2.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":17,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gemBlue.png",
+                 "image":"..\/images\/items\/gemBlue.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":18,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gemGreen.png",
+                 "image":"..\/images\/items\/gemGreen.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":19,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gemRed.png",
+                 "image":"..\/images\/items\/gemRed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":20,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gemYellow.png",
+                 "image":"..\/images\/items\/gemYellow.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":21,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gold_1.png",
+                 "image":"..\/images\/items\/gold_1.png",
                  "imageheight":64,
                  "imagewidth":64
                 },
                 {
                  "id":22,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gold_2.png",
+                 "image":"..\/images\/items\/gold_2.png",
                  "imageheight":64,
                  "imagewidth":64
                 },
                 {
                  "id":23,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gold_3.png",
+                 "image":"..\/images\/items\/gold_3.png",
                  "imageheight":64,
                  "imagewidth":64
                 },
                 {
                  "id":24,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/gold_4.png",
+                 "image":"..\/images\/items\/gold_4.png",
                  "imageheight":64,
                  "imagewidth":64
                 },
                 {
                  "id":25,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/keyBlue.png",
+                 "image":"..\/images\/items\/keyBlue.png",
                  "imageheight":128,
                  "imagewidth":128,
                  "objectgroup":
@@ -1268,37 +1268,37 @@
                 },
                 {
                  "id":26,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/keyGreen.png",
+                 "image":"..\/images\/items\/keyGreen.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":27,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/keyRed.png",
+                 "image":"..\/images\/items\/keyRed.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":28,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/keyYellow.png",
+                 "image":"..\/images\/items\/keyYellow.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":29,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/ladderMid.png",
+                 "image":"..\/images\/items\/ladderMid.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":30,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/ladderTop.png",
+                 "image":"..\/images\/items\/ladderTop.png",
                  "imageheight":128,
                  "imagewidth":128
                 },
                 {
                  "id":31,
-                 "image":"..\/..\/..\/arcade\/resources\/images\/items\/star.png",
+                 "image":"..\/images\/items\/star.png",
                  "imageheight":128,
                  "imagewidth":128
                 }],
@@ -1306,7 +1306,7 @@
         },
         {
          "firstgid":182,
-         "source":"..\/..\/..\/arcade\/resources\/tiled_maps\/grass.json"
+         "source":"..\/tiled_maps\/grass.json"
         }],
  "tilewidth":128,
  "type":"map",

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer.py
@@ -215,7 +215,7 @@ class GameWindow(arcade.Window):
         self.player_sprite.center_y = 250
         self.player_list.append(self.player_sprite)
 
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Read in the tiled map
         my_map = arcade.tilemap.read_map(map_name)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_04.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_04.py
@@ -59,7 +59,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_05.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_05.py
@@ -83,7 +83,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_06.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_06.py
@@ -85,7 +85,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_07.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_07.py
@@ -92,7 +92,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_08.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_08.py
@@ -187,7 +187,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_09.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_09.py
@@ -196,7 +196,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_10.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_10.py
@@ -205,7 +205,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_11.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_11.py
@@ -206,7 +206,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)

--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_12.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_12.py
@@ -251,7 +251,7 @@ class GameWindow(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Map name
-        map_name = "pymunk_test_map.json"
+        map_name = ":resources:/tiled_maps/pymunk_test_map.json"
 
         # Load in TileMap
         tile_map = arcade.load_tilemap(map_name, SPRITE_SCALING_TILES)


### PR DESCRIPTION
issue #1098 
The pymunk example tiled map has been shifted into the resources folder. Each of the code examples in the pymunk tutorial now refer to that new location. The tiled map itself now refers to other image assets in the resources folder correctly. 