### PR TITLE
Headless Compatibility

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -53,6 +53,10 @@ else:
 # noinspection PyPep8
 import pyglet
 
+# Not sure if this is generic enough
+if not os.environ.get('DISPLAY'):
+    pyglet.options["headless"] = True
+
 # Disable shadow windows until issues with intel GPUs
 # on Windows and elsewhere are better understood.
 # Originally, this only disabled them for macs where
@@ -240,8 +244,9 @@ from .isometric import create_isometric_grid_lines
 from .isometric import isometric_grid_to_screen
 from .isometric import screen_to_isometric_grid
 
-from .joysticks import get_game_controllers
-from .joysticks import get_joysticks
+if not pyglet.options["headless"]:
+    from .joysticks import get_game_controllers
+    from .joysticks import get_joysticks
 
 from .emitter import EmitBurst
 from .emitter import EmitController

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -8,6 +8,7 @@ import time
 from typing import Tuple, Optional
 
 import pyglet
+
 import pyglet.gl as gl
 from pyglet.canvas.base import ScreenMode
 
@@ -165,9 +166,15 @@ class Window(pyglet.window.Window):
             self.center_window()
 
         if enable_polling:
+            
             self.keyboard = pyglet.window.key.KeyStateHandler()
-            self.mouse = pyglet.window.mouse.MouseStateHandler()
-            self.push_handlers(self.keyboard, self.mouse)
+            
+            if pyglet.options["headless"]:
+                self.push_handlers(self.keyboard)
+                
+            else:
+                self.mouse = pyglet.window.mouse.MouseStateHandler()
+                self.push_handlers(self.keyboard, self.mouse)
         else:
             self.keyboard = None
             self.mouse = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,7 @@
 # import pytest
 
 # pytest.main(["-x", "tests/unit2"])
+
+# Headless mode
+import pyglet
+pyglet.options["headless"] = True


### PR DESCRIPTION
Implemented simple Headless Compatibility:
- test if display is present in the __init__ of arcade.
- if no display, set pyglet's headless option﻿
