### PR TITLE
Add Py 3.7 install requirement, add information on old python versions

### DIFF
--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -5,7 +5,7 @@ Installation Instructions
 
 Arcade runs on Windows, Mac OS X, and Linux.
 
-Arcade requires Python 3.6 or newer. It does not run on Python 2.x.
+Arcade requires Python 3.7 or newer. It does not run on Python 2.x.
 
 Select the instructions for your platform:
 
@@ -17,3 +17,5 @@ Select the instructions for your platform:
    mac
    linux
    source
+   obsolete
+

--- a/doc/install/obsolete.rst
+++ b/doc/install/obsolete.rst
@@ -1,0 +1,34 @@
+.. _currently supported by the PSF: https://devguide.python.org/#status-of-python-branches
+
+Installation for Obsolete Python Versions
+=========================================
+
+Arcade aims to support the same Python versions
+`currently supported by the PSF`_. You are strongly encouraged to upgrade to
+one of these if at all possible.
+
+If you absolutely cannot upgrade to Python 3.7 or later, you can try using an
+older and unsupported version of Arcade.
+
+Please remember the following:
+
+#. Bugs will not be fixed, unless they are also present in current versions
+#. The features and API may be very different from current versions
+#. You will need use documentation for the version of Arcade you run
+
+The pairings suggested below might not work. They are based on briefly skimming
+git history.  You may have to use trial and error to look for a version that 
+works, and it's possible that you won't find one! Here be dragons!
+
+======================= ======================== ===============
+Obsolete Python Version Suggested Arcade Version Git Commit Hash 
+======================= ======================== ===============
+3.6                     2.6.7                    6e0a9af 
+3.5                     1.2.2                    078f5be
+======================= ======================== ===============
+
+You can attempt to install these versions via the command line through pip,
+or by installing from source from github. Check the tags on Arcade's 
+`github page <https://github.com/pythonarcade/arcade>`_ for additional commit
+IDs.
+


### PR DESCRIPTION
Closes #1117 

I ran a sphinx build locally and the result looks ok. I made sure to check that page doesn't link the obsolete python version page.

Is the wording in obsolete.rst too strong?