### PR TITLE
Fix two broken links on the homepage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -154,7 +154,7 @@ The Python Arcade Library
           <ul>
             <li><a href="https://github.com/pythonarcade/arcade">GitHub</a></li>
             <li><a href="development/release_notes.html">Release Notes</a></li>
-            <li><a href="enhancement_list/enhancement_list.html">Enhancement List</a></li>
+            <li><a href="development/enhancement_list.html">Enhancement List</a></li>
             <li><a href="development/release_checklist.html">Release Check-List</a></li>
           </ul>
         </td>
@@ -183,7 +183,7 @@ The Python Arcade Library
           </div>
           <ul>
             <li><a href="https://learn.arcade.academy/">Book: Learn to Program with Arcade</a></li>
-            <li><a href="tutorials/edge_artifacts/index.html">Fixing Edge Artifacts</a></li>
+            <li><a href="development/edge_artifacts/index.html">Fixing Edge Artifacts</a></li>
             <li><a href="https://mryslab.github.io/bots-in-pieces/python-banyan/arcade/2020/02/21/p2p-arcade-1.html">Peer To Peer Gaming With Arcade and Python Banyan</a></li>
             <li><a href="https://youtu.be/Djtm1DzWSvo">US PyCon 2019 Tutorial</a></li>
             <li><a href="https://youtu.be/2SMkk63k6Ik">Aus PyCon 2018 Multiplayer Games</a></li>


### PR DESCRIPTION
This PR fixes two links currently broken on the homepage:
Learn > Fixing Edge Artifacts
Development > Enhancement List

Running doc build locally indicates the fixes work.