### PR TITLE
Remove obsolete [docs] option from source install instructions

### DIFF
--- a/doc/install/source.rst
+++ b/doc/install/source.rst
@@ -24,7 +24,5 @@ To install additional documentation and development requirements:
 
 .. code-block:: bash
 
-    pip install -e .[dev,docs]
-    # .. or separately
     pip install -e .[dev]
-    pip install -e .[docs]
+


### PR DESCRIPTION
Running the install from source instructions with [docs] produces an error:
```
WARNING: arcade 2.6.13 does not provide the extra 'docs'
```
This option has been obsolete since at least October 2021 per [a message from Clepto in discord](https://discord.com/channels/458662222697070613/458662222697070615/898015011736277002):
```
Docs aren't split anymore FYI, it's just pip install -e .[dev]
```

