### PR TITLE
Fix 4 broken links in example and tutorial pages

### DIFF
--- a/doc/examples/drawing_with_functions.rst
+++ b/doc/examples/drawing_with_functions.rst
@@ -8,9 +8,10 @@ Drawing with Functions
 This example shows how to define functions that draw objects. Such as
 ``draw_tree(x, y)`` and ``draw_bird(x, y)``.
 
-For more information see:
+For more information see `Chapter 9 of Arcade Academy - Learn Python <academy_py_ch9_>`_
+or watch the video below:
 
-*  https://learn.arcade.academy/chapters/09_drawing_with_functions/drawing_with_functions.html
+.. _academy_py_ch9: https://learn.arcade.academy/en/latest/chapters/09_drawing_with_functions/drawing_with_functions.html
 
 .. raw:: html
 

--- a/doc/examples/platform_tutorial/step_04.rst
+++ b/doc/examples/platform_tutorial/step_04.rst
@@ -18,8 +18,8 @@ move our player and keep her from running through walls. The ``PhysicsEngineSimp
 class takes two parameters: The moving
 sprite, and a list of sprites the moving sprite can't move through.
 
-For more information about the physics engine we are using here, see
-`PhysicsEngineSimple class <../../api/physics_engines.html#arcade.PhysicsEngineSimple>`_
+For more information about the physics engine we are using in this tutorial,
+see :py:class:`arcade.PhysicsEngineSimple`.
 
 .. note::
 

--- a/doc/examples/sprite_collect_coins_move_down.rst
+++ b/doc/examples/sprite_collect_coins_move_down.rst
@@ -5,9 +5,9 @@
 Collect Coins Moving Down
 =========================
 
-For a complete explanation, see:
+For a complete explanation, see `Chapter 22 of Arcade Academy - Learn Python <academy_py_ch22_>`_.
 
-* https://learn.arcade.academy/chapters/19_moving_sprites/moving_sprites.html#moving-sprites-down
+.. _academy_py_ch22: https://learn.arcade.academy/en/latest/chapters/22_moving_sprites/moving_sprites.html#moving-sprites-down
 
 .. image:: sprite_collect_coins_move_down.png
     :width: 600px

--- a/doc/examples/text_loc_example.rst
+++ b/doc/examples/text_loc_example.rst
@@ -128,7 +128,7 @@ it).
 We need to put our translation into the right folder structure so our
 library will be able to find it. Create the ``my_app.mo`` folder
 heirarchy. Because we're translating it into Spanish (whose `country
-code <https://www.iso.org/obp/ui/#search>`__ is ``es``), we have to make
+code <https://www.iso.org/obp/ui/>`__ is ``es``), we have to make
 a ``locale/es/LC_MESSAGES`` directory for it.
 
 ::


### PR DESCRIPTION
This PR has been manually built and tested locally, as well as having `make linkcheck` run against it to verify that the links in question no longer 404.

One of them still technically works but reports as broken (fdaf2ff) due to the anchor no longer existing on the linked external page.
