### PR TITLE
Fix doc for Sprite's turn_left and turn_right

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -462,17 +462,19 @@ class Sprite:
         self.change_x += -math.sin(self.radians) * speed
         self.change_y += math.cos(self.radians) * speed
 
-    def turn_right(self, theta: float = 90):
+    def turn_right(self, theta: float = 90.0):
         """
-        Rotate the sprite right a certain number of degrees.
-        :param theta: change in angle
+        Rotate the sprite right by the passed number of degrees.
+
+        :param theta: change in angle, in degrees
         """
         self.angle -= theta
 
-    def turn_left(self, theta: float = 90):
+    def turn_left(self, theta: float = 90.0):
         """
-        Rotate the sprite left a certain number of degrees.
-        :param theta: change in angle
+        Rotate the sprite left by the passed number of degrees.
+
+        :param theta: change in angle, in degrees
         """
         self.angle += theta
 


### PR DESCRIPTION
The doc for these two methods is currently misformatted: https://api.arcade.academy/en/latest/api/sprites.html#arcade.Sprite.turn_left

Changes in this PR:
* Fix param formatting in generated doc
* Add units to param lines
* Replace int keyword arg values with matching floats

Built and tested locally.