### PR TITLE
Add a color fill classmethod to Texture

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -1375,8 +1375,7 @@ class SpriteSolidColor(Sprite):
 
         # otherwise, generate a filler sprite and add it to the cache
         else:
-            image = PIL.Image.new("RGBA", (width, height), color)
-            texture = Texture(cache_name, image)
+            texture = Texture.create_filled(cache_name, (width, height), color)
             load_texture.texture_cache[cache_name] = texture  # type: ignore
 
         # apply chosen texture to the current sprite

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -128,7 +128,7 @@ class Texture:
         background color, you can save CPU time and RAM by calling this
         function once, then passing the ``image`` attribute of the
         resulting Texture object to the class constructor for each
-        additional blank Texture instance you would like to create.
+        additional filled Texture instance you would like to create.
         This can be especially helpful if you are creating multiple
         large Textures.
         """

--- a/arcade/texture.py
+++ b/arcade/texture.py
@@ -15,6 +15,7 @@ from typing import Union
 from arcade import lerp
 from arcade import RectList
 from arcade import Color
+from arcade import get_four_byte_color
 from arcade import calculate_hit_box_points_simple
 from arcade import calculate_hit_box_points_detailed
 from arcade.resources import resolve_resource_path
@@ -98,6 +99,45 @@ class Texture:
         self._hit_box_algorithm = hit_box_algorithm or "None"
 
         self._hit_box_detail = hit_box_detail
+
+    @classmethod
+    def create_filled(cls, name: str, size: Tuple[int, int], color: Color) -> "Texture":
+        """
+        Create a texture completely filled with the passed color.
+
+        The hit box of the returned Texture will be set to a rectangle
+        with the dimensions in ``size`` because all pixels are filled
+        with the same color.
+
+        :param str name: The unique name for this texture
+        :param Tuple[int,int] size: The xy size of the internal image
+        :param Color color: the color to fill the texture with
+
+        This function has multiple uses, including:
+
+            - A helper for pre-blending backgrounds into terrain tiles
+            - Fillers to stand in for state-specific textures
+            - Quick filler assets for various proofs of concept
+
+        Be careful of your RAM usage when using this function. The
+        Texture this method returns will have a new internal RGBA
+        Pillow image which uses 4 bytes for every pixel in it.
+        This will quickly add up if you create many large Textures.
+
+        If you want to create more than one filled texture with the same
+        background color, you can save CPU time and RAM by calling this
+        function once, then passing the ``image`` attribute of the
+        resulting Texture object to the class constructor for each
+        additional blank Texture instance you would like to create.
+        This can be especially helpful if you are creating multiple
+        large Textures.
+        """
+        return Texture(
+            name,
+            # ensure pillow gets the 1 byte / channel it expects
+            image=PIL.Image.new("RGBA", size, get_four_byte_color(color)),
+            hit_box_algorithm=None,
+        )
 
     @classmethod
     def create_empty(cls, name: str, size: Tuple[int, int]) -> "Texture":


### PR DESCRIPTION
## tl;dr
1. Added `arcade.Texture.create_filled`, which is like `create_empty` but takes a color
2. Made `arcade.SpriteSolidColor` use it
3. Tested affected examples and building the doc, all looks ok

## Why?
### 1. Easier prototyping for end users
Some users may begin their project by displaying game state through`Sprite.color` changes applied to solid white `SpriteCircle` or `SpriteSolidColor` instances. However, it can be annoying to rewrite such code to use texture data.

Merging this PR will make it easier for users to generate filler textures from the start. Switching to loading texture data from files is easy, regardless of whether they use [`load_textures`](https://api.arcade.academy/en/latest/api/texture.html#arcade-load-textures), [`load_spritesheet`](https://api.arcade.academy/en/latest/api/texture.html#arcade-load-spritesheet), or another method of their choice.

The code for projects that expand on #1204 could also be cleaner as a result. For example, some RTS games use a convention of red for low health, yellow for medium health, and green for full health. Users will no longer need to understand Pillow's API or image channels to achieve this.

### 2. Make writing examples easier
The piano example for #1198 will be easier to write cleanly with this merged.

### 3. Avoid memory leaks
It's unclear whether this comment is still relevant, but [`Sprite.color` may create memory leaks](https://github.com/pythonarcade/arcade/pull/974#issuecomment-931342070):
> [pvcraven](https://github.com/pvcraven) commented [on Sep 30, 2021](https://github.com/pythonarcade/arcade/pull/974#issuecomment-931342070)
My initial, quick-look-through, makes me think this is a good change.
>
>If someone color-cycles we'll have a memory leak, but that will mess up the atlas anyways. Makes me wonder if there should be docs somewhere that explain to use .color or otherwise explain the internals a bit.
