### PR TITLE
Rename pitch to speed, added example, and tweaked existing sound example

### DIFF
--- a/arcade/examples/asteroid_smasher.py
+++ b/arcade/examples/asteroid_smasher.py
@@ -272,7 +272,7 @@ class MyGame(arcade.Window):
 
             self.bullet_list.append(bullet_sprite)
 
-            arcade.play_sound(self.laser_sound, pitch=random.random() * 3 + 0.5)
+            arcade.play_sound(self.laser_sound)
 
         if symbol == arcade.key.LEFT:
             self.player_sprite.change_angle = 3

--- a/arcade/examples/sound_demo.py
+++ b/arcade/examples/sound_demo.py
@@ -1,11 +1,5 @@
 """
-Starting Template
-
-Once you have learned how to use classes, you can begin your program with this
-template.
-
-If Python and Arcade are installed, this example can be run from the command
-line with:
+Sound Panning Demo
 
 python -m arcade.examples.sound_demo
 
@@ -23,8 +17,11 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
-SCREEN_TITLE = "Starting Template"
+SCREEN_TITLE = "Sound Panning Demo"
 BUTTON_SIZE = 30
+
+SOUND_PANNING = [-1.0, -0.5, 0.0, 0.5, 1.0]
+assert len(SOUND_PANNING) == 5
 
 
 class SoundButton(arcade.SpriteSolidColor):
@@ -74,19 +71,9 @@ class AudioStreamButton(arcade.SpriteSolidColor):
 
 
 class MyGame(arcade.Window):
-    """
-    Main application class.
-
-    NOTE: Go ahead and delete the methods you don't need.
-    If you do need a method, delete the 'pass' and replace it
-    with your own code. Don't leave 'pass' in this program.
-    """
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title)
-
         arcade.set_background_color(arcade.color.AMAZON)
-
         self.button_sprites = None
 
     def setup(self):
@@ -102,83 +89,42 @@ class MyGame(arcade.Window):
         self.button_sprites.append(button)
 
         upgrade_sound = ":resources:sounds/upgrade4.wav"
-
-        # fmt: off
-        button_params = [
-        #    sound        , pan  , vol , x                          , y
-            [upgrade_sound, -1.0 , 0.1 , BUTTON_SIZE                , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, -0.5 , 0.1 , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  0   , 0.1 , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  0.5 , 0.1 , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  1.0 , 0.1 , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, -1.0 , 0.5 , BUTTON_SIZE                , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, -0.5 , 0.5 , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  0   , 0.5 , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  0.5 , 0.5 , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  1.0 , 0.5 , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, -1.0 , 1   , BUTTON_SIZE                , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, -0.5 , 1   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  0   , 1   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  0.5 , 1   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  1.0 , 1   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 - 50 ],
+        volume_variation = [0.1, 0.5, 1]
+        y_offset = [50, 0, -50]
+        button_x_spread = [
+            BUTTON_SIZE,
+            SCREEN_WIDTH / 4,
+            SCREEN_WIDTH / 2,
+            SCREEN_WIDTH / 4 * 3,
+            SCREEN_WIDTH - BUTTON_SIZE,
         ]
-        # fmt: on
 
-        self.button_sprites.extend([SoundButton(*param) for param in button_params])
+        for vol, y_offset in zip(volume_variation, y_offset):
+            for pan_setting, x_pos in zip(SOUND_PANNING, button_x_spread):
+                self.button_sprites.append(
+                    SoundButton(
+                        upgrade_sound,
+                        pan_setting,
+                        vol,
+                        x_pos,
+                        SCREEN_HEIGHT / 2 + y_offset,
+                    )
+                )
 
     def on_draw(self):
-        """
-        Render the screen.
-        """
-
-        # This command should happen before we start drawing. It will clear
-        # the screen to the background color, and erase what we drew last frame.
         self.clear()
-
-        # Call draw() on all your sprite lists below
         self.button_sprites.draw()
 
     def on_update(self, delta_time):
-        """
-        All the logic to move, and the game logic goes here.
-        Normally, you'll call update() on the sprite lists that
-        need it.
-        """
         self.button_sprites.update()
 
-    def on_key_press(self, key, key_modifiers):
-        """
-        Called whenever a key on the keyboard is pressed.
-
-        For a full list of keys, see:
-        https://api.arcade.academy/en/latest/arcade.key.html
-        """
-        pass
-
-    def on_key_release(self, key, key_modifiers):
-        """
-        Called whenever the user lets off a previously pressed key.
-        """
-        pass
-
-    def on_mouse_motion(self, x, y, delta_x, delta_y):
-        """
-        Called whenever the mouse moves.
-        """
-        pass
-
     def on_mouse_press(self, x, y, button, key_modifiers):
-        """
-        Called when the user presses a mouse button.
-        """
         hit_sprites = arcade.get_sprites_at_point((x, y), self.button_sprites)
         for sprite in hit_sprites:
             button_sprite = typing.cast(SoundButton, sprite)
             if button == arcade.MOUSE_BUTTON_LEFT:
                 button_sprite.play()
-            elif (
-                button == arcade.MOUSE_BUTTON_RIGHT
-            ):  # right click to increase volume on currently playing sound
+            elif button == arcade.MOUSE_BUTTON_RIGHT:
                 if not button_sprite.sound.is_complete():
                     button_sprite.volume_up()
                     button_sprite.stream_position()
@@ -187,15 +133,8 @@ class MyGame(arcade.Window):
                     button_sprite.volume_down()
                     button_sprite.stream_position()
 
-    def on_mouse_release(self, x, y, button, key_modifiers):
-        """
-        Called when a user releases a mouse button.
-        """
-        pass
-
 
 def main():
-    """Main function"""
     game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     game.setup()
     arcade.run()

--- a/arcade/examples/sound_speed_demo.py
+++ b/arcade/examples/sound_speed_demo.py
@@ -30,47 +30,20 @@ BUTTON_SIZE = 30
 class SoundButton(arcade.SpriteSolidColor):
     """Button, click-for-sound"""
 
-    def __init__(self, sound_file, pan, volume, center_x, center_y):
+    def __init__(self, sound_file, speed, volume, center_x, center_y):
         super().__init__(BUTTON_SIZE, BUTTON_SIZE, arcade.color.WHITE)
         self.sound = arcade.Sound(sound_file)
-        self.pan = pan
+        self.speed = speed
         self.volume = volume
         self.center_x = center_x
         self.center_y = center_y
 
     def play(self):
         """Play"""
-        self.sound.play(pan=self.pan, volume=self.volume)
+        self.sound.play(speed=self.speed, volume=self.volume)
 
     def draw(self):
         super().draw(self)
-
-
-class AudioStreamButton(arcade.SpriteSolidColor):
-    """Button, click-for-streaming-sound"""
-
-    def __init__(self, sound_file, pan, volume):
-        super().__init__(BUTTON_SIZE, BUTTON_SIZE, arcade.color.WHITE)
-        self.sound = arcade.Sound(sound_file, streaming=True)
-        self.pan = pan
-        self.volume = volume
-
-    def play(self):
-        """Play"""
-        self.sound.play(volume=self.volume, pan=self.pan)
-
-    def volume_up(self):
-        vol = self.sound.get_volume()
-        self.sound.set_volume(vol + 0.1)
-        print(f"Volume: {self.sound.get_volume()}")
-
-    def volume_down(self):
-        vol = self.sound.get_volume()
-        self.sound.set_volume(vol - 0.1)
-        print(f"Volume: {self.sound.get_volume()}")
-
-    def stream_position(self):
-        print(f"Current position: {self.sound.get_stream_position()}")
 
 
 class MyGame(arcade.Window):
@@ -92,35 +65,28 @@ class MyGame(arcade.Window):
     def setup(self):
         self.button_sprites = arcade.SpriteList()
 
-        y = SCREEN_HEIGHT / 2 + 150
-        volume = 0.1
-        button = AudioStreamButton(
-            ":resources:music/funkyrobot.mp3", pan=-1.0, volume=volume
-        )
-        button.center_x = BUTTON_SIZE
-        button.center_y = y
-        self.button_sprites.append(button)
-
-        upgrade_sound = ":resources:sounds/upgrade4.wav"
+        upgrade_sound = ":resources:sounds/gameover3.wav"
 
         # fmt: off
         button_params = [
-        #    sound        , pan  , vol , x                          , y
-            [upgrade_sound, -1.0 , 0.1 , BUTTON_SIZE                , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, -0.5 , 0.1 , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  0   , 0.1 , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  0.5 , 0.1 , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound,  1.0 , 0.1 , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, -1.0 , 0.5 , BUTTON_SIZE                , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, -0.5 , 0.5 , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  0   , 0.5 , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  0.5 , 0.5 , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound,  1.0 , 0.5 , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, -1.0 , 1   , BUTTON_SIZE                , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, -0.5 , 1   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  0   , 1   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  0.5 , 1   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound,  1.0 , 1   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 - 50 ],
+        #    sound        , speed, vol   , x                          , y
+            [upgrade_sound, 0.1 , 0.1   , BUTTON_SIZE                , SCREEN_HEIGHT / 2 + 50 ],
+            [upgrade_sound, 0.5 , 0.1   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 + 50 ],
+            [upgrade_sound, 1.0 , 0.1   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 + 50 ],
+            [upgrade_sound, 2.0 , 0.1   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 + 50 ],
+            [upgrade_sound, 4.0 , 0.1   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 + 50 ],
+            
+            [upgrade_sound, 0.1 , 0.5   , BUTTON_SIZE                , SCREEN_HEIGHT / 2      ],
+            [upgrade_sound, 0.5 , 0.5   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2      ],
+            [upgrade_sound, 1.0 , 0.5   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2      ],
+            [upgrade_sound, 2.0 , 0.5   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2      ],
+            [upgrade_sound, 4.0 , 0.5   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2      ],
+            
+            [upgrade_sound, 0.1 , 1     , BUTTON_SIZE                , SCREEN_HEIGHT / 2 - 50 ],
+            [upgrade_sound, 0.5 , 1     , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 - 50 ],
+            [upgrade_sound, 1.0 , 1     , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 - 50 ],
+            [upgrade_sound, 2.0 , 1     , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 - 50 ],
+            [upgrade_sound, 4.0 , 1     , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 - 50 ],
         ]
         # fmt: on
 

--- a/arcade/examples/sound_speed_demo.py
+++ b/arcade/examples/sound_speed_demo.py
@@ -1,16 +1,10 @@
 """
-Starting Template
+Sound Speed Demo
 
-Once you have learned how to use classes, you can begin your program with this
-template.
-
-If Python and Arcade are installed, this example can be run from the command
-line with:
-
-python -m arcade.examples.sound_demo
+python -m arcade.examples.sound_speed_demo
 
 The top button is to play a music track.
-The 3 rows of buttons are arranged such that the audio is panned in the
+The 3 rows of buttons are arranged such that the audio is sped up in the
 direction of the button, and the volume increases as you go down the column.
 
 Left click a button to play a sound. 
@@ -23,8 +17,13 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
-SCREEN_TITLE = "Starting Template"
+SCREEN_TITLE = "Sound Speed Demo"
 BUTTON_SIZE = 30
+
+SPEED_VARIATION = [0.1, 0.5, 1.0, 2.0, 4.0]
+assert len(SPEED_VARIATION) == 5
+for speed in SPEED_VARIATION:
+    assert speed > 0
 
 
 class SoundButton(arcade.SpriteSolidColor):
@@ -47,14 +46,6 @@ class SoundButton(arcade.SpriteSolidColor):
 
 
 class MyGame(arcade.Window):
-    """
-    Main application class.
-
-    NOTE: Go ahead and delete the methods you don't need.
-    If you do need a method, delete the 'pass' and replace it
-    with your own code. Don't leave 'pass' in this program.
-    """
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title)
 
@@ -65,86 +56,44 @@ class MyGame(arcade.Window):
     def setup(self):
         self.button_sprites = arcade.SpriteList()
 
-        upgrade_sound = ":resources:sounds/gameover3.wav"
+        game_over_sound = ":resources:sounds/gameover3.wav"
 
-        # fmt: off
-        button_params = [
-        #    sound        , speed, vol   , x                          , y
-            [upgrade_sound, 0.1 , 0.1   , BUTTON_SIZE                , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, 0.5 , 0.1   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, 1.0 , 0.1   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, 2.0 , 0.1   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 + 50 ],
-            [upgrade_sound, 4.0 , 0.1   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 + 50 ],
-            
-            [upgrade_sound, 0.1 , 0.5   , BUTTON_SIZE                , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, 0.5 , 0.5   , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, 1.0 , 0.5   , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, 2.0 , 0.5   , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2      ],
-            [upgrade_sound, 4.0 , 0.5   , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2      ],
-            
-            [upgrade_sound, 0.1 , 1     , BUTTON_SIZE                , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, 0.5 , 1     , SCREEN_WIDTH / 4           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, 1.0 , 1     , SCREEN_WIDTH / 2           , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, 2.0 , 1     , SCREEN_WIDTH / 4 * 3       , SCREEN_HEIGHT / 2 - 50 ],
-            [upgrade_sound, 4.0 , 1     , SCREEN_WIDTH - BUTTON_SIZE , SCREEN_HEIGHT / 2 - 50 ],
+        volume_variation = [0.1, 0.5, 1]
+        y_offset = [50, 0, -50]
+        button_x_spread = [
+            BUTTON_SIZE,
+            SCREEN_WIDTH / 4,
+            SCREEN_WIDTH / 2,
+            SCREEN_WIDTH / 4 * 3,
+            SCREEN_WIDTH - BUTTON_SIZE,
         ]
-        # fmt: on
 
-        self.button_sprites.extend([SoundButton(*param) for param in button_params])
+        for vol, y_offset in zip(volume_variation, y_offset):
+            for speed_setting, x_pos in zip(SPEED_VARIATION, button_x_spread):
+                self.button_sprites.append(
+                    SoundButton(
+                        game_over_sound,
+                        speed_setting,
+                        vol,
+                        x_pos,
+                        SCREEN_HEIGHT / 2 + y_offset,
+                    )
+                )
 
     def on_draw(self):
-        """
-        Render the screen.
-        """
-
-        # This command should happen before we start drawing. It will clear
-        # the screen to the background color, and erase what we drew last frame.
         self.clear()
-
-        # Call draw() on all your sprite lists below
         self.button_sprites.draw()
 
     def on_update(self, delta_time):
-        """
-        All the logic to move, and the game logic goes here.
-        Normally, you'll call update() on the sprite lists that
-        need it.
-        """
         self.button_sprites.update()
 
-    def on_key_press(self, key, key_modifiers):
-        """
-        Called whenever a key on the keyboard is pressed.
-
-        For a full list of keys, see:
-        https://api.arcade.academy/en/latest/arcade.key.html
-        """
-        pass
-
-    def on_key_release(self, key, key_modifiers):
-        """
-        Called whenever the user lets off a previously pressed key.
-        """
-        pass
-
-    def on_mouse_motion(self, x, y, delta_x, delta_y):
-        """
-        Called whenever the mouse moves.
-        """
-        pass
-
     def on_mouse_press(self, x, y, button, key_modifiers):
-        """
-        Called when the user presses a mouse button.
-        """
         hit_sprites = arcade.get_sprites_at_point((x, y), self.button_sprites)
         for sprite in hit_sprites:
             button_sprite = typing.cast(SoundButton, sprite)
             if button == arcade.MOUSE_BUTTON_LEFT:
                 button_sprite.play()
-            elif (
-                button == arcade.MOUSE_BUTTON_RIGHT
-            ):  # right click to increase volume on currently playing sound
+            elif button == arcade.MOUSE_BUTTON_RIGHT:
                 if not button_sprite.sound.is_complete():
                     button_sprite.volume_up()
                     button_sprite.stream_position()
@@ -153,15 +102,8 @@ class MyGame(arcade.Window):
                     button_sprite.volume_down()
                     button_sprite.stream_position()
 
-    def on_mouse_release(self, x, y, button, key_modifiers):
-        """
-        Called when a user releases a mouse button.
-        """
-        pass
-
 
 def main():
-    """Main function"""
     game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     game.setup()
     arcade.run()

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -11,7 +11,9 @@ from arcade.resources import resolve_resource_path
 import pyglet
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
-    pyglet.options["audio"] = tuple(v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(","))
+    pyglet.options["audio"] = tuple(
+        v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(",")
+    )
 else:
     pyglet.options["audio"] = ("openal", "xaudio2", "directsound", "pulse", "silent")
 
@@ -19,7 +21,7 @@ import pyglet.media as media
 
 
 class Sound:
-    """ This class represents a sound you can play."""
+    """This class represents a sound you can play."""
 
     def __init__(self, file_name: Union[str, Path], streaming: bool = False):
         self.file_name: str = ""
@@ -31,16 +33,20 @@ class Sound:
             )
         self.file_name = str(file_name)
 
-        self.source: Union[media.StaticSource, media.StreamingSource] = media.load(self.file_name, streaming=streaming)
+        self.source: Union[media.StaticSource, media.StreamingSource] = media.load(
+            self.file_name, streaming=streaming
+        )
 
-        self.min_distance = 100000000  # setting the players to this allows for 2D panning with 3D audio
+        self.min_distance = (
+            100000000  # setting the players to this allows for 2D panning with 3D audio
+        )
 
     def play(
         self,
         volume: float = 1.0,
         pan: float = 0.0,
         loop: bool = False,
-        speed: float = 1.0
+        speed: float = 1.0,
     ) -> media.Player:
         """
         Play the sound.
@@ -49,16 +55,28 @@ class Sound:
         :param float pan: Pan, from -1=left to 0=centered to 1=right
         :param bool loop: Loop, false to play once, true to loop continuously
         """
-        if isinstance(self.source, media.StreamingSource) \
-                and self.source.is_player_source:
-            raise RuntimeError("Tried to play a streaming source more than once."
-                               " Streaming sources should only be played in one instance."
-                               " If you need more use a Static source.")
+        if (
+            isinstance(self.source, media.StreamingSource)
+            and self.source.is_player_source
+        ):
+            raise RuntimeError(
+                "Tried to play a streaming source more than once."
+                " Streaming sources should only be played in one instance."
+                " If you need more use a Static source."
+            )
 
         player: media.Player = media.Player()
         player.volume = volume
-        player.position = (pan, 0.0, math.sqrt(1 - math.pow(pan, 2)))  # used to mimic panning with 3D audio
-        player.pitch = speed # note that the underlying attribute is pitch but "speed" is used because it better describes the behavior see #1198
+        player.position = (
+            pan,
+            0.0,
+            math.sqrt(1 - math.pow(pan, 2)),
+        )  # used to mimic panning with 3D audio
+
+        # Note that the underlying attribute is pitch but "speed" is used
+        # because it describes the behavior better (see #1198)
+        player.pitch = speed
+
         player.loop = loop
         player.queue(self.source)
         player.play()
@@ -83,11 +101,11 @@ class Sound:
             media.Source._players.remove(player)
 
     def get_length(self) -> float:
-        """ Get length of audio in seconds """
+        """Get length of audio in seconds"""
         return self.source.duration
 
     def is_complete(self, player: media.Player) -> bool:
-        """ Return true if the sound is done playing. """
+        """Return true if the sound is done playing."""
         if player.time >= self.source.duration:
             return True
         else:
@@ -151,7 +169,9 @@ def load_sound(path: Union[str, Path], streaming: bool = False) -> Optional[Soun
         sound = Sound(file_name, streaming)
         return sound
     except Exception as ex:
-        raise FileNotFoundError(f'Unable to load sound file: "{file_name}". Exception: {ex}')
+        raise FileNotFoundError(
+            f'Unable to load sound file: "{file_name}". Exception: {ex}'
+        )
 
 
 def play_sound(
@@ -159,7 +179,7 @@ def play_sound(
     volume: float = 1.0,
     pan: float = 0.0,
     looping: bool = False,
-    speed: float = 1.0
+    speed: float = 1.0,
 ) -> media.Player:
     """
     Play a sound.
@@ -192,11 +212,15 @@ def stop_sound(player: media.Player):
     :param pyglet.media.Player player: Player returned from :func:`play_sound`.
     """
     if isinstance(player, Sound):
-        raise ValueError("stop_sound takes the media player object returned from the play() command, "
-                         "not the loaded Sound object.")
+        raise ValueError(
+            "stop_sound takes the media player object returned from the play() command, "
+            "not the loaded Sound object."
+        )
 
     if not isinstance(player, media.Player):
-        raise ValueError("stop_sound takes a media player object returned from the play() command.")
+        raise ValueError(
+            "stop_sound takes a media player object returned from the play() command."
+        )
 
     player.pause()
     player.delete()

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -40,7 +40,7 @@ class Sound:
         volume: float = 1.0,
         pan: float = 0.0,
         loop: bool = False,
-        pitch: float = 1.0
+        speed: float = 1.0
     ) -> media.Player:
         """
         Play the sound.
@@ -58,7 +58,7 @@ class Sound:
         player: media.Player = media.Player()
         player.volume = volume
         player.position = (pan, 0.0, math.sqrt(1 - math.pow(pan, 2)))  # used to mimic panning with 3D audio
-        player.pitch = pitch
+        player.pitch = speed # note that the underlying attribute is pitch but "speed" is used because it better describes the behavior see #1198
         player.loop = loop
         player.queue(self.source)
         player.play()
@@ -159,7 +159,7 @@ def play_sound(
     volume: float = 1.0,
     pan: float = 0.0,
     looping: bool = False,
-    pitch: float = 1.0
+    speed: float = 1.0
 ) -> media.Player:
     """
     Play a sound.
@@ -168,7 +168,7 @@ def play_sound(
     :param float volume: Volume, from 0=quiet to 1=loud
     :param float pan: Pan, from -1=left to 0=centered to 1=right
     :param bool looping: Should we loop the sound over and over?
-    :param float pitch: Change the pitch of the sound which also changes speed, default 1.0
+    :param float speed: Change the speed of the sound which also changes pitch, default 1.0
     """
     if sound is None:
         print("Unable to play sound, no data passed in.")
@@ -180,7 +180,7 @@ def play_sound(
         )
         raise Exception(msg)
     try:
-        return sound.play(volume, pan, looping, pitch)
+        return sound.play(volume, pan, looping, speed)
     except Exception as ex:
         print("Error playing sound.", ex)
 


### PR DESCRIPTION
Mainly renaming the `pitch` parameter to `speed` as per #1198. I also reverted the change to the `asteroid_smasher.py` example and created a standalone `sound_speed_demo.py` example.

I also tweaked the original `sound_demo.py` to make it a bit more concise before I created the speed demo from that template. I thought about renaming `sound_demo.py`, since it is mainly demonstrating panning. Further, I'd probably move the streaming button (in `sound_demo.py`) into it's own example, because it seems to be demonstrating something different, and it also crashes if you press it twice in quick succession.

I didn't yet, though, because that would probably mess with the diff, and that could be done in another PR.
