### PR TITLE
Match pyglet version in release notes to the one in setup.py

### DIFF
--- a/doc/development/release_notes.rst
+++ b/doc/development/release_notes.rst
@@ -35,7 +35,7 @@ Version 2.6.15
 * Pin Pygments version to get around a Pygments/Furo incompatibility.
   (`#1107 <https://github.com/pythonarcade/arcade/issues/1224>`_).
 * Fix Google analytics ID
-* Bump Pyglet version to 2.0.dev16. (Thanks Pyglet!)
+* Bump Pyglet version to 2.0.dev18. (Thanks Pyglet!)
 * Fix API colors for Furo theme
 
 Version 2.6.14


### PR DESCRIPTION
s/dev16/dev18/

Built doc & tested locally in browser.