### PR TITLE
Partial fix for #1111: replace some draw_text calls

### DIFF
--- a/arcade/examples/sprite_collect_coins.py
+++ b/arcade/examples/sprite_collect_coins.py
@@ -1,11 +1,12 @@
 """
 Sprite Collect Coins
 
-Simple program to show basic sprite usage.
+A simple game demonstrating an easy way to create and use sprites.
 
 Artwork from https://kenney.nl
 
-If Python and Arcade are installed, this example can be run from the command line with:
+If Python and Arcade are installed, this example can be run from the
+command line with:
 python -m arcade.examples.sprite_collect_coins
 """
 
@@ -34,11 +35,14 @@ class MyGame(arcade.Window):
         self.player_list = None
         self.coin_list = None
 
-        # Set up the player info
+        # Create a variable to hold the player sprite
         self.player_sprite = None
-        self.score = 0
 
-        # Don't show the mouse cursor
+        # Variables to hold the score and the Text object displaying it
+        self.score = 0
+        self.score_display = None
+
+        # Hide the mouse cursor while it's over the window
         self.set_mouse_visible(False)
 
         arcade.set_background_color(arcade.color.AMAZON)
@@ -46,19 +50,21 @@ class MyGame(arcade.Window):
     def setup(self):
         """ Set up the game and initialize the variables. """
 
-        # Sprite lists
+        # Create the sprite lists
         self.player_list = arcade.SpriteList()
         self.coin_list = arcade.SpriteList()
 
-        # Score
+        # Reset the score and the score display
         self.score = 0
+        self.score_display = arcade.Text(
+            text="Score: 0", start_x=10, start_y=20,
+            color=arcade.color.WHITE, font_size=14)
 
         # Set up the player
         # Character image from kenney.nl
         img = ":resources:images/animated_characters/female_person/femalePerson_idle.png"
         self.player_sprite = arcade.Sprite(img, SPRITE_SCALING_PLAYER)
-        self.player_sprite.center_x = 50
-        self.player_sprite.center_y = 50
+        self.player_sprite.position = 50, 50
         self.player_list.append(self.player_sprite)
 
         # Create the coins
@@ -78,21 +84,22 @@ class MyGame(arcade.Window):
 
     def on_draw(self):
         """ Draw everything """
+
+        # Clear the screen to only show the background color
         self.clear()
+
+        # Draw the sprites
         self.coin_list.draw()
         self.player_list.draw()
 
-        # Put the text on the screen.
-        output = f"Score: {self.score}"
-        arcade.draw_text(text=output, start_x=10, start_y=20,
-                         color=arcade.color.WHITE, font_size=14)
+        # Draw the score Text object on the screen
+        self.score_display.draw()
 
     def on_mouse_motion(self, x, y, dx, dy):
         """ Handle Mouse Motion """
 
-        # Move the center of the player sprite to match the mouse x, y
-        self.player_sprite.center_x = x
-        self.player_sprite.center_y = y
+        # Move the player sprite to place its center on the mouse x, y
+        self.player_sprite.position = x, y
 
     def on_update(self, delta_time):
         """ Movement and game logic """
@@ -101,10 +108,17 @@ class MyGame(arcade.Window):
         coins_hit_list = arcade.check_for_collision_with_list(self.player_sprite,
                                                               self.coin_list)
 
+        # Keep track of the score from before collisions occur
+        old_score = self.score
+
         # Loop through each colliding sprite, remove it, and add to the score.
         for coin in coins_hit_list:
             coin.remove_from_sprite_lists()
             self.score += 1
+
+        # Update the score display if the score changed this tick
+        if old_score != self.score:
+            self.score_display.text = f"Score: {self.score}"
 
 
 def main():

--- a/arcade/examples/sprite_move_joystick.py
+++ b/arcade/examples/sprite_move_joystick.py
@@ -1,11 +1,13 @@
 """
 Move Sprite with Joystick
 
-Simple program to show basic sprite usage.
+An example of one way to use joystick and controller input to move a
+sprite.
 
 Artwork from https://kenney.nl
 
-If Python and Arcade are installed, this example can be run from the command line with:
+If Python and Arcade are installed, this example can be run from the
+command line with:
 python -m arcade.examples.sprite_move_joystick
 """
 import arcade
@@ -121,10 +123,11 @@ class MyGame(arcade.Window):
         self.all_sprites_list = arcade.SpriteList()
 
         # Set up the player
-        self.player_sprite = Player(":resources:images/animated_characters/female_person/"
-                                    "femalePerson_idle.png", SPRITE_SCALING)
-        self.player_sprite.center_x = 50
-        self.player_sprite.center_y = 50
+        self.player_sprite = Player(
+            ":resources:images/animated_characters/female_person/"
+            "femalePerson_idle.png", SPRITE_SCALING,
+        )
+        self.player_sprite.position = self.width / 2, self.height / 2
         self.all_sprites_list.append(self.player_sprite)
 
     def on_draw(self):

--- a/arcade/examples/sprite_move_keyboard_accel.py
+++ b/arcade/examples/sprite_move_keyboard_accel.py
@@ -1,9 +1,13 @@
 """
-Show how to use acceleration and friction
+Acceleration and Friction
+
+Demonstrate how to implement simple acceleration and friction without a
+physics engine.
 
 Artwork from https://kenney.nl
 
-If Python and Arcade are installed, this example can be run from the command line with:
+If Python and Arcade are installed, this example can be run from the
+command line with:
 python -m arcade.examples.sprite_move_keyboard_accel
 """
 
@@ -62,11 +66,16 @@ class MyGame(arcade.Window):
         # Call the parent class initializer
         super().__init__(width, height, title)
 
-        # Variables that will hold sprite lists
+        # Variable to will hold the player sprite list
         self.player_list = None
 
-        # Set up the player info
+        # Create a place to store the player sprite
+        # so it can be  accessed directly.
         self.player_sprite = None
+
+        # Create places to store the speed display Text objects
+        self.x_speed_display = None
+        self.y_speed_display = None
 
         # Track the current state of what key is pressed
         self.left_pressed = False
@@ -80,15 +89,23 @@ class MyGame(arcade.Window):
     def setup(self):
         """ Set up the game and initialize the variables. """
 
-        # Sprite lists
+        # Create a sprite list
         self.player_list = arcade.SpriteList()
 
         # Set up the player
         self.player_sprite = Player(":resources:images/animated_characters/female_person/femalePerson_idle.png",
                                     SPRITE_SCALING)
-        self.player_sprite.center_x = 50
-        self.player_sprite.center_y = 50
+        self.player_sprite.position = self.width / 2, self.height / 2
         self.player_list.append(self.player_sprite)
+
+        # Create the speed display objects with initial text
+        self.x_speed_display = arcade.Text(
+            f"X Speed: {self.player_sprite.change_x:6.3f}",
+            10, 50, arcade.color.BLACK)
+
+        self.y_speed_display = arcade.Text(
+            f"Y Speed: {self.player_sprite.change_y:6.3f}",
+            10, 70, arcade.color.BLACK)
 
     def on_draw(self):
         """
@@ -101,9 +118,9 @@ class MyGame(arcade.Window):
         # Draw all the sprites.
         self.player_list.draw()
 
-        # Display speed
-        arcade.draw_text(f"X Speed: {self.player_sprite.change_x:6.3f}", 10, 50, arcade.color.BLACK)
-        arcade.draw_text(f"Y Speed: {self.player_sprite.change_y:6.3f}", 10, 70, arcade.color.BLACK)
+        # Draw the speed indicators
+        self.x_speed_display.draw()
+        self.y_speed_display.draw()
 
     def on_update(self, delta_time):
         """ Movement and game logic """
@@ -143,9 +160,13 @@ class MyGame(arcade.Window):
             self.player_sprite.change_y = -MAX_SPEED
 
         # Call update to move the sprite
-        # If using a physics engine, call update on it instead of the sprite
-        # list.
+        # IMPORTANT: If using a physics engine, you need to call update
+        # on it instead of the sprite list!
         self.player_list.update()
+
+        # Update the speed displays based on the final speed
+        self.x_speed_display.text = f"X Speed: {self.player_sprite.change_x:6.3f}"
+        self.y_speed_display.text = f"Y Speed: {self.player_sprite.change_y:6.3f}"
 
     def on_key_press(self, key, modifiers):
         """Called whenever a key is pressed. """

--- a/doc/examples/sprite_move_keyboard_accel.rst
+++ b/doc/examples/sprite_move_keyboard_accel.rst
@@ -13,4 +13,4 @@ Acceleration and Friction
 .. literalinclude:: ../../arcade/examples/sprite_move_keyboard_accel.py
     :caption: sprite_move_keyboard_accel.py
     :linenos:
-    :emphasize-lines: 20-27, 39, 42, 46, 49, 111-143
+    :emphasize-lines: 24-31, 43, 46, 50, 53, 128-160


### PR DESCRIPTION
Built locally and viewed in browser. Includes tweaks to highlighted line numbers.

Let me know if the vertical slice of changes here is acceptable. If it is, I'll keep working on #1111.

Changes made:
* Sprite Collect Coins: Replace `arcade.draw_text` and `.center_`* with `arcade.Text` and `.position`
* Acceleration and Friction: Replace `arcade.draw_text` and `.center_`* with `arcade.Text` and `.position`
* Game Controller/Joystick: Replace `.center_`* in initialization with `.position`

