### PR TITLE
Improve keyboard modifier & event doc

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -367,7 +367,7 @@ class Window(pyglet.window.Window):
                            * ``arcade.MOUSE_BUTTON_MIDDLE``
 
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         pass
 
@@ -383,7 +383,7 @@ class Window(pyglet.window.Window):
         :param int dy: Change in y since the last time this method was called
         :param int buttons: Which button is pressed
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         self.on_mouse_motion(x, y, dx, dy)
 
@@ -401,7 +401,7 @@ class Window(pyglet.window.Window):
                            arcade.MOUSE_BUTTON_LEFT, arcade.MOUSE_BUTTON_RIGHT,
                            arcade.MOUSE_BUTTON_MIDDLE
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         pass
 
@@ -470,11 +470,18 @@ class Window(pyglet.window.Window):
 
     def on_key_press(self, symbol: int, modifiers: int):
         """
+        Called once when a key gets pushed down.
+
         Override this function to add key press functionality.
 
-        :param int symbol: Key that was hit
-        :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+        .. tip:: If you want the length of key presses to affect
+                 gameplay, you also need to override
+                 :meth:`~.Window.on_key_release`.
+
+        :param int symbol: Key that was just pushed down
+        :param int modifiers: Bitwise 'and' of all modifiers (shift,
+                              ctrl, num lock) active during this event.
+                              See :ref:`keyboard_modifiers`.
         """
         try:
             self.key = symbol
@@ -483,11 +490,22 @@ class Window(pyglet.window.Window):
 
     def on_key_release(self, symbol: int, modifiers: int):
         """
+        Called once when a key gets released.
+
         Override this function to add key release functionality.
 
-        :param int symbol: Key that was hit
-        :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+        Situations that require handling key releases include:
+
+        * Rythm games where a note must be held for a certain
+          amount of time
+        * 'Charging up' actions that change strength depending on
+          how long a key was pressed
+        * Showing which keys are currently pressed down
+
+        :param int symbol: Key that was just released
+        :param int modifiers: Bitwise 'and' of all modifiers (shift,
+                              ctrl, num lock) active during this event.
+                              See :ref:`keyboard_modifiers`.
         """
         try:
             self.key = None
@@ -855,7 +873,7 @@ def open_window(
     :param Number width: Width of the window.
     :param Number height: Height of the window.
     :param str window_title: Title of the window.
-    :param bool resizable: Whether the window can be user-resizable.
+    :param bool resizable: Whether the user can resize the window.
     :param bool antialiasing: Smooth the graphics?
 
     :returns: Handle to window
@@ -962,7 +980,7 @@ class View:
                            arcade.MOUSE_BUTTON_LEFT, arcade.MOUSE_BUTTON_RIGHT,
                            arcade.MOUSE_BUTTON_MIDDLE
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         pass
 
@@ -976,7 +994,7 @@ class View:
         :param int dy: Change in y since the last time this method was called
         :param int _buttons: Which button is pressed
         :param int _modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         self.on_mouse_motion(x, y, dx, dy)
 
@@ -990,7 +1008,7 @@ class View:
                            arcade.MOUSE_BUTTON_LEFT, arcade.MOUSE_BUTTON_RIGHT,
                            arcade.MOUSE_BUTTON_MIDDLE
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         pass
 
@@ -1011,7 +1029,7 @@ class View:
 
         :param int symbol: Key that was hit
         :param int modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                              pressed during this event. See :ref:`keyboard_modifiers`.
+                              active during this event. See :ref:`keyboard_modifiers`.
         """
         try:
             self.key = symbol
@@ -1024,7 +1042,7 @@ class View:
 
         :param int _symbol: Key that was hit
         :param int _modifiers: Bitwise 'and' of all modifiers (shift, ctrl, num lock)
-                               pressed during this event. See :ref:`keyboard_modifiers`.
+                               active during this event. See :ref:`keyboard_modifiers`.
         """
         try:
             self.key = None

--- a/doc/keyboard.rst
+++ b/doc/keyboard.rst
@@ -1,14 +1,81 @@
 Working with the Keyboard
 =========================
 
+.. _keyboard_events:
+
+Events
+------
+
+What is a keyboard event?
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Keyboard events are arcade's representation of physical keyboard interactions.
+
+For example, if your keyboard is working correctly and you type the letter A
+into the window of a running arcade game, it will see two separate events:
+
+#. a key press event with the key code for ``A``
+#. a key release event with the key code for ``A``
+
+.. _keyboard_event_handlers:
+
+How do I handle keyboard events?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You must implement key event handlers. These functions are called whenever a
+key event is detected:
+
+* :meth:`arcade.Window.on_key_press`
+* :meth:`arcade.Window.on_key_release`
+
+You need to implement your own versions of the above methods on your subclass
+of :class:`arcade.Window`. The :ref:`arcade.key <key>` module contains
+constants for specific keys.
+
+For runnable examples, see the following:
+
+* :ref:`sprite_move_keyboard`
+* :ref:`sprite_move_keyboard_better`
+* :ref:`sprite_move_keyboard_accel`
+
+.. note:: If you are using :class:`Views <arcade.View>`, you can
+          also implement key event handler methods on them.
+
 .. _keyboard_modifiers:
 
 Modifiers
 ---------
 
-The modifiers that are held down when the event is generated are combined in a
-bitwise fashion and provided in the modifiers parameter. The modifier constants
-defined in arcade.key are:
+What is a modifier?
+^^^^^^^^^^^^^^^^^^^
+
+Modifiers are keys that modify the behavior of keyboard input. Examples include
+keys such as shift, control, and command. Lock keys such as capslock are also
+modifiers.
+
+What does active mean?
+^^^^^^^^^^^^^^^^^^^^^^
+
+Modifiers can be active in two ways:
+
+1. A modifier key is currently held down by the user (example: shift)
+2. A lock modifier is currently turned on (example: capslock)
+
+This is important because lock modifiers can be active without their
+corresponding key held down. Instead, they are switched on and off by pressing
+their keys.
+
+How do I use modifiers?
+^^^^^^^^^^^^^^^^^^^^^^^
+
+As long as you don't need to distinguish between the left and right versions of
+modifiers keys, you can rely on the ``modifiers`` argument of :ref:`key event
+handlers <keyboard_event_handlers>`.
+
+For every key event, the current state of all modifiers is passed to the
+handler method through the ``modifiers`` argument as a single integer. For each
+active modifier during an event, a corresponding bit is set to 1.
+
+Constants for each of these bits are defined in :ref:`arcade.key <key>`:
 
 .. code-block:: text
 
@@ -23,13 +90,27 @@ defined in arcade.key are:
     MOD_SCROLLLOCK
     MOD_ACCEL       Equivalent to MOD_CTRL, or MOD_COMMAND on Mac OS X.
 
-For example, to test if the shift key is held down:
+You can use these constants with bitwise operations to check if a specific
+modifier is active during a keyboard event:
 
 .. code-block:: python
 
-    if modifiers & MOD_SHIFT:
-        pass
+    # this should be implemented on a subclass of Window or View
+    def on_key_press(self, symbol, modifiers):
 
-Unlike the corresponding key symbols, it is not possible to determine whether
-the left or right modifier is held down (though you could emulate this behavior
-by keeping track of the key states yourself).
+        if modifiers & arcade.key.MOD_SHIFT:
+            print("The shift key is held down")
+
+        if modifiers & arcade.key.MOD_CAPSLOCK:
+            print("Capslock is on")
+
+How do I tell left & right modifers apart?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Many keyboards have both left and right versions of modifiers such as shift and
+control. However, the ``modifiers`` argument to key handlers does not tell you which
+specific modifier keys are currently pressed!
+
+Instead, you have to use specific key codes for left and right versions from
+:ref:`arcade.key <key>` to :ref:`track press and release events
+<keyboard_event_handlers>`.


### PR DESCRIPTION
This is a follow-up to https://github.com/pyglet/pyglet/issues/629. Prior to this PR, our keyboard  modifier doc was a copy of the pyglet's. I significantly expanded it to hold the reader's hand because middle and highschool students are one of our target demographics.

Built & tested locally.

Summary of changes:
* Rewrite Working with the Keyboard to include concept of active modifiers
* Fix misleading keyboard modifier phrasing in application.py to use active instead of held
* Make keyboard event doc consistent with mouse event doc in Window
* Add links to examples of handling keyboard events to Working with the Keyboard
* Add links to doc for arcade.key module containing constants
* Fix some awkward phrasing in open_window docstring