### PR TITLE
Bump pyglet version to 2.0.dev20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     url="https://api.arcade.academy",
     download_url="https://api.arcade.academy",
     install_requires=[
-        "pyglet==2.0.dev19",
+        "pyglet==2.0.dev20",
         "pillow~=9.1.1",
         "pymunk~=6.2.1",
         "pytiled-parser==2.0.1",


### PR DESCRIPTION
This release fixes issues a user reported on a 32 bit python version. There appears to be no difference in pytest output between dev19 and dev20 versions.