### PR TITLE
Improve performance info example & related doc

### DIFF
--- a/arcade/examples/performance_statistics.py
+++ b/arcade/examples/performance_statistics.py
@@ -1,7 +1,20 @@
 """
 Performance Statistic Displays
 
+This example demonstrates how to use a few performance profiling tools
+built into arcade:
+
+    * arcade.PerfGraph
+    * arcade.get_fps
+
+A large number of sprites are drawn on screen to produce load. You can
+adjust the number of sprites by changing the COIN_COUNT constant below.
+
 Artwork from https://kenney.nl
+
+If Python and Arcade are installed, this example can be run from the
+command line with:
+python -m arcade.examples.background_scrolling
 """
 
 import random
@@ -53,10 +66,10 @@ class MyGame(arcade.Window):
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Variables that will hold sprite lists
-        self.coin_list = None
-        self.perf_graph_list = None
-
-        self.frame_count = 0
+        self.coin_list: arcade.SpriteList = None
+        self.perf_graph_list: arcade.SpriteList = None
+        self.frame_count: int = 0
+        self.fps_text: arcade.Text = None
 
         arcade.set_background_color(arcade.color.AMAZON)
 
@@ -90,6 +103,12 @@ class MyGame(arcade.Window):
         # Create a sprite list to put the performance graph into
         self.perf_graph_list = arcade.SpriteList()
 
+        # Create FPS text object
+        self.fps_text = arcade.Text(
+            f"FPS: {arcade.get_fps(60):5.1f}",
+            10, 10, arcade.color.BLACK, 22
+        )
+
         # Create the FPS performance graph
         graph = arcade.PerfGraph(GRAPH_WIDTH, GRAPH_HEIGHT, graph_data="FPS")
         graph.center_x = GRAPH_WIDTH / 2
@@ -120,9 +139,9 @@ class MyGame(arcade.Window):
         # Draw the graphs
         self.perf_graph_list.draw()
 
-        # Get FPS for the last 60 frames
-        text = f"FPS: {arcade.get_fps(60):5.1f}"
-        arcade.draw_text(text, 10, 10, arcade.color.BLACK, 22)
+        # Get & draw the FPS for the last 60 frames
+        self.fps_text.value = f"FPS: {arcade.get_fps(60):5.1f}"
+        self.fps_text.draw()
 
     def update(self, delta_time):
         """ Update method """

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -10,12 +10,18 @@ class PerfGraph(arcade.Sprite):
     """
     An auto-updating line chart of FPS or event handler execution times.
 
-    It is a subclass of :class:`arcade.Sprite` and can be used with any
-    :class:`SpriteList <arcade.SpriteList>` like a regular sprite.
+    You must use :func:`arcade.enable_timings` to turn on performance
+    tracking for the chart to display data.
 
-    Unlike other :class:`Sprite <arcade.Sprite>` instances, it neither
-    loads an :class:`arcade.Texture` nor accepts one as a constructor
-    argument. Instead, it creates a new internal
+    Aside from instantiation and updating the chart, this class behaves
+    like other :class:`arcade.Sprite` instances. You can use it with
+    :class:`SpriteList <arcade.SpriteList>` normally. See
+    :ref:`performance_statistics_example` for an example of how to use
+    this class.
+
+    Unlike other :class:`Sprite <arcade.Sprite>` instances, this class
+    neither loads an :class:`arcade.Texture` nor accepts one as a
+    constructor argument. Instead, it creates a new internal
     :class:`Texture <arcade.Texture>` instance. The chart is
     automatically redrawn to this internal
     :class:`Texture <arcade.Texture>` every ``update_rate`` seconds.
@@ -74,9 +80,8 @@ class PerfGraph(arcade.Sprite):
         """
         Update the graph by redrawing the internal texture data.
 
-        .. warning:: You do not need to call this method!
-
-                     This function will be called automatically!
+        .. warning:: You do not need to call this method! It will be
+                     called automatically!
 
         :param delta_time: Elapsed time. Passed by the pyglet scheduler
         """

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -1,24 +1,45 @@
 from typing import List
 
 import arcade
+from arcade import Color
 import random
 import pyglet.clock
 
 
 class PerfGraph(arcade.Sprite):
     """
-    Create a graph showing performance statistics.
+    An auto-updating line chart of FPS or event handler execution times.
+
+    It is a subclass of :class:`arcade.Sprite` and can be used with any
+    :class:`SpriteList <arcade.SpriteList>` like a regular sprite.
+
+    Unlike other :class:`Sprite <arcade.Sprite>` instances, it neither
+    loads an :class:`arcade.Texture` nor accepts one as a constructor
+    argument. Instead, it creates a new internal
+    :class:`Texture <arcade.Texture>` instance. The chart is
+    automatically redrawn to this internal
+    :class:`Texture <arcade.Texture>` every ``update_rate`` seconds.
+
+    :param width: The width of the chart texture in pixels
+    :param height: The height of the chart texture in pixels
+    :param graph_data: The pyglet event handler or statistic to track
+    :param update_rate: How often the graph updates, in seconds
+    :param background_color: The background color of the chart
+    :param data_line_color: Color of the line tracking drawn
+    :param axis_color: The color to draw the x & y axes in
+    :param font_color: The color of the label font
+    :param font_size: The size of the label font in points
     """
     def __init__(self,
-                 width, height,
+                 width: int, height: int,
                  graph_data: str = "FPS",
                  update_rate: float = 0.1,
-                 background_color=arcade.color.BLACK,
-                 data_line_color=arcade.color.WHITE,
-                 axis_color=arcade.color.DARK_YELLOW,
-                 grid_color=arcade.color.DARK_YELLOW,
-                 font_color=arcade.color.WHITE,
-                 font_size=10):
+                 background_color: Color = arcade.color.BLACK,
+                 data_line_color: Color = arcade.color.WHITE,
+                 axis_color: Color = arcade.color.DARK_YELLOW,
+                 grid_color: Color = arcade.color.DARK_YELLOW,
+                 font_color: Color = arcade.color.WHITE,
+                 font_size: int = 10):
 
         unique_id = str(random.random())
 
@@ -42,7 +63,13 @@ class PerfGraph(arcade.Sprite):
 
     def update_graph(self, delta_time: float):
         """
-        Update the graph.
+        Update the graph by redrawing the internal texture data.
+
+        .. warning:: You do not need to call this method!
+
+                     This function will be called automatically!
+
+        :param delta_time: Elapsed time. Passed by the pyglet scheduler
         """
         bottom_y = 15
         left_x = 25

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -58,7 +58,16 @@ class PerfGraph(arcade.Sprite):
         pyglet.clock.schedule_interval(self.update_graph, update_rate)
 
     def remove_from_sprite_lists(self):
+        """
+        Remove the sprite from all lists and cancel the update event.
+
+        :return:
+        """
         super().remove_from_sprite_lists()
+
+        # It is very important to call this to prevent potential
+        # issues such as crashes or excess memory use from failed
+        # garbage collection.
         pyglet.clock.unschedule(self.update)
 
     def update_graph(self, delta_time: float):

--- a/arcade/perf_info.py
+++ b/arcade/perf_info.py
@@ -50,8 +50,12 @@ def _dispatch_event(self, *args):
 
 def print_timings():
     """
-    This prints to stdout a table of the most recent dispatched events and
-    their average time.
+    Print event handler statistics to stdout as a table.
+
+    The statistics consist of:
+
+    * how many times each registered event was called
+    * the average time for handling each type of event in seconds
 
     The table looks something like:
 
@@ -78,9 +82,13 @@ def print_timings():
         print(f"{index:15}{call_count:5}  {average_time:11.4f}")
 
 
-def clear_timings():
+def clear_timings() -> None:
     """
-    Clear the dispatch event timing table created after :func:`arcade.enable_timings` is called.
+    Reset all event handler statistics.
+
+    Resets the count and average time for each dispatch event type to
+    zero. :func:`arcade.enable_timings` must be called first to enable
+    tracking.
     """
     global _timings
     _timings = {}
@@ -88,14 +96,21 @@ def clear_timings():
 
 def get_timings() -> Dict:
     """
-    Get a table with the dispatch event timings.
+    Get a dict of the current dispatch event timings.
+
+    :return: A dict of event timing data
     """
     return _timings
 
 
-def enable_timings(max_history: int = 100):
+def enable_timings(max_history: int = 100) -> None:
     """
-    Enable the saving of performance information.
+    Enable recording of performance information.
+
+    This function must be called before any other performance
+    features are used.
+
+    :param max_history: How many frames to keep performance info for.
     """
     global _pyglets_dispatch_event, _max_history
 
@@ -107,9 +122,12 @@ def enable_timings(max_history: int = 100):
     _max_history = max_history
 
 
-def disable_timings():
+def disable_timings() -> None:
     """
-    Turn off the collection of timing information started by :func:`arcade.enable_timings`.
+    Disable collection of timing information.
+
+    :func:`arcade.enable_timings` must be called first to enable
+    collection.
     """
     global _pyglets_dispatch_event
 
@@ -125,11 +143,15 @@ def disable_timings():
 
 def get_fps(frame_count: int = 60) -> float:
     """
-    Get the current FPS.
-    :func:`arcade.enable_timings` must be called before getting the FPS.
+    Get the FPS over the last ``frame_count`` frames.
 
-    :param int frame_count: How many frames to look at to get FPS. So 30, would give you
-                            average FPS over the last 30 frames.
+    To get the FPS over the last 30 frames, you would pass 30 instead
+    of the default 60.
+
+    :func:`arcade.enable_timings` must be called before getting the
+    FPS.
+
+    :param int frame_count: How many frames to calculate the FPS over.
     """
     cur_time = time.perf_counter()
     if len(_frame_times) == 0:
@@ -143,8 +165,12 @@ def get_fps(frame_count: int = 60) -> float:
     return fps
 
 
-def timings_enabled():
+def timings_enabled() -> bool:
     """
-    Return true if timings are enabled, false otherwise. See :func:`arcade.enable_timings`.
+    Return true if timings are enabled, false otherwise.
+
+    See :func:`arcade.enable_timings` for more information.
+
+    :return: Whether timings are currently enabled.
     """
     return _pyglets_dispatch_event is not None

--- a/arcade/perf_info.py
+++ b/arcade/perf_info.py
@@ -16,7 +16,7 @@ _max_history: int = 100
 
 def _dispatch_event(self, *args):
     """
-    Dispatch event function that will be monkey-patched over Pyglet's dispatch event function.
+    This function will be monkey-patched over Pyglet's dispatch event function.
     """
     # Name of the dispatched event, like 'on_draw'
     name = args[0]
@@ -52,13 +52,16 @@ def print_timings():
     """
     Print event handler statistics to stdout as a table.
 
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
+
+    See :ref:`performance_statistics_example` for an example of how to
+    use function.
+
     The statistics consist of:
 
     * how many times each registered event was called
     * the average time for handling each type of event in seconds
-
-    Performance tracking must be enabled with
-    :func:`arcade.enable_timings` before calling this function.
 
     The table looks something like:
 
@@ -87,14 +90,13 @@ def print_timings():
 
 def clear_timings() -> None:
     """
-    Reset all event handler statistics.
-
-    Resets the count and average time for each dispatch event type to
-    zero. :func:`arcade.enable_timings` must be called first to enable
-    tracking.
+    Reset the count & average time for each event type to zero.
 
     Performance tracking must be enabled with
     :func:`arcade.enable_timings` before calling this function.
+
+    See :ref:`performance_statistics_example` for an example of how to
+    use function.
     """
     global _timings
     _timings = {}
@@ -117,8 +119,12 @@ def enable_timings(max_history: int = 100) -> None:
     """
     Enable recording of performance information.
 
-    This function must be called before usinng any other performance
-    features, except for :func:`arcade.timings_enabled`.
+    This function must be called before using any other performance
+    features, except for :func:`arcade.timings_enabled`, which can
+    be called at any time.
+
+    See :ref:`performance_statistics_example` for an example of how to
+    use function.
 
     :param max_history: How many frames to keep performance info for.
     """
@@ -155,11 +161,14 @@ def get_fps(frame_count: int = 60) -> float:
     """
     Get the FPS over the last ``frame_count`` frames.
 
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
+
     To get the FPS over the last 30 frames, you would pass 30 instead
     of the default 60.
 
-    Performance tracking must be enabled with
-    :func:`arcade.enable_timings` before calling this function.
+    See :ref:`performance_statistics_example` for an example of how to
+    use function.
 
     :param int frame_count: How many frames to calculate the FPS over.
     """

--- a/arcade/perf_info.py
+++ b/arcade/perf_info.py
@@ -57,6 +57,9 @@ def print_timings():
     * how many times each registered event was called
     * the average time for handling each type of event in seconds
 
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
+
     The table looks something like:
 
     .. code-block:: text
@@ -89,6 +92,9 @@ def clear_timings() -> None:
     Resets the count and average time for each dispatch event type to
     zero. :func:`arcade.enable_timings` must be called first to enable
     tracking.
+
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
     """
     global _timings
     _timings = {}
@@ -98,7 +104,11 @@ def get_timings() -> Dict:
     """
     Get a dict of the current dispatch event timings.
 
-    :return: A dict of event timing data
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
+
+    :return: A dict of event timing data, consisting of counts and
+             average handler duration.
     """
     return _timings
 
@@ -107,8 +117,8 @@ def enable_timings(max_history: int = 100) -> None:
     """
     Enable recording of performance information.
 
-    This function must be called before any other performance
-    features are used.
+    This function must be called before usinng any other performance
+    features, except for :func:`arcade.timings_enabled`.
 
     :param max_history: How many frames to keep performance info for.
     """
@@ -126,8 +136,8 @@ def disable_timings() -> None:
     """
     Disable collection of timing information.
 
-    :func:`arcade.enable_timings` must be called first to enable
-    collection.
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
     """
     global _pyglets_dispatch_event
 
@@ -148,8 +158,8 @@ def get_fps(frame_count: int = 60) -> float:
     To get the FPS over the last 30 frames, you would pass 30 instead
     of the default 60.
 
-    :func:`arcade.enable_timings` must be called before getting the
-    FPS.
+    Performance tracking must be enabled with
+    :func:`arcade.enable_timings` before calling this function.
 
     :param int frame_count: How many frames to calculate the FPS over.
     """
@@ -169,7 +179,8 @@ def timings_enabled() -> bool:
     """
     Return true if timings are enabled, false otherwise.
 
-    See :func:`arcade.enable_timings` for more information.
+    This function can be used at any time to check if timings are
+    enabled. See :func:`arcade.enable_timings` for more information.
 
     :return: Whether timings are currently enabled.
     """

--- a/doc/example_code/how_to_examples/performance_statistics.rst
+++ b/doc/example_code/how_to_examples/performance_statistics.rst
@@ -7,11 +7,18 @@ Performance Statistics
 
 .. image:: performance_statistics.png
 
-You can easily include graphs that show FPS, or how long it takes dispatched events to process.
-See :ref:`perf_info_api`.
+Arcade includes performance monitoring tools to help you optimize your
+game. This example demonstrates the following performance api features:
 
-You can also print out the count and average time for all dispatched events with the :func:`arcade.print_timings`
-function. The output of that function looks like:
+* :meth:`arcade.enable_timings`
+* :class:`arcade.PerfGraph`
+* :meth:`arcade.get_fps`
+* :meth:`arcade.print_timings`
+* :meth:`arcade.clear_timings`
+
+If you do not want to display graphs in your game window, you can use
+:func:`arcade.print_timings` to print out the count and average time for
+all dispatched events with the function. The output looks like this:
 
 .. code-block:: text
 
@@ -27,8 +34,9 @@ function. The output of that function looks like:
     on_mouse_enter     1       0.0000
     on_mouse_motion  100       0.0000
 
+See :ref:`perf_info_api` for more information about the performance api.
+
 .. literalinclude:: ../../../arcade/examples/performance_statistics.py
     :caption: performance_statistics.py
     :linenos:
-    :emphasize-lines: 26, 90-109, 120-125, 131-134
-
+    :emphasize-lines: 43-45, 114-141, 152-157, 164-166


### PR DESCRIPTION
This PR improves style, typing, and doc for ``PerfGraph`` and related functions.  Line number highlights have been changed to accommodate example code changes. 

Built & tested locally. Looks good here.

Partially addresses the following tickets:
* #1111 , by replacing ``draw_text`` calls in the performance example.
* #1211 , by adding run instructions in example doc string

