### PR TITLE
Expand SpriteList.extend typing to include Iterables of Sprites

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Deque,
     Dict,
+    Iterable,
     Iterator,
     List,
     Optional,
@@ -672,11 +673,11 @@ class SpriteList:
         if self.spatial_hash:
             self.spatial_hash.remove_object(sprite)
 
-    def extend(self, sprites: Union[list, "SpriteList"]):
+    def extend(self, sprites: Union[Iterable[_SpriteType], "SpriteList"]):
         """
-        Extends the current list with the given list
+        Extends the current list with the given iterable
 
-        :param list sprites: list of Sprites to add to the list
+        :param list sprites: Iterable of Sprites to add to the list
         """
         for sprite in sprites:
             self.append(sprite)

--- a/tests/unit2/test_sprite_list.py
+++ b/tests/unit2/test_sprite_list.py
@@ -18,7 +18,7 @@ def make_named_sprites(amount):
     return spritelist
 
 
-def test_it_can_extend_a_spritelist():
+def test_it_can_extend_a_spritelist_from_a_list():
     spritelist = arcade.SpriteList()
     sprites = []
     for i in range(10):
@@ -27,6 +27,15 @@ def test_it_can_extend_a_spritelist():
     spritelist.extend(sprites)
 
     assert len(spritelist) == 10
+
+
+def test_it_can_extend_a_spritelist_from_a_generator():
+    sprite_list = arcade.SpriteList()
+    sprite_list.extend(
+        (arcade.Sprite(center_x=coord, center_y=coord) for coord in range(5))
+    )
+    for coord, sprite in enumerate(sprite_list):
+        assert sprite.position == (coord, coord)
 
 
 def test_it_can_insert_in_a_spritelist():

--- a/tests/unit2/test_sprite_list.py
+++ b/tests/unit2/test_sprite_list.py
@@ -29,13 +29,32 @@ def test_it_can_extend_a_spritelist_from_a_list():
     assert len(spritelist) == 10
 
 
-def test_it_can_extend_a_spritelist_from_a_generator():
+def test_it_can_extend_a_spritelist_from_a_generator_expression():
     sprite_list = arcade.SpriteList()
     sprite_list.extend(
         (arcade.Sprite(center_x=coord, center_y=coord) for coord in range(5))
     )
     for coord, sprite in enumerate(sprite_list):
         assert sprite.position == (coord, coord)
+
+
+def test_it_can_extend_a_spritelist_from_a_generator_function():
+    sprite_list = arcade.SpriteList()
+
+    def sprite_grid_generator(cols: int, rows: int, cell_size: float):
+        for row in range(rows):
+            for col in range(cols):
+                yield arcade.Sprite(
+                    center_x=col * cell_size,
+                    center_y=row * cell_size
+                )
+
+    sprite_list.extend(sprite_grid_generator(3, 5, 1.0))
+    index = 0
+    for y in range(5):
+        for x in range(3):
+            assert sprite_list[index].position == (x, y)
+            index += 1
 
 
 def test_it_can_insert_in_a_spritelist():


### PR DESCRIPTION
It seems reasonable to support this, and it's easier than bringing SpriteList into full compliance with the MutableSequence ABC. It also seems more elegant to use generators of various sorts to create sprites instead of creating a second list, then copying from it to the SpriteList's internal one.