### PR TITLE
Link function referred to by Window.on_resize doc

### DIFF
--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -164,9 +164,12 @@ def set_viewport(left: float, right: float, bottom: float, top: float) -> None:
         line up with the pixels on the screen. Otherwise, tiled pixel art
         may not line up well during render, creating rectangle artifacts.
 
-    .. note:: ``Window.on_resize`` calls ``set_viewport`` by default.
-              If you want to set your own custom viewport during the
-              game, you may need to over-ride the ``on_resize`` method.
+    .. note:: :py:meth:`Window.on_resize <arcade.Window.on_resize>`
+              calls ``set_viewport`` by default. If you want to set your
+              own custom viewport during the game, you may need to
+              override the
+              :py:meth:`Window.on_resize <arcade.Window.on_resize>`
+              method.
 
     .. note:: For more advanced users
 


### PR DESCRIPTION
* Link the Window.on_resize function mentioned by the Window.set_viewport docstring
* Replace "over-ride" with override, which is the more common colloquial form

Built & tested locally.