### PR TITLE
Issue #1287: Correct the command to launch the instructions and game over example.

### DIFF
--- a/arcade/examples/view_instructions_and_game_over.py
+++ b/arcade/examples/view_instructions_and_game_over.py
@@ -15,7 +15,7 @@ around (see: time_taken), or you can store data on the Window object to share da
 all Views (see: total_score).
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.view_instructions_and_game_over.py
+python -m arcade.examples.view_instructions_and_game_over
 """
 
 import arcade


### PR DESCRIPTION
The command shouldn't specify the `*.py` file extension.

Issue #1287 