### PR TITLE
Fix type hint in `arcade.Window.__init__()`

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -85,7 +85,7 @@ class Window(pyglet.window.Window):
         update_rate: Optional[float] = 1 / 60,
         antialiasing: bool = True,
         gl_version: Tuple[int, int] = (3, 3),
-        screen: pyglet.canvas.Screen = None,
+        screen: Optional[pyglet.canvas.Screen] = None,
         style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
         vsync: bool = False,


### PR DESCRIPTION
Added `Optional[]` to the `screen` parameter in `arcade.Window.__init__()` because the default value is `None`. Fixes #1291.