### PR TITLE
Use stronger typing for buffer protocol objects in gl module

### DIFF
--- a/arcade/arcade_types.py
+++ b/arcade/arcade_types.py
@@ -1,10 +1,13 @@
 """
 Module specifying data custom types used for type hinting.
 """
+from array import array
 from collections import namedtuple
+from collections.abc import ByteString
 from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from pytiled_parser import Properties
+
 
 RGB = Union[Tuple[int, int, int], List[int]]
 RGBA = Union[Tuple[int, int, int, int], List[int]]
@@ -26,3 +29,13 @@ class TiledObject(NamedTuple):
     properties: Optional[Properties] = None
     name: Optional[str] = None
     type: Optional[str] = None
+
+
+# This is a temporary workaround for the lack of a way to type annotate
+# objects implementing the buffer protocol. Although there is a PEP to
+# add typing, it is scheduled for 3.12. Since that is years away from
+# being our minimum Python version, we have to use a workaround. See
+# the PEP and Python doc for more information:
+# https://peps.python.org/pep-0688/
+# https://docs.python.org/3/c-api/buffer.html
+BufferProtocol = Union[ByteString, memoryview, array]

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -1,6 +1,6 @@
 from ctypes import byref, string_at
 import weakref
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from pyglet import gl
 

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -17,11 +17,20 @@ class Buffer:
     They are used for storage of vertex data,
     element data (vertex indexing), uniform block data etc.
 
-    Buffer objects should be created using :py:meth:`arcade.gl.Context.buffer`
+    The ``data`` parameter can be anything that implements the
+    `Buffer Protocol <https://docs.python.org/3/c-api/buffer.html>`_.
+
+    This includes ``bytes``, ``bytearray``, ``array.array``, and
+    more. You may need to use typing workarounds for non-builtin
+    types. See :ref:`prog-guide-gl-buffer-protocol-typing` for more
+    information.
+
+    .. warning:: Buffer objects should be created using :py:meth:`arcade.gl.Context.buffer`
 
     :param Context ctx: The context this buffer belongs to
-    :param Any data: The data this buffer should contain.
-                     It can be bytes or any object supporting the buffer protocol.
+    :param BufferProtocol data: The data this buffer should contain.
+                                It can be a ``bytes`` instance or any
+                                object supporting the buffer protocol.
     :param int reserve: Create a buffer of a specific byte size
     :param str usage: A hit of this buffer is ``static`` or ``dynamic`` (can mostly be ignored)
     """
@@ -34,7 +43,7 @@ class Buffer:
     }
 
     def __init__(
-        self, ctx: "Context", data: Optional[Any] = None, reserve: int = 0, usage: str = "static"
+        self, ctx: "Context", data: Optional[BufferProtocol] = None, reserve: int = 0, usage: str = "static"
     ):
 
         self._ctx = ctx

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from pyglet import gl
 
 from .utils import data_to_ctypes
+from arcade.arcade_types import BufferProtocol
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context
@@ -158,8 +159,16 @@ class Buffer:
         gl.glUnmapBuffer(gl.GL_ARRAY_BUFFER)
         return data
 
-    def write(self, data: Any, offset: int = 0):
-        """Write byte data to the buffer.
+    def write(self, data: BufferProtocol, offset: int = 0):
+        """Write byte data to the buffer from a buffer protocol object.
+
+        The ``data`` value can be anything that implements the
+        `Buffer Protocol <https://docs.python.org/3/c-api/buffer.html>`_.
+
+        This includes ``bytes``, ``bytearray``, ``array.array``, and
+        more. You may need to use typing workarounds for non-builtin
+        types. See :ref:`prog-guide-gl-buffer-protocol-typing` for more
+        information.
 
         :param bytes data: The byte data to write. This can be bytes or any object supporting the buffer protocol.
         :param int offset: The byte offset

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -770,8 +770,8 @@ class Context:
                 The data contents will be modified repeatedly and used many times.
 
         :param BufferProtocol data: The buffer data. This can be a ``bytes`` instance or any
-                                     any other object supporting the buffer protocol.
-        :param int reserve: The number of bytes reserve
+                                    any other object supporting the buffer protocol.
+        :param int reserve: The number of bytes to reserve
         :param str usage: Buffer usage. 'static', 'dynamic' or 'stream'
         :rtype: :py:class:`~arcade.gl.Buffer`
         """
@@ -799,7 +799,7 @@ class Context:
         *,
         components: int = 4,
         dtype: str = "f1",
-        data: Any = None,
+        data: Optional[BufferProtocol] = None,
         wrap_x: gl.GLenum = None,
         wrap_y: gl.GLenum = None,
         filter: Tuple[gl.GLenum, gl.GLenum] = None,
@@ -818,7 +818,8 @@ class Context:
         :param Tuple[int, int] size: The size of the texture
         :param int components: Number of components (1: R, 2: RG, 3: RGB, 4: RGBA)
         :param str dtype: The data type of each component: f1, f2, f4 / i1, i2, i4 / u1, u2, u4
-        :param Any data: The texture data (optional). Can be bytes or an object supporting the buffer protocol.
+        :param BufferProtocol data: The texture data (optional). Can be ``bytes``
+                                    or any object supporting the buffer protocol.
         :param GLenum wrap_x: How the texture wraps in x direction
         :param GLenum wrap_y: How the texture wraps in y direction
         :param Tuple[GLenum,GLenum] filter: Minification and magnification filter
@@ -839,13 +840,15 @@ class Context:
             immutable=immutable,
         )
 
-    def depth_texture(self, size: Tuple[int, int], *, data=None) -> Texture:
+    def depth_texture(self, size: Tuple[int, int], *, data: Optional[BufferProtocol] = None) -> Texture:
         """
         Create a 2D depth texture. Can be used as a depth attachment
         in a :py:class:`~arcade.gl.Framebuffer`.
 
         :param Tuple[int, int] size: The size of the texture
-        :param Any data: The texture data (optional). Can be bytes or an object supporting the buffer protocol.
+        :param BufferProtocol data: The texture data (optional). Can be
+                                    ``bytes`` or any object supporting
+                                    the buffer protocol.
         """
         return Texture(self, size, data=data, depth=True)
 

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -19,6 +19,7 @@ from .query import Query
 from .texture import Texture
 from .types import BufferDescription
 from .vertex_array import Geometry
+from ..arcade_types import BufferProtocol
 
 LOG = logging.getLogger(__name__)
 
@@ -730,7 +731,7 @@ class Context:
     # --- Resource methods ---
 
     def buffer(
-        self, *, data: Optional[Any] = None, reserve: int = 0, usage: str = "static"
+        self, *, data: Optional[BufferProtocol] = None, reserve: int = 0, usage: str = "static"
     ) -> Buffer:
         """
         Create an OpenGL Buffer object. The buffer will contain all zero-bytes if no data is supplied.
@@ -745,12 +746,21 @@ class Context:
             # Create a buffer with 1000 random 32 bit floats using numpy
             self.ctx.buffer(data=np.random.random(1000).astype("f4"))
 
+
+        The ``data`` parameter can be anything that implements the
+        `Buffer Protocol <https://docs.python.org/3/c-api/buffer.html>`_.
+
+        This includes ``bytes``, ``bytearray``, ``array.array``, and
+        more. You may need to use typing workarounds for non-builtin
+        types. See :ref:`prog-guide-gl-buffer-protocol-typing` for more
+        information.
+
         The ``usage`` parameter enables the GL implementation to make more intelligent
         decisions that may impact buffer object performance. It does not add any restrictions.
         If in doubt, skip this parameter and revisit when optimizing. The result
         are likely to be different between vendors/drivers or may not have any effect.
 
-        The available values means the following::
+        The available values mean the following::
 
             stream
                 The data contents will be modified once and used at most a few times.
@@ -759,7 +769,8 @@ class Context:
             dynamic
                 The data contents will be modified repeatedly and used many times.
 
-        :param Any data: The buffer data, This can be ``bytes`` or an object supporting the buffer protocol.
+        :param BufferProtocol data: The buffer data. This can be a ``bytes`` instance or any
+                                     any other object supporting the buffer protocol.
         :param int reserve: The number of bytes reserve
         :param str usage: Buffer usage. 'static', 'dynamic' or 'stream'
         :rtype: :py:class:`~arcade.gl.Buffer`

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -7,7 +7,8 @@ from pyglet import gl
 
 from .buffer import Buffer
 from .utils import data_to_ctypes
-from .types import pixel_formats
+from .types import pixel_formats, BufferOrBufferProtocol
+
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context
@@ -637,12 +638,24 @@ class Texture:
         else:
             raise ValueError("Unknown gl_api: '{self._ctx.gl_api}'")
 
-    def write(self, data: Union[bytes, Buffer, array], level: int = 0, viewport=None) -> None:
-        """Write byte data to the texture. This can be bytes or a :py:class:`~arcade.gl.Buffer`.
+    def write(self, data: BufferOrBufferProtocol, level: int = 0, viewport=None) -> None:
+        """Write byte data from the passed source to the texture.
 
-        :param Union[bytes,Buffer] data: bytes or a Buffer with data to write
+        The ``data`` value can be either an
+        :py:class:`arcade.gl.Buffer` or anything that implements the
+        `Buffer Protocol <https://docs.python.org/3/c-api/buffer.html>`_.
+
+        The latter category includes ``bytes``, ``bytearray``,
+        ``array.array``, and more. You may need to use typing
+        workarounds for non-builtin types. See
+        :ref:`prog-guide-gl-buffer-protocol-typing` for more
+        information.
+
+        :param BufferOrBufferProtocol data: :ref:`~arcade.gl.Buffer` or
+                                            buffer protocol object with
+                                            data to write.
         :param int level: The texture level to write
-        :param tuple viewport: The are of the texture to write. 2 or 4 component tuple
+        :param Union[Tuple[int, int], Tuple[int, int, int, int]] viewport: The area of the texture to write. 2 or 4 component tuple
         """
         # TODO: Support writing to layers using viewport + alignment
         if self._samples > 0:

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -43,7 +43,6 @@ class Texture:
     :param int components: The number of components (1: R, 2: RG, 3: RGB, 4: RGBA)
     :param str dtype: The data type of each component: f1, f2, f4 / i1, i2, i4 / u1, u2, u4
     :param data: The texture data (optional). Can be bytes or any object supporting the buffer protocol.
-    :param Any data: The byte data of the texture. bytes or anything supporting the buffer protocol.
     :param Tuple[gl.GLuint,gl.GLuint] filter: The minification/magnification filter of the texture
     :param gl.GLuint wrap_x: Wrap mode x
     :param gl.GLuint wrap_y: Wrap mode y

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -649,7 +649,7 @@ class Texture:
         :ref:`prog-guide-gl-buffer-protocol-typing` for more
         information.
 
-        :param BufferOrBufferProtocol data: :ref:`~arcade.gl.Buffer` or
+        :param BufferOrBufferProtocol data: :class:`~arcade.gl.Buffer` or
                                             buffer protocol object with
                                             data to write.
         :param int level: The texture level to write

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -8,7 +8,7 @@ from pyglet import gl
 from .buffer import Buffer
 from .utils import data_to_ctypes
 from .types import pixel_formats, BufferOrBufferProtocol
-
+from ..arcade_types import BufferProtocol
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context
@@ -42,7 +42,7 @@ class Texture:
     :param Tuple[int, int] size: The size of the texture
     :param int components: The number of components (1: R, 2: RG, 3: RGB, 4: RGBA)
     :param str dtype: The data type of each component: f1, f2, f4 / i1, i2, i4 / u1, u2, u4
-    :param data: The texture data (optional). Can be bytes or any object supporting the buffer protocol.
+    :param BufferProtocol data: The texture data (optional). Can be bytes or any object supporting the buffer protocol.
     :param Tuple[gl.GLuint,gl.GLuint] filter: The minification/magnification filter of the texture
     :param gl.GLuint wrap_x: Wrap mode x
     :param gl.GLuint wrap_y: Wrap mode y
@@ -114,7 +114,7 @@ class Texture:
         *,
         components: int = 4,
         dtype: str = "f1",
-        data: Any = None,
+        data: Optional[BufferProtocol] = None,
         filter: Tuple[gl.GLuint, gl.GLuint] = None,
         wrap_x: gl.GLuint = None,
         wrap_y: gl.GLuint = None,

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -1,7 +1,6 @@
-from array import array
 from ctypes import byref
 import weakref
-from typing import Any, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 from pyglet import gl
 
@@ -654,7 +653,8 @@ class Texture:
                                             buffer protocol object with
                                             data to write.
         :param int level: The texture level to write
-        :param Union[Tuple[int, int], Tuple[int, int, int, int]] viewport: The area of the texture to write. 2 or 4 component tuple
+        :param Union[Tuple[int, int], Tuple[int, int, int, int]] viewport:
+          The area of the texture to write. 2 or 4 component tuple
         """
         # TODO: Support writing to layers using viewport + alignment
         if self._samples > 0:

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -1,9 +1,13 @@
 import re
-from typing import Iterable, List
+from typing import Iterable, List, Union
 
 from pyglet import gl
 
 from .buffer import Buffer
+from arcade.arcade_types import BufferProtocol
+
+
+BufferOrBufferProtocol = Union[BufferProtocol, Buffer]
 
 
 _float_base_format = (0, gl.GL_RED, gl.GL_RG, gl.GL_RGB, gl.GL_RGBA)

--- a/doc/programming_guide/opengl_notes.rst
+++ b/doc/programming_guide/opengl_notes.rst
@@ -98,16 +98,16 @@ first ``draw()`` call or ``initialize()`` is called.
 Writing Raw Bytes to GL Buffers & Textures
 -----------------------------------------------------------
 
-Some OpenGL classes support writing to them from anything that
-implements the
+Many of arcade's OpenGL classes support creation from or writing to
+any object that supports the
 `buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_.
-The OpenGL classes that support this include:
+The classes most useful to end users are:
 
 * :py:meth:`arcade.gl.Buffer <arcade.gl.Buffer.write>`
 * :py:meth:`arcade.gl.Texture <arcade.gl.Texture.write>`
 
-This feature can be used for displaying the results of calculations
-such as:
+This functionality can be used for displaying the results of
+calculations such as:
 
 * Scientific visualizations displaying data from numpy arrays
 * Simple console emulators drawing their internal screen buffer

--- a/doc/programming_guide/opengl_notes.rst
+++ b/doc/programming_guide/opengl_notes.rst
@@ -95,13 +95,13 @@ first ``draw()`` call or ``initialize()`` is called.
 
 .. _prog-guide-gl-buffer-protocol-typing:
 
-Buffer Protocol Typing for Writing to GL Buffers & Textures
+Writing Raw Bytes to GL Buffers & Textures
 -----------------------------------------------------------
 
 Some OpenGL classes support writing to them from anything that
 implements the
-`buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_. These
-include:
+`buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_.
+The OpenGL classes that support this include:
 
 * :py:meth:`arcade.gl.Buffer <arcade.gl.Buffer.write>`
 * :py:meth:`arcade.gl.Texture <arcade.gl.Texture.write>`
@@ -110,7 +110,7 @@ This feature can be used for displaying the results of calculations
 such as:
 
 * Scientific visualizations displaying data from numpy arrays
-* Emulators drawing screen data
+* Simple console emulators drawing their internal screen buffer
 
 There should be no typing issues when using Python's built-in buffer
 protocol objects as arguments to the ``write`` method of arcade's GL

--- a/doc/programming_guide/opengl_notes.rst
+++ b/doc/programming_guide/opengl_notes.rst
@@ -93,3 +93,40 @@ created with the ``lazy=True`` parameters.
 This ensures OpenGL resources are not created until the
 first ``draw()`` call or ``initialize()`` is called.
 
+.. _prog-guide-gl-buffer-protocol-typing:
+
+Buffer Protocol Typing for Writing to GL Buffers & Textures
+-----------------------------------------------------------
+
+Some OpenGL classes support writing to them from anything that
+implements the
+`buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_. These
+include:
+
+* :py:meth:`arcade.gl.Buffer <arcade.gl.Buffer.write>`
+* :py:meth:`arcade.gl.Texture <arcade.gl.Texture.write>`
+
+This feature can be used for displaying the results of calculations
+such as:
+
+* Scientific visualizations displaying data from numpy arrays
+* Emulators drawing screen data
+
+There should be no typing issues when using Python's built-in buffer
+protocol objects as arguments to the ``write`` method of arcade's GL
+objects. We list these built-in types in the
+``arcade.arcade_types.BufferProtocol``
+`Union <https://docs.python.org/3/library/typing.html#typing.Union>`_
+type.
+
+For objects from third-party libraries, your type checker may warn you
+about type mismatches. This is because Python will not support general
+annotations for buffer protocol objects until
+`version 3.12 at the earliest <https://peps.python.org/pep-0688/>`_.
+
+In the meantime, there are workarounds for users who want to write to
+arcade's GL objects from third-party buffer protocol objects:
+
+* use the `typing.cast <https://docs.python.org/3/library/typing.html#typing.cast>`_
+  method to convert the object's type for the linter
+* use ``# type: ignore`` to silence the warnings


### PR DESCRIPTION
Closes #1227 and goes beyond the initial ticket. There were multiple places with weak or absent typing worth improving. There's also a new programming guide section that is linked from the docstrings of the more commonly used objects.

Since GL objects have subtle differences in `write` behavior,  there are two union types:
1. `BufferProtocol` as a top-level arcade type to cover general cases
2. `BufferOrBufferProtocol` in `gl.types` for cases where a `gl.Buffer` is also acceptable.