### PR TITLE
Update to pyglet 2.0.dev22 & update PerfGraph to use it

### DIFF
--- a/arcade/examples/performance_statistics.py
+++ b/arcade/examples/performance_statistics.py
@@ -124,7 +124,7 @@ class MyGame(arcade.Window):
         self.perf_graph_list.append(graph)
 
         # Create the on_update graph
-        graph = arcade.PerfGraph(GRAPH_WIDTH, GRAPH_HEIGHT, graph_data="update")
+        graph = arcade.PerfGraph(GRAPH_WIDTH, GRAPH_HEIGHT, graph_data="on_update")
         graph.position = starting_x + step_x, row_y
         self.perf_graph_list.append(graph)
 

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -8,30 +8,6 @@ from pyglet.shapes import Line
 from pyglet.graphics import Batch
 
 
-def _set_line_to_color(
-        line: Line, color: Color
-) -> None:
-    """
-    Set the color of a pyglet Line, and optionally its opacity
-
-    Pyglet does not yet support RGBA colors on shapes, but that feature
-    will likely be merged soon. This function is marked with underscore
-    protection because it will be superfluous once pyglet's shapes have
-    RGBA support added.
-
-    :param line: the pyglet Line to set the color and opacity on
-    :param color: the RGB or RGBA color to set the line to
-    """
-
-    r, g, b, *alpha = color
-    line.color = r, g, b
-
-    # set the alpha if any alpha channel data was provided, imitating
-    # the proposed pyglet functionality.
-    if alpha:
-        line.opacity = alpha[0]
-
-
 class PerfGraph(arcade.Sprite):
     """
     An auto-updating line chart of FPS or event handler execution times.
@@ -131,16 +107,16 @@ class PerfGraph(arcade.Sprite):
         self._x_axis = Line(
             self._left_x, self._bottom_y,
             self._left_x, height,
-            batch=self._pyglet_batch
+            batch=self._pyglet_batch,
+            color=self._axis_color
         )
-        _set_line_to_color(self._x_axis, self._axis_color)
 
         self._y_axis = Line(
             self._left_x, self._bottom_y,
             width, self._bottom_y,
-            batch=self._pyglet_batch
+            batch=self._pyglet_batch,
+            color=self._axis_color
         )
-        _set_line_to_color(self._y_axis, self._axis_color)
 
         # Create the Y scale text objects & lines
         for i in range(self._y_axis_num_lines):
@@ -155,10 +131,10 @@ class PerfGraph(arcade.Sprite):
                 Line(
                     self._left_x, y_level,
                     width, y_level,
-                    batch=self._pyglet_batch
+                    batch=self._pyglet_batch,
+                    color=self._grid_color
                 )
             )
-            _set_line_to_color(self._grid_lines[-1], self._grid_color)
 
         self._all_text_objects.extend(self._vertical_axis_text_objects)
 
@@ -181,7 +157,7 @@ class PerfGraph(arcade.Sprite):
     def grid_color(self, raw_color: Color):
         new_color = arcade.get_four_byte_color(raw_color)
         for grid_line in self._grid_lines:
-            _set_line_to_color(grid_line.color, new_color)
+            grid_line.color = new_color
 
     @property
     def axis_color(self) -> Color:
@@ -190,8 +166,8 @@ class PerfGraph(arcade.Sprite):
     @axis_color.setter
     def axis_color(self, raw_color: Color):
         new_color = arcade.get_four_byte_color(raw_color)
-        _set_line_to_color(self._x_axis, new_color)
-        _set_line_to_color(self._y_axis, new_color)
+        self._x_axis.color = new_color
+        self._y_axis.color = new_color
 
     @property
     def font_size(self) -> int:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     url="https://api.arcade.academy",
     download_url="https://api.arcade.academy",
     install_requires=[
-        "pyglet==2.0.dev21",
+        "pyglet==2.0.dev22",
         "pillow~=9.1.1",
         "pymunk~=6.2.1",
         "pytiled-parser~=2.1.1",


### PR DESCRIPTION
This also gets rid of the last use of `update` as a window event that I can find while grepping the main examples folder.