### PR TITLE
Fix interproject link generation to point to pyglet's master branch

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -817,9 +817,8 @@ class Window(pyglet.window.Window):
         platform-specific visibility as the defaults from pyglet will
         usually handle their needs automatically.
 
-        For more information on what this means, see the `relevant
-        pyglet documentation
-        <https://pyglet.readthedocs.io/en/master/modules/window.html#pyglet.window.Window.set_mouse_platform_visible>`_
+        For more information on what this means, see the documentation
+        for :py:meth:`pyglet.window.Window.set_mouse_platform_visible`.
         """
         super().set_mouse_platform_visible(platform_visible)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,7 +188,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                       'pyglet': ('https://pyglet.readthedocs.io/en/latest/', None),
+                       'pyglet': ('https://pyglet.readthedocs.io/en/master/', None),
                        'PIL': ('https://pillow.readthedocs.io/en/stable', None)}
 
 # Fix: "more than one target found for cross-reference 'Texture'"


### PR DESCRIPTION
Arcade uses dev releases off of pyglet's `master` branch. This PR points generated inter-project doc links to that branch instead of the doc for 1.5.X stable.

This will help with documentation that @einarf and @DragonMoffon have discussed writing.

Built & tested locally.