### PR TITLE
Fix Get Started Here link at top of home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,10 +20,8 @@ The Python Arcade Library
       <tr>
         <td>
            <h2>
-             <a class="reference external" href="get_started.html">
+             <a class="reference internal" href="programming_guide/get_started.html">
                <img alt="Get started here" src="_images/woman_sprinter.svg" width="48">
-             </a>
-             <a class="reference internal" href="get_started.html#get-started-here">
                <span class="std std-ref">Get Started Here</span>
              </a>
              <a class="headerlink" href="#go-get-started-here" title="Permalink to this headline">¶</a>


### PR DESCRIPTION
Built & tested locally.

During work on #1298, I noticed the top Get Started Here link on the home page was broken due to the Get Started Here content moving to the programming guide.

This PR makes two changes:
1. Corrects the link to point to the new location in the doc structure
2. Unifies the sprinter graphic and the link text into a single link

The second change improves accessibility on all platforms by making a larger click target. On desktops, it also improves legibility by highlighting the link text when the sprinter graphic is hovered over with the cursor.

I have encountered the second issue on smaller mobile screens recently.