### PR TITLE
Clarify SpriteSolidColor and SpriteCircle docstrings

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -1416,12 +1416,19 @@ def load_animated_gif(resource_name) -> AnimatedTimeBasedSprite:
 
 class SpriteSolidColor(Sprite):
     """
-    This sprite is just a rectangular sprite of one solid color. No need to
-    use an image file.
+    A rectangular sprite of the given ``width``, ``height``, and ``color``.
 
-    :param int width: Width of the sprite
-    :param int height: Height of the sprite
-    :param Color color: Color of the sprite
+    The texture is automatically generated instead of loaded from a
+    file.
+
+    There may be a stutter the first time a combination of ``width``,
+    ``height``, and ``color`` is used due to texture generation. All
+    subsequent calls for the same combination will run faster because
+    they will re-use the texture generated earlier.
+
+    :param int width: Width of the sprite in pixels
+    :param int height: Height of the sprite in pixels
+    :param Color color: The color of the sprite as an RGB or RGBA tuple
     """
     def __init__(self, width: int, height: int, color: Color):
         """
@@ -1447,12 +1454,24 @@ class SpriteSolidColor(Sprite):
 
 class SpriteCircle(Sprite):
     """
-    This sprite is just an elliptical sprite of one solid color. No need to
-    use an image file.
+    A circle of the specified `radius <https://simple.wikipedia.org/wiki/Radius>`_.
 
-    :param float radius: Radius of the circle
-    :param Color color: Color of the circle
-    :param bool soft: If True, will add a alpha gradient
+    The texture is automatically generated instead of loaded from a
+    file.
+
+    There may be a stutter the first time a combination of ``radius``,
+    ``color``, and ``soft`` is used due to texture generation. All
+    subsequent calls for the same combination will run faster because
+    they will re-use the texture generated earlier.
+
+    For a gradient fill instead of a solid color, set ``soft`` to
+    ``True``. The circle will fade from an opaque center to transparent
+    at the edges.
+
+    :param int radius: Radius of the circle in pixels
+    :param Color color: The Color of the sprite as an RGB or RGBA tuple
+    :param bool soft: If ``True``, the circle will fade from an opaque
+                      center to transparent edges.
     """
     def __init__(self, radius: int, color: Color, soft: bool = False):
         super().__init__()


### PR DESCRIPTION
Built & tested locally.

This PR clarifies the `SpriteSolidColor` and `SpriteCircle` docstrings by making the following changes:
* Use more precise language in describing the shapes (circle instead of ellipse)
* Succinctly explain the user impact of the texture generation & caching behavior
* Explain the direction of the gradient for `SpriteCircle`
* Sync the types of arguments and their annotation in the docstrings