### PR TITLE
Update pymunk_physics_engine.py

### DIFF
--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -308,7 +308,7 @@ class PymunkPhysicsEngine:
 
         def _f3(arbiter, space, data):
             sprite_a, sprite_b = self.get_sprites_from_arbiter(arbiter)
-            pre_handler(sprite_a, sprite_b, arbiter, space, data)
+            return pre_handler(sprite_a, sprite_b, arbiter, space, data)
 
         def _f4(arbiter, space, data):
             sprite_a, sprite_b = self.get_sprites_from_arbiter(arbiter)


### PR DESCRIPTION
Per pymunk documentation, the pre handler is supposed to return a bool:

"Return false from the callback to make pymunk ignore the collision this step or true to process it normally. Additionally, you may override collision values using Arbiter.friction, Arbiter.elasticity or Arbiter.surfaceVelocity to provide custom friction, elasticity, or surface velocity values. See Arbiter for more info."

This addresses the error which occurs if you define a pre_handler function for collisions without this fix.:
"UserWarning: Function '_f3' should return a bool to indicate if the collision should be processed or not when used as 'begin' or 'pre_solve' collision callback.
  def _f3(arbiter, space, data):"  

