### PR TITLE
GUI: Add union method to Rect to allow to get the union of two rects

### DIFF
--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -166,6 +166,22 @@ class Rect(NamedTuple):
 
         return Rect(self.x, self.y, w, h)
 
+    def union(self, rect: "Rect"):
+        """
+        Returns a new Rect that is the union of this rect and another.
+        The union is the smallest rectangle that contains theses two rectangles.
+        """
+        x = min(self.x, rect.x)
+        y = min(self.y, rect.y)
+        right = max(self.right, rect.right)
+        top = max(self.top, rect.top)
+        return Rect(
+            x=x,
+            y=y,
+            width=right - x,
+            height=top - y
+        )
+
 
 W = TypeVar("W", bound="UIWidget")
 

--- a/tests/test_gui/test_rect.py
+++ b/tests/test_gui/test_rect.py
@@ -146,3 +146,15 @@ def test_rect_max_size_only_height():
 
     # THEN
     assert new_rect == (10, 20, 100, 80)
+
+
+def test_rect_union():
+    # GIVEN
+    rect_a = Rect(0, 5, 10, 5)
+    rect_b = Rect(5, 0, 15, 8)
+
+    # WHEN
+    new_rect = rect_a.union(rect_b)
+
+    # THEN
+    assert new_rect == (0, 0, 20, 10)


### PR DESCRIPTION
This adds a method to gui Rect to allow the union between to rects:


```python
# inside Rect class
    def union(self, rect: "Rect"):
        """
        Returns a new Rect that is the union of this rect and another.
        The union is the smallest rectangle that contains theses two rectangles.
        """
        x = min(self.x, rect.x)
        y = min(self.y, rect.y)
        right = max(self.right, rect.right)
        top = max(self.top, rect.top)
        return Rect(
            x=x,
            y=y,
            width=right - x,
            height=top - y
        )
```