### PR TITLE
Add start_z parameter for Text

### DIFF
--- a/arcade/text.py
+++ b/arcade/text.py
@@ -171,7 +171,6 @@ class Text:
         text: str,
         start_x: float,
         start_y: float,
-        start_z: float = 0,
         color: Color = arcade.color.WHITE,
         font_size: float = 12,
         width: int = 0,
@@ -184,7 +183,8 @@ class Text:
         multiline: bool = False,
         rotation: float = 0,
         batch: Optional[pyglet.graphics.Batch] = None,
-        group: Optional[pyglet.graphics.Group] = None
+        group: Optional[pyglet.graphics.Group] = None,
+        start_z: float = 0
     ):
         """Build a text object"""
 
@@ -554,7 +554,6 @@ def create_text_sprite(
     text: str,
     start_x: float,
     start_y: float,
-    start_z: float = 0,
     color: Color = arcade.color.WHITE,
     font_size: float = 12,
     width: int = 0,
@@ -567,6 +566,7 @@ def create_text_sprite(
     multiline: bool = False,
     rotation: float = 0,
     texture_atlas: Optional[arcade.TextureAtlas] = None,
+    start_z: float = 0
 ) -> arcade.Sprite:
     """
     Creates a sprite containing text based off of :py:class:`~arcade.Text`.
@@ -607,7 +607,6 @@ def create_text_sprite(
         text,
         start_x,
         start_y,
-        start_z,
         color,
         font_size,
         width,
@@ -618,7 +617,8 @@ def create_text_sprite(
         anchor_x,
         anchor_y,
         multiline,
-        rotation
+        rotation,
+        start_z=start_z
     )
 
     size = (int(text_object.right - text_object.left), int(text_object.top - text_object.bottom))
@@ -642,7 +642,6 @@ def draw_text(
     text: Any,
     start_x: float,
     start_y: float,
-    start_z: float = 0,
     color: Color = arcade.color.WHITE,
     font_size: float = 12,
     width: int = 0,
@@ -654,6 +653,7 @@ def draw_text(
     anchor_y: str = "baseline",
     multiline: bool = False,
     rotation: float = 0,
+    start_z: float = 0
 ):
     """
     A simple way for beginners to draw text.

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -121,6 +121,7 @@ class Text:
     :param str text: Initial text to display. Can be an empty string
     :param float start_x: x position to align the text's anchor point with
     :param float start_y: y position to align the text's anchor point with
+    :param float start_z: z position to align the text's anchor point with
     :param Color color: Color of the text as a tuple or list of 3 (RGB) or 4 (RGBA) integers
     :param float font_size: Size of the text in points
     :param float width: A width limit in pixels
@@ -170,6 +171,7 @@ class Text:
         text: str,
         start_x: float,
         start_y: float,
+        start_z: float = 0,
         color: Color = arcade.color.WHITE,
         font_size: float = 12,
         width: int = 0,
@@ -197,6 +199,7 @@ class Text:
             text=text,
             x=start_x,
             y=start_y,
+            z=start_z,
             font_name=adjusted_font,
             font_size=font_size,
             anchor_x=anchor_x,
@@ -551,7 +554,8 @@ def create_text_sprite(
     text: str,
     start_x: float,
     start_y: float,
-    color: Color,
+    start_z: float = 0,
+    color: Color = arcade.color.WHITE,
     font_size: float = 12,
     width: int = 0,
     align: str = "left",
@@ -582,6 +586,7 @@ def create_text_sprite(
     :param str text: Initial text to display. Can be an empty string
     :param float start_x: x position to align the text's anchor point with
     :param float start_y: y position to align the text's anchor point with
+    :param float start_z: z position to align the text's anchor point with
     :param Color color: Color of the text as a tuple or list of 3 (RGB) or 4 (RGBA) integers
     :param float font_size: Size of the text in points
     :param float width: A width limit in pixels
@@ -602,6 +607,7 @@ def create_text_sprite(
         text,
         start_x,
         start_y,
+        start_z,
         color,
         font_size,
         width,
@@ -636,6 +642,7 @@ def draw_text(
     text: Any,
     start_x: float,
     start_y: float,
+    start_z: float = 0,
     color: Color = arcade.color.WHITE,
     font_size: float = 12,
     width: int = 0,
@@ -673,6 +680,7 @@ def draw_text(
     :param Any text: Text to display. The object passed in will be converted to a string
     :param float start_x: x position to align the text's anchor point with
     :param float start_y: y position to align the text's anchor point with
+    :param float start_z: z position to align the text's anchor point with
     :param Color color: Color of the text as a tuple or list of 3 (RGB) or 4 (RGBA) integers
     :param float font_size: Size of the text in points
     :param float width: A width limit in pixels
@@ -822,6 +830,7 @@ def draw_text(
             text=str(text),
             start_x=start_x,
             start_y=start_y,
+            start_z=start_z,
             font_name=adjusted_font,
             font_size=font_size,
             anchor_x=anchor_x,

--- a/doc/programming_guide/release_notes.rst
+++ b/doc/programming_guide/release_notes.rst
@@ -118,6 +118,8 @@ Changes
     the GPU now.
   * As part of this move, the ``arcade.text_pillow`` module has been removed completely, and the ``arcade.text_pyglet`` module has been re-named
     just be ``arcade.text``.
+  * :py:func:`~arcade.draw_text` and :py:class:`~arcade.Text` both now accept a ``start_z`` parameter. This will allow advanced usage to set the Z
+    position of the underlying Label. This parameter defaults to 0 and does not change any existing usage.
 
 * OpenGL
 


### PR DESCRIPTION
This exposes the ability to set the Z position of Text objects in Arcade. This is a recently added feature to Pyglet, and is not currently released. This will need at minimum Pyglet 2.0b2(at time of writing is not yet released on pypi). 

Once we have Pyglet 2.0b2 minimum we can merge this in. This is just exposing the ability to control the values that Pyglet has added, we are defaulting them to zero here.