### PR TITLE
Sections improvements

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -697,25 +697,27 @@ class Window(pyglet.window.Window):
         self._current_view = new_view
         if new_view.has_sections:
             section_manager_managed_events = new_view.section_manager.managed_events
-            self.push_handlers(
-                **{
-                    event_type: getattr(new_view.section_manager, event_type, None)
-                    for event_type in section_manager_managed_events
-                }
-            )
+            section_handlers = {event_type: getattr(new_view.section_manager, event_type, None) for event_type in
+                                section_manager_managed_events}
+            if section_handlers:
+                self.push_handlers(
+                    **section_handlers
+                )
         else:
             section_manager_managed_events = set()
 
         # Note: Excluding on_show because this even can trigger multiple times.
         #       It should only be called once when the view is shown.
-        self.push_handlers(
-            **{
-                event_type: getattr(new_view, event_type, None)
-                for event_type in self.event_types
-                if event_type != 'on_show' and event_type not in section_manager_managed_events
-                and hasattr(new_view, event_type)
-            }
-        )
+        view_handlers = {
+            event_type: getattr(new_view, event_type, None)
+            for event_type in self.event_types
+            if event_type != 'on_show' and event_type not in section_manager_managed_events and hasattr(new_view,
+                                                                                                        event_type)
+        }
+        if view_handlers:
+            self.push_handlers(
+                **view_handlers
+            )
         self._current_view.on_show()
         self._current_view.on_show_view()
         if self._current_view.has_sections:
@@ -904,7 +906,14 @@ class View:
 
         self.window = arcade.get_window() if window is None else window
         self.key: Optional[int] = None
-        self.section_manager: SectionManager = SectionManager(self)
+        self._section_manager: Optional[SectionManager] = None
+
+    @property
+    def section_manager(self) -> SectionManager:
+        """ lazy instantiation of the section manager """
+        if self._section_manager is None:
+            self._section_manager = SectionManager(self)
+        return self._section_manager
 
     @property
     def has_sections(self) -> bool:

--- a/arcade/examples/sections_demo_2.py
+++ b/arcade/examples/sections_demo_2.py
@@ -37,8 +37,7 @@ class Player(Section):
 
     def __init__(self, left: int, bottom: int, width: int, height: int,
                  key_up: int, key_down: int, **kwargs):
-        super().__init__(left, bottom, width, height,
-                         accept_keyboard_events={key_up, key_down}, **kwargs)
+        super().__init__(left, bottom, width, height, accept_keyboard_keys={key_up, key_down}, **kwargs)
 
         # keys assigned to move the paddle
         self.key_up: int = key_up

--- a/arcade/examples/sections_demo_3.py
+++ b/arcade/examples/sections_demo_3.py
@@ -264,9 +264,8 @@ class GameView(arcade.View):
                                           400, 200)
 
         # we set accept_keyboard_events to False (default to True)
-        self.info_bar = InfoBar(0, self.window.height - INFO_BAR_HEIGHT,
-                                self.window.width, INFO_BAR_HEIGHT,
-                                accept_keyboard_events=False)
+        self.info_bar = InfoBar(0, self.window.height - INFO_BAR_HEIGHT, self.window.width, INFO_BAR_HEIGHT,
+                                accept_keyboard_keys=False)
 
         # as prevent_dispatch is on by default, we let pass the events to the
         # following Section: the map

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -300,10 +300,12 @@ class SectionManager:
         # Holds the section the mouse is currently on top
         self.mouse_over_section: Optional[Section] = None
 
-        # True will call view.on_draw before sections on_draw False after, None will not call view on_draw
+        # True will call view.on_draw before sections on_draw, False after, None will not call view on_draw
         self.view_draw_first: Optional[bool] = True
-        # True will call view.on_update before sections on_update False after, None will not call view on_update
+        # True will call view.on_update before sections on_update, False after, None will not call view on_update
         self.view_update_first: Optional[bool] = True
+        # True will call view.on_resize before sections on_resize, False after, None will not call view on_resize
+        self.view_resize_first: Optional[bool] = True
 
         # Events that the section manager should handle (instead of the View) if sections are present in a View
         self.managed_events: Set = {
@@ -418,10 +420,13 @@ class SectionManager:
         First dispatch the view event, then the section ones.
         """
         self.camera.resize(width, height)  # resize the default camera
-        self.view.on_resize(width, height)  # call resize on the view
+        if self.view_resize_first is True:
+            self.view.on_resize(width, height)  # call resize on the view
         for section in self.sections:
             if section.enabled:
                 section.on_resize(width, height)
+        if self.view_resize_first is False:
+            self.view.on_resize(width, height)  # call resize on the view
 
     def disable_all_keyboard_events(self) -> None:
         """ Removes the keyboard events handling from all sections """
@@ -591,7 +596,6 @@ class SectionManager:
             # clear the section the mouse is over as it's out of the screen
             kwargs['current_section'], self.mouse_over_section = self.mouse_over_section, None
             return self.dispatch_mouse_event('on_mouse_leave', x, y, *args, **kwargs)
-
         return False
 
     def on_key_press(self, *args, **kwargs) -> Optional[bool]:

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -431,7 +431,7 @@ class SectionManager:
     def disable_all_keyboard_events(self) -> None:
         """ Removes the keyboard events handling from all sections """
         for section in self.sections:
-            section.accept_keyboard_events = False
+            section.accept_keyboard_keys = False
 
     def get_section(self, x: int, y: int) -> Optional[Section]:
         """ Returns the first section based on x,y position """

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Optional, List, Iterable, Union, Set
 
+from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
+
 from arcade import SimpleCamera, get_window
 
 if TYPE_CHECKING:
@@ -14,30 +16,50 @@ class Section:
 
     def __init__(self, left: int, bottom: int, width: int, height: int,
                  *, name: Optional[str] = None,
-                 accept_keyboard_events: Union[bool, Iterable] = True,
+                 accept_keyboard_keys: Union[bool, Iterable] = True,
+                 accept_mouse_events: Union[bool, Iterable] = True,
                  prevent_dispatch: Optional[Iterable] = None,
                  prevent_dispatch_view: Optional[Iterable] = None,
                  local_mouse_coordinates: bool = False,
                  enabled: bool = True, modal: bool = False):
-
+        """
+        :param int left: the left position of this section
+        :param int bottom: the bottom position of this section
+        :param int width: the width of this section
+        :param int height: the height of this section
+        :param Optional[str] name: the name of this section
+        :param Union[bool, Iterable] accept_keyboard_keys: whether or not this section captures keyboard keys through.
+            keyboard events. If the param is an iterable means the keyboard keys that are captured in press/release
+            events: for example: [arcade.key.UP, arcade.key.DOWN] will only capture this two keys
+        :param Union[bool, Iterable] accept_mouse_events: whether or not this section captures mouse events.
+            If the param is an iterable means the mouse events that are captured.
+            for example: ['on_mouse_press', 'on_mouse_release'] will only capture this two events.
+        :param Optional[Iterable] prevent_dispatch: a list of event names that will not be dispatched to subsequent
+            sections. You can pass None (default) or {True} to prevent the dispatch of all events.
+        :param Optional[Iterable] prevent_dispatch_view: a list of event names that will not be dispatched to the view.
+            You can pass None (default) or {True} to prevent the dispatch of all events to the view.
+        :param bool local_mouse_coordinates: if True the section mouse events will receive x, y coordinates section
+            related to the section dimensions and position (not related to the screen)
+        :param bool enabled: if False the section will not capture any events
+        """
         # name of the section
         self.name: Optional[str] = name
 
-        # parent view: set by the SectionManager
-        # protected, you should not change section.view manually
+        # parent view: set by the SectionManager. Protected, you should not change section.view manually
         self._view: Optional["View"] = None
 
         # section options
         self._enabled: bool = enabled  # enables or disables this section
-        # prevent the following sections from receiving input events and
-        # updating
+        # prevent the following sections from receiving input events and updating
         self._modal: bool = modal
-        # if True update and on_update will not trigger in this section
+        # if True 'update' and 'on_update' will not trigger in this section
         self.block_updates: bool = False
-        # holds the True or False to allow or noy key events or a set of
-        # arcade keys to accept.
-        self.accept_keyboard_events: Union[bool,
-                                           Iterable] = accept_keyboard_events
+
+        # arcade keyboard keys to accept.
+        self.accept_keyboard_keys: Union[bool, Iterable] = accept_keyboard_keys
+        # arcade moouse events to accept.
+        self.accept_mouse_events:  Union[bool, Iterable] = accept_mouse_events
+
         # prevents events to propagate
         self.prevent_dispatch: Iterable = prevent_dispatch or {True}
         # prevents events to propagate to the view
@@ -46,7 +68,7 @@ class Section:
         self.local_mouse_coordinates: bool = local_mouse_coordinates
 
         # section position into the current viewport
-        # if screen is resized it's upto the user to move or resize each section
+        # if screen is resized it's upto the user to move or resize each section (section will receive on_resize event)
         self._left: int = left
         self._bottom: int = bottom
         self._width: int = width
@@ -187,7 +209,7 @@ class Section:
         else:
             return self._view.window
 
-    def overlaps_with(self, section) -> bool:
+    def overlaps_with(self, section: "Section") -> bool:
         """ Checks if this section overlaps with another section """
         return not (self.right < section.left or self.left > section.right
                     or self.top < section.bottom or self.bottom > section.top)
@@ -256,12 +278,11 @@ class Section:
 class SectionManager:
     """
     This manages the different Sections a View has.
-    Actions such as dispatching the events to the correct Section,
-    draw order, etc.
+    Actions such as dispatching the events to the correct Section, draw order, etc.
     """
 
-    def __init__(self, view):
-        self.view = view  # the view this section manager belongs to
+    def __init__(self, view: "View"):
+        self.view: "View" = view  # the view this section manager belongs to
 
         # store sections in update/event order and in draw order
         # a list of the current sections for this in update/event order
@@ -279,8 +300,7 @@ class SectionManager:
         # Holds the section the mouse is currently on top
         self.mouse_over_section: Optional[Section] = None
 
-        # Events that the section manager should handle (instead of the View)
-        # if sections are present in a View
+        # Events that the section manager should handle (instead of the View) if sections are present in a View
         self.managed_events: Set = {
             'on_mouse_motion', 'on_mouse_drag', 'on_mouse_press',
             'on_mouse_release', 'on_mouse_scroll', 'on_mouse_enter',
@@ -308,14 +328,12 @@ class SectionManager:
 
     def get_section_by_name(self, name: str) -> Optional[Section]:
         """ Returns the first section with the given name """
-        sections = [section for section in self.sections if
-                    section.name == name]
+        sections = [section for section in self.sections if section.name == name]
         if sections:
             return sections[0]
         return None
 
-    def add_section(self, section: "Section",
-                    at_index: Optional[int] = None) -> None:
+    def add_section(self, section: "Section", at_index: Optional[int] = None) -> None:
         """
         Adds a section to this Section Manager
         :param section: the section to add to this section manager
@@ -332,10 +350,9 @@ class SectionManager:
         # modals go first
         self._sections.sort(key=lambda s: 0 if s.modal else 1)
         # modals go last
-        self._sections_draw = sorted(self._sections,
-                                     key=lambda s: 1 if s.modal else 0)
+        self._sections_draw = sorted(self._sections, key=lambda s: 1 if s.modal else 0)
 
-    def remove_section(self, section: "Section") -> None:
+    def remove_section(self, section: Section) -> None:
         """ Removes a section from this section manager """
         section._view = None
         self._sections.remove(section)
@@ -344,37 +361,33 @@ class SectionManager:
         # modals go first
         self._sections.sort(key=lambda s: 0 if s.modal else 1)
         # modals go last
-        self._sections_draw = sorted(self._sections,
-                                     key=lambda s: 1 if s.modal else 0)
+        self._sections_draw = sorted(self._sections, key=lambda s: 1 if s.modal else 0)
 
-    def clear_sections(self):
+    def clear_sections(self) -> None:
         """ Removes all sections """
         for section in self.sections:
             section._view = None
         self._sections = []
         self._sections_draw = []
 
-    def on_update(self, delta_time: float):
+    def on_update(self, delta_time: float) -> None:
         """
-        Called on each event loop. First dispatch the view event,
-        then the section ones.
+        Called on each event loop. First dispatch the view event, then the section ones.
         """
         modal_present = False
         self.view.on_update(delta_time)
         for section in self.sections:
-            if section.enabled and not section.block_updates \
-                    and not modal_present:
+            if section.enabled and not section.block_updates and not modal_present:
                 section.on_update(delta_time)
                 if section.modal:
                     modal_present = True
 
-    def on_draw(self):
+    def on_draw(self) -> None:
         """
         Called on each event loop.
         First dispatch the view event, then the section ones.
-        It automatically calls camera.use() for each section
-        that has a camera and resets the camera effects by calling the
-        default SectionManager camera afterwards if needed.
+        It automatically calls camera.use() for each section that has a camera and resets the camera
+         effects by calling the default SectionManager camera afterwards if needed.
         """
         self.view.on_draw()
         for section in self._sections_draw:  # iterate over sections_draw
@@ -388,7 +401,7 @@ class SectionManager:
                 # reset to the default camera after the section is drawn
                 self.camera.use()
 
-    def on_resize(self, width: int, height: int):
+    def on_resize(self, width: int, height: int) -> None:
         """
         Called when the window is resized.
         First dispatch the view event, then the section ones.
@@ -411,11 +424,10 @@ class SectionManager:
                 return section
         return None
 
-    def dispatch_mouse_event(self, event: str, x: int, y: int, *args,
-                             **kwargs) -> Optional[bool]:
+    def dispatch_mouse_event(self, event: str, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         """ Generic method to dispatch mouse events to the correct Section """
         # check if the affected section has been already computed
-        prevent_dispatch = False
+        prevent_dispatch = EVENT_UNHANDLED
 
         section_pre_computed = 'current_section' in kwargs
         if section_pre_computed:
@@ -427,31 +439,33 @@ class SectionManager:
             # get the section from mouse position
             section = self.get_section(x, y)
         if section:
-            # get the method to call from the section
-            method = getattr(section, event, None)
-            if method:
-                if section.local_mouse_coordinates:
-                    position = section.get_xy_section_relative(x, y)
-                else:
-                    position = x, y
+            mouse_events_allowed = section.accept_mouse_events
+            if mouse_events_allowed is False:
+                prevent_dispatch = EVENT_UNHANDLED
+            if mouse_events_allowed is True or event in mouse_events_allowed:  # event allowed
+                # get the method to call from the section
+                method = getattr(section, event, None)
+                if method:
+                    if section.local_mouse_coordinates:
+                        position = section.get_xy_section_relative(x, y)
+                    else:
+                        position = x, y
 
-                # call the section method
-                prevent_dispatch = method(*position, *args, **kwargs)
-                # prevent dispatch if modal
-                prevent_dispatch = True if section.modal else prevent_dispatch
-                if prevent_dispatch is True or any(
-                        test in section.prevent_dispatch for test in
-                        [True, event]):
-                    # prevent_dispatch attributte from section only affects if
-                    #  the method is implemented in the same section
-                    prevent_dispatch = True
-        if section and any(test in section.prevent_dispatch_view for test in
-                           [True, event]):
+                    # call the section method
+                    prevent_dispatch = method(*position, *args, **kwargs)
+                    # prevent dispatch if modal
+                    prevent_dispatch = EVENT_HANDLED if section.modal else prevent_dispatch
+                    if prevent_dispatch is EVENT_HANDLED or any(
+                            test in section.prevent_dispatch for test in [True, event]):
+                        # prevent_dispatch attributte from section only affects if
+                        #  the method is implemented in the same section
+                        prevent_dispatch = EVENT_HANDLED
+        if section and any(test in section.prevent_dispatch_view for test in [True, event]):
             # if the section prevents dispatching events to the view return
             return prevent_dispatch
 
         # call the method from the view.
-        view_prevent_dispatch = False
+        view_prevent_dispatch = EVENT_UNHANDLED
         method = getattr(self.view, event, None)  # get the method from the view
         if method:
             # call the view method
@@ -463,32 +477,28 @@ class SectionManager:
         Generic method to dispatch keyboard events to the correct sections
         """
         propagate_to_view = True
-        prevent_dispatch = False
+        prevent_dispatch = EVENT_UNHANDLED
         for section in self.sections:
             if prevent_dispatch:
                 break
             if not section.enabled:
                 continue
-            keys_allowed = section.accept_keyboard_events
+            keys_allowed = section.accept_keyboard_keys
             if keys_allowed is False:
                 continue
-            if keys_allowed is True or args[0] in keys_allowed \
-                    or args in keys_allowed:
-                if any(test in section.prevent_dispatch_view for test in
-                       [True, event]):
+            if keys_allowed is True or args[0] in keys_allowed or args in keys_allowed:
+                if any(test in section.prevent_dispatch_view for test in [True, event]):
                     propagate_to_view = False
                 # get the method to call from the section
                 method = getattr(section, event, None)
                 if method:
-
                     # call the section method
                     prevent_dispatch = method(*args, **kwargs)
-                    if prevent_dispatch is True or any(
-                            test in section.prevent_dispatch for test in
-                            [True, event]):
+                    if prevent_dispatch is EVENT_HANDLED or any(
+                            test in section.prevent_dispatch for test in [True, event]):
                         # prevent_dispatch attributte from section only affect
                         #  if the method is implemented in the same section
-                        prevent_dispatch = True
+                        prevent_dispatch = EVENT_HANDLED
             if section.modal:
                 # if this section is modal, then avoid passing any event
                 # to more sections
@@ -501,21 +511,17 @@ class SectionManager:
         if method:
             # call the view method
             return method(*args, **kwargs) or prevent_dispatch
+        return EVENT_UNHANDLED
 
-        return False
-
-    def on_mouse_press(self, x: int, y: int,
-                       *args, **kwargs) -> Optional[bool]:
+    def on_mouse_press(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         return self.dispatch_mouse_event('on_mouse_press', x, y, *args,
                                          **kwargs)
 
-    def on_mouse_release(self, x: int, y: int,
-                         *args, **kwargs) -> Optional[bool]:
+    def on_mouse_release(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         return self.dispatch_mouse_event('on_mouse_release', x, y, *args,
                                          **kwargs)
 
-    def on_mouse_motion(self, x: int, y: int,
-                        *args, **kwargs) -> Optional[bool]:
+    def on_mouse_motion(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         """
         This method dispatches the on_mouse_motion and also calculates
          if on_mouse_enter/leave should be fired
@@ -527,25 +533,19 @@ class SectionManager:
             if before_section:
                 # dispatch on_mouse_leave to before_section
                 # (result from this call is ignored)
-                self.dispatch_mouse_event('on_mouse_leave', x, y,
-                                          current_section=before_section)
+                self.dispatch_mouse_event('on_mouse_leave', x, y, current_section=before_section)
             if current_section:
                 # dispatch on_mouse_enter to current_section
                 # (result from this call is ignored)
-                self.dispatch_mouse_event('on_mouse_enter', x, y,
-                                          current_section=current_section)
+                self.dispatch_mouse_event('on_mouse_enter', x, y, current_section=current_section)
         if current_section is not None:
             kwargs['current_section'] = current_section
-        return self.dispatch_mouse_event('on_mouse_motion', x, y, *args,
-                                         **kwargs)
+        return self.dispatch_mouse_event('on_mouse_motion', x, y, *args, **kwargs)
 
-    def on_mouse_scroll(self, x: int, y: int,
-                        *args, **kwargs) -> Optional[bool]:
-        return self.dispatch_mouse_event('on_mouse_scroll', x, y, *args,
-                                         **kwargs)
+    def on_mouse_scroll(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
+        return self.dispatch_mouse_event('on_mouse_scroll', x, y, *args, **kwargs)
 
-    def on_mouse_drag(self, x: int, y: int,
-                      *args, **kwargs) -> Optional[bool]:
+    def on_mouse_drag(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         """
         This method dispatches the on_mouse_drag and also calculates
          if on_mouse_enter/leave should be fired
@@ -557,36 +557,29 @@ class SectionManager:
             if before_section:
                 # dispatch on_mouse_leave to before_section
                 # (result from this call is ignored)
-                self.dispatch_mouse_event('on_mouse_leave', x, y,
-                                          current_section=before_section)
+                self.dispatch_mouse_event('on_mouse_leave', x, y, current_section=before_section)
             if current_section:
                 # dispatch on_mouse_enter to current_section
                 # (result from this call is ignored)
-                self.dispatch_mouse_event('on_mouse_enter', x, y,
-                                          current_section=current_section)
+                self.dispatch_mouse_event('on_mouse_enter', x, y, current_section=current_section)
         if current_section is not None:
             kwargs['current_section'] = current_section
         return self.dispatch_mouse_event('on_mouse_drag', x, y, *args, **kwargs)
 
-    def on_mouse_enter(self, x: int, y: int,
-                       *args, **kwargs) -> Optional[bool]:
+    def on_mouse_enter(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         current_section = self.get_section(x, y)
         # set the section the mouse is over
         self.mouse_over_section = current_section
         # pass the correct section to the dispatch event,
         # so it is not computed again
         kwargs['current_section'] = current_section
-        return self.dispatch_mouse_event('on_mouse_enter', x, y, *args,
-                                         **kwargs)
+        return self.dispatch_mouse_event('on_mouse_enter', x, y, *args, **kwargs)
 
-    def on_mouse_leave(self, x: int, y: int,
-                       *args, **kwargs) -> Optional[bool]:
+    def on_mouse_leave(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         if self.mouse_over_section:
             # clear the section the mouse is over as it's out of the screen
-            kwargs['current_section'], self.mouse_over_section = \
-                self.mouse_over_section, None
-            return self.dispatch_mouse_event('on_mouse_leave', x, y, *args,
-                                             **kwargs)
+            kwargs['current_section'], self.mouse_over_section = self.mouse_over_section, None
+            return self.dispatch_mouse_event('on_mouse_leave', x, y, *args, **kwargs)
 
         return False
 
@@ -596,12 +589,14 @@ class SectionManager:
     def on_key_release(self, *args, **kwargs) -> Optional[bool]:
         return self.dispatch_keyboard_event('on_key_release', *args, **kwargs)
 
-    def on_show_view(self):
+    def on_show_view(self) -> None:
+        """ Called when the view is shown """
         for section in self.sections:
             if section.enabled:
                 section.on_show_section()
 
-    def on_hide_view(self):
+    def on_hide_view(self) -> None:
+        """ Called when the view is hide """
         for section in self.sections:
             if section.enabled:
                 section.on_hide_section()

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -300,8 +300,10 @@ class SectionManager:
         # Holds the section the mouse is currently on top
         self.mouse_over_section: Optional[Section] = None
 
-        self.view_draw_first: bool = True  # True will call view.draw before sections on_draw False after
-        self.view_update_first: bool = True  # True will call view.update before sections on_draw False after
+        # True will call view.on_draw before sections on_draw False after, None will not call view on_draw
+        self.view_draw_first: Optional[bool] = True
+        # True will call view.on_update before sections on_update False after, None will not call view on_update
+        self.view_update_first: Optional[bool] = True
 
         # Events that the section manager should handle (instead of the View) if sections are present in a View
         self.managed_events: Set = {
@@ -378,14 +380,14 @@ class SectionManager:
         Called on each event loop. First dispatch the view event, then the section ones.
         """
         modal_present = False
-        if self.view_update_first:
+        if self.view_update_first is True:
             self.view.on_update(delta_time)
         for section in self.sections:
             if section.enabled and not section.block_updates and not modal_present:
                 section.on_update(delta_time)
                 if section.modal:
                     modal_present = True
-        if not self.view_update_first:
+        if self.view_update_first is False:
             self.view.on_update(delta_time)
 
     def on_draw(self) -> None:
@@ -395,7 +397,7 @@ class SectionManager:
         It automatically calls camera.use() for each section that has a camera and resets the camera
          effects by calling the default SectionManager camera afterwards if needed.
         """
-        if self.view_draw_first:
+        if self.view_draw_first is True:
             self.view.on_draw()
         for section in self._sections_draw:  # iterate over sections_draw
             if not section.enabled:
@@ -407,7 +409,7 @@ class SectionManager:
             if section.camera:
                 # reset to the default camera after the section is drawn
                 self.camera.use()
-        if not self.view_draw_first:
+        if self.view_draw_first is False:
             self.view.on_draw()
 
     def on_resize(self, width: int, height: int) -> None:

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -397,7 +397,7 @@ class SectionManager:
         Called on each event loop.
         First dispatch the view event, then the section ones.
         It automatically calls camera.use() for each section that has a camera and resets the camera
-         effects by calling the default SectionManager camera afterwards if needed.
+        effects by calling the default SectionManager camera afterwards if needed.
         """
         if self.view_draw_first is True:
             self.view.on_draw()
@@ -539,8 +539,7 @@ class SectionManager:
 
     def on_mouse_motion(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         """
-        This method dispatches the on_mouse_motion and also calculates
-         if on_mouse_enter/leave should be fired
+        This method dispatches the on_mouse_motion and also calculates if on_mouse_enter/leave should be fired
         """
         before_section = self.mouse_over_section
         current_section = self.get_section(x, y)
@@ -563,8 +562,7 @@ class SectionManager:
 
     def on_mouse_drag(self, x: int, y: int, *args, **kwargs) -> Optional[bool]:
         """
-        This method dispatches the on_mouse_drag and also calculates
-         if on_mouse_enter/leave should be fired
+        This method dispatches the on_mouse_drag and also calculates if on_mouse_enter/leave should be fired
         """
         before_section = self.mouse_over_section
         current_section = self.get_section(x, y)

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -58,7 +58,7 @@ class Section:
         # arcade keyboard keys to accept.
         self.accept_keyboard_keys: Union[bool, Iterable] = accept_keyboard_keys
         # arcade moouse events to accept.
-        self.accept_mouse_events:  Union[bool, Iterable] = accept_mouse_events
+        self.accept_mouse_events: Union[bool, Iterable] = accept_mouse_events
 
         # prevents events to propagate
         self.prevent_dispatch: Iterable = prevent_dispatch or {True}


### PR DESCRIPTION
This PR adds a few improvements and fixes to Sections:

- Section new param `accept_mouse_events` to allow a section to accept certain mouse events if any
- Section **breaking change**: param `accept_keyboard_events` renamed to `accept_keyboard_keys`
- SectionManager now returns pyglet event standard return values: `EVENT_HANDLED` / `EVENT_UNHANDLED`
- Added init docstrings to Section
- Improved typing in Section
- Improved: `Window.show_view` will only push the handlers if they are not empty
- `View.section_manager` is now lazily instantiated 
- You can now configure `View.on_draw`, `View.on_update` and `View.on_resize` to be called after the section corresponding methods or not being call at all.