### PR TITLE
Sections can now define their draw order and event delivery between sections is now working

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -920,14 +920,15 @@ class View:
         """ Return if the View has sections """
         return self.section_manager.has_sections
 
-    def add_section(self, section, at_index: Optional[int] = None) -> None:
+    def add_section(self, section, at_index: Optional[int] = None, at_draw_order: Optional[int] = None) -> None:
         """
         Adds a section to the view Section Manager.
 
         :param section: the section to add to this section manager
-        :param at_index: inserts the section at that index. If None at the end
+        :param at_index: inserts the section at that index for event capture and update events. If None at the end
+        :param at_draw_order: inserts the section in a specific draw order. Overwrites section.draw_order
         """
-        return self.section_manager.add_section(section, at_index)
+        self.section_manager.add_section(section, at_index, at_draw_order)
 
     def clear(
         self,

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -137,7 +137,7 @@ class Section:
     @draw_order.setter
     def draw_order(self, value: int) -> None:
         if value < 1:
-            raise ValueError(f'draw_order must be greater than zero')
+            raise ValueError('draw_order must be greater than zero')
         self._draw_order = value
         if self.section_manager is not None:
             self.section_manager.sort_sections_draw_order()


### PR DESCRIPTION
Added `Section.draw_order`: now sections can define precisely in what order they will be drawn.

Also Improved Docstrings and remove duplicate code