### PR TITLE
Fix small typos

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,12 @@
 [flake8]
-# --- Description of what we ingore ---
+# --- Description of what we ignore ---
+#
 # H405: multi line docstring summary not separated with an empty line
 # W503: line break before binary operator
 # E731 do not assign a lambda expression, use a def
 # W291 trailing whitespace
-# F811: redefinitiyon
+# F811: redefinition
+
 ignore = H405, W503, F811, W291, E731
 show-source = True
 statistics = True


### PR DESCRIPTION
Just a few typos in the comments at the beginning of the file.

1. **Ingore** → Ignore
2. **Redefinitiyon** → Redefinition