### PR TITLE
Fix type checking in Sprite.texture setter

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -902,10 +902,9 @@ class Sprite:
         if texture == self._texture:
             return
 
-        if not isinstance(texture, Texture):
-            raise ValueError(f"The 'texture' parameter must be an instance of arcade.Texture."
-                             f"It is an instance of '{type(texture)}'.")
-        assert isinstance(texture, Texture)
+        if __debug__ and not isinstance(texture, Texture):
+            raise TypeError(f"The 'texture' parameter must be an instance of arcade.Texture,"
+                            f" but is an instance of '{type(texture)}'.")
 
         self.clear_spatial_hashes()
         self._point_list_cache = None

--- a/tests/unit2/test_sprite.py
+++ b/tests/unit2/test_sprite.py
@@ -1,3 +1,5 @@
+import pytest as pytest
+
 import arcade
 
 frame_counter = 0
@@ -118,6 +120,15 @@ def test_sprite_2(window):
 
     window.on_draw = on_draw
     window.test(2)
+
+
+@pytest.mark.parametrize('not_a_texture', [
+    1, "not_a_texture", (1, 2, 3)
+])
+def test_sprite_texture_setter_raises_type_error_when_given_non_texture(not_a_texture):
+    sprite = arcade.Sprite(":resources:images/items/coinGold.png", 1.0)
+    with pytest.raises(TypeError):
+        sprite.texture = not_a_texture
 
 
 def test_sprite_sizes(window: arcade.Window):


### PR DESCRIPTION
This PR fixes a repeated type check noticed while discussing #1408 :

* Replace double texture type check with single `__debug__` short circuiting check
* Raise `TypeError` instead of `ValueError` on wrong type
* Add a test for raising a `TypeError` when something other than a texture is passed to the setter