### PR TITLE
Fix sprite scaling issues

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -555,13 +555,7 @@ class Sprite:
         if new_value != self._width:
             self.clear_spatial_hashes()
             self._point_list_cache = None
-
-            # If there is a hit box, rescale it to the new width
-            if self._points:
-                scale = new_value / self._width
-                old_points = self._points
-                self._points = [(point[0] * scale, point[1]) for point in old_points]
-
+            self._scale = new_value / self.texture.width, self._scale[1]
             self._width = new_value
             self.add_spatial_hashes()
 
@@ -579,13 +573,7 @@ class Sprite:
         if new_value != self._height:
             self.clear_spatial_hashes()
             self._point_list_cache = None
-
-            # If there is a hit box, rescale it to the new width
-            if self._points:
-                scale = new_value / self._height
-                old_points = self._points
-                self._points = [(point[0], point[1] * scale) for point in old_points]
-
+            self._scale = self._scale[0], new_value / self.texture.height
             self._height = new_value
             self.add_spatial_hashes()
 
@@ -612,7 +600,7 @@ class Sprite:
         self._scale = new_value, new_value
         if self._texture:
             self._width = self._texture.width * self._scale[0]
-            self._height = self._texture.height * self._scale[0]
+            self._height = self._texture.height * self._scale[1]
 
         self.add_spatial_hashes()
 
@@ -1066,7 +1054,7 @@ class Sprite:
 
         self._sprite_list.draw(filter=filter, pixelated=pixelated, blend_function=blend_function)
 
-    def draw_hit_box(self, color: Color = BLACK, line_thickness: float = 1) -> None:
+    def draw_hit_box(self, color: Color = BLACK, line_thickness: float = 2.0) -> None:
         """
         Draw a sprite's hit-box.
 

--- a/tests/unit2/test_sprite_collision.py
+++ b/tests/unit2/test_sprite_collision.py
@@ -35,7 +35,7 @@ def test_sprites_at_point():
 
 
 def test_sprite_collides_with_point():
-    sprite = arcade.Sprite(center_x=0, center_y=0)
+    sprite = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
     sprite.width = 2
     sprite.height = 2
 
@@ -65,15 +65,15 @@ def test_sprite_collides_with_point():
 
 
 def test_sprite_collides_with_sprite():
-    sprite_one = arcade.Sprite(center_x=0, center_y=0)
+    sprite_one = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
     sprite_one.width = 10
     sprite_one.height = 10
 
-    sprite_two = arcade.Sprite(center_x=0, center_y=0)
+    sprite_two = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
     sprite_two.width = 10
     sprite_two.height = 10
 
-    sprite_three = arcade.Sprite(center_x=0, center_y=0)
+    sprite_three = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
     sprite_three.width = 1
     sprite_three.height = 1
 
@@ -107,12 +107,14 @@ def test_sprite_collides_with_sprite():
 def test_sprite_collides_with_list():
     coins = arcade.SpriteList()
     for x in range(0, 50, 10):
-        coin = arcade.Sprite(center_x=x, center_y=0)
+        coin = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
+        coin.position = x, 0
         coin.width = 10
         coin.height = 10
         coins.append(coin)
 
-    player = arcade.Sprite(center_x=100, center_y=100)
+    player = arcade.SpriteSolidColor(32, 32, arcade.csscolor.RED)
+    player.position = 100, 100
     player.width = 10
     player.height = 10
 


### PR DESCRIPTION
When setting width and height we simply calcualte a new scale based on the textures size. This simplifies the calculations, avoids division by zero issues and allows sprite scale 0 without destroying the hit box points.
