### PR TITLE
Fix color table rendering & RGBA constant compatibility

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -189,6 +189,10 @@ table.colorTable {
     border-spacing: 5px;
 }
 
+table.colorTable tr > td:nth-child(3) {
+    border: 1px solid black;
+}
+
 table.colorTable tr > td:nth-child(3) > div {
     display: block;
     width: 80px;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -184,6 +184,17 @@ table.dataTable.display tbody tr.odd > .sorting_1 {
 table.dataTable.display tbody tr.even > .sorting_1 {
     background-color: var(--color-background-secondary);
 }
+
+table.colorTable {
+    border-spacing: 5px;
+}
+
+table.colorTable tr > td:nth-child(3) > div {
+    display: block;
+    width: 80px;
+    min-width: 80px;
+}
+
 p code.literal {
     border: None;
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,19 +271,24 @@ def source_read(_app, docname, source):
 
         original_text = source[0]
         append_text = "\n\n.. raw:: html\n\n"
-        append_text += "    <table>"
+        append_text += "    <table class='colorTable'><tbody>\n"
         color_file = open(filename)
 
         for line in color_file:
             match = p.match(line)
+
             if match:
-                append_text += "    <tr><td>"
-                append_text += match.group(1)
-                append_text += "</td><td>"
-                append_text += match.group(2)
-                append_text += f"<td style='width:80px;background-color:rgba{match.group(2)};'>&nbsp;</td>"
-                append_text += "    </td></tr>\n"
-        append_text += "    </table>"
+                color_variable_name = match.group(1)
+                color_rgba_string = match.group(2).strip('()')
+                color_rgb_string = color_rgba_string[:color_rgba_string.rfind(',')]
+
+                append_text += "    <tr>"
+                append_text += f"<td>{color_variable_name}</td>"
+                append_text += f"<td>({color_rgba_string})</td>"
+                append_text += f"<td style='background-color:rgba({color_rgb_string}, 1.0);'><div></div></td>"
+                append_text += "</tr>\n"
+
+        append_text += "    </tbody></table>"
         source[0] = original_text + append_text
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -259,14 +259,15 @@ def source_read(_app, docname, source):
     os.chdir(file_path)
 
     filename = None
-    if docname == "arcade.color":
+    if docname == "api_docs/arcade.color":
         filename = "../arcade/color/__init__.py"
-    elif docname == "arcade.csscolor":
+    elif docname == "api_docs/arcade.csscolor":
         filename = "../arcade/csscolor/__init__.py"
 
     if filename:
+        # print(f"  XXX Handling color file: {filename}")
         import re
-        p = re.compile("^([A-Z_]+) = (\\(.*\\))")
+        p = re.compile(r"^([A-Z_]+) = (\(.*\))")
 
         original_text = source[0]
         append_text = "\n\n.. raw:: html\n\n"
@@ -280,7 +281,7 @@ def source_read(_app, docname, source):
                 append_text += match.group(1)
                 append_text += "</td><td>"
                 append_text += match.group(2)
-                append_text += f"<td style='width:80px;background-color:rgb{match.group(2)};'>&nbsp;</td>"
+                append_text += f"<td style='width:80px;background-color:rgba{match.group(2)};'>&nbsp;</td>"
                 append_text += "    </td></tr>\n"
         append_text += "    </table>"
         source[0] = original_text + append_text

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -279,13 +279,13 @@ def source_read(_app, docname, source):
 
             if match:
                 color_variable_name = match.group(1)
-                color_rgba_string = match.group(2).strip('()')
-                color_rgb_string = color_rgba_string[:color_rgba_string.rfind(',')]
+                color_tuple = tuple(int(num) for num in match.group(2).strip('()').split(','))
+                color_rgb_string = ', '.join(str(i) for i in color_tuple[:3])
 
                 append_text += "    <tr>"
                 append_text += f"<td>{color_variable_name}</td>"
-                append_text += f"<td>({color_rgba_string})</td>"
-                append_text += f"<td style='background-color:rgba({color_rgb_string}, 1.0);'><div></div></td>"
+                append_text += f"<td>{color_tuple}</td>"
+                append_text += f"<td style='background-color:rgba({color_rgb_string}, {color_tuple[3] / 255});'><div></div></td>"
                 append_text += "</tr>\n"
 
         append_text += "    </tbody></table>"


### PR DESCRIPTION
Color table generation has been broken for a while because the API doc paths it assumed were changed by #1194. We didn't notice until it was highlighted by #1422 and #1342.

This PR does the following:

1. Fix color table build
2. Add support for rendering RGBA color constants with non-255 alpha value into proper CSS (3 unsigned bytes + normalized float)
3. Enhance standards compliance in small ways: a raw string for a regex, move some styling behavior into CSS from HTML

