### PR TITLE
Camera zoom changes

### DIFF
--- a/arcade/camera.py
+++ b/arcade/camera.py
@@ -114,6 +114,15 @@ class SimpleCamera:
         self._set_projection_matrix()
 
     @property
+    def scale(self) -> Tuple[float, float]:
+        """
+        Returns the x, y scale from the difference of projection to view.
+        """
+        _, _, vw, vh = self._viewport
+        _, pw, _, ph = self._projection
+        return vw / pw, vh / ph
+
+    @property
     def viewport_to_projection_width_ratio(self):
         """ The ratio of viewport width to projection width """
         return self.viewport_width / (self._projection[1] - self._projection[0])

--- a/arcade/camera.py
+++ b/arcade/camera.py
@@ -184,10 +184,14 @@ class SimpleCamera:
             vector = Vec2(*vector)
 
         # get the center of the camera viewport
-        center = Vec2(self.viewport_width / 2, self.viewport_height / 2)
+        center = Vec2(self.viewport_width, self.viewport_height) / 2
+
+        # adjust vector to projection ratio
+        vector = Vec2(vector.x * self.viewport_to_projection_width_ratio,
+                      vector.y * self.viewport_to_projection_height_ratio)
 
         # move to the vector substracting the center
-        target = vector - center
+        target = (vector - center)
 
         self.move_to(target, speed)
 

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -182,11 +182,6 @@ class MyGame(arcade.Window):
 
         # Center the minimap viewport to the player in the minimap
         self.camera_minimap.center(self.player_sprite.position, CAMERA_SPEED)
-        # print(self.camera_sprites.position, self.camera_sprites.get_adjusted_position(),
-        #       self.camera_minimap.position, self.camera_minimap.get_adjusted_position())
-        # print(self.camera_sprites.sync(self.camera_minimap))
-        print(self.camera_minimap.scale)
-        print(self.camera_minimap.projection)
 
     def on_resize(self, width: int, height: int):
         """

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -8,10 +8,8 @@ python -m arcade.examples.minimap
 """
 
 import random
-from uuid import uuid4
 
 import arcade
-from pyglet.math import Vec2
 
 SPRITE_SCALING = 0.5
 

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -1,0 +1,214 @@
+"""
+Work with a mini-map
+
+Artwork from https://kenney.nl
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.minimap
+"""
+
+import random
+from uuid import uuid4
+
+import arcade
+from pyglet.math import Vec2
+
+SPRITE_SCALING = 0.5
+
+DEFAULT_SCREEN_WIDTH = 800
+DEFAULT_SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Minimap Example"
+
+# How many pixels to keep as a minimum margin between the character
+# and the edge of the screen.
+VIEWPORT_MARGIN = 220
+
+# How fast the camera pans to the player. 1.0 is instant.
+CAMERA_SPEED = 0.1
+
+# How fast the character moves
+PLAYER_MOVEMENT_SPEED = 7
+
+# Background color must include an alpha component
+MINIMAP_BACKGROUND_COLOR = arcade.get_four_byte_color(arcade.color.ALMOND)
+MINIMAP_WIDTH = 256
+MINIMAP_HEIGHT = 256
+MAP_WIDTH = 2048
+MAP_HEIGHT = 2048
+
+MAP_PROJECTION_WIDTH = 256
+MAP_PROJECTION_HEIGHT = 256
+
+
+class MyGame(arcade.Window):
+    """ Main application class. """
+
+    def __init__(self, width, height, title):
+        """
+        Initializer
+        """
+        super().__init__(width, height, title, resizable=True)
+
+        # Sprite lists
+        self.player_list = None
+        self.wall_list = None
+
+        # Mini-map related
+        minimap_viewport = (DEFAULT_SCREEN_WIDTH - MINIMAP_WIDTH,
+                            DEFAULT_SCREEN_HEIGHT - MINIMAP_HEIGHT,
+                            MINIMAP_WIDTH, MINIMAP_HEIGHT)
+        minimap_projection = (0, MAP_PROJECTION_WIDTH, 0, MAP_PROJECTION_HEIGHT)
+        self.camera_minimap = arcade.SimpleCamera(viewport=minimap_viewport, projection=minimap_projection)
+
+        # Set up the player
+        self.player_sprite = None
+
+        self.physics_engine = None
+
+        # Camera for sprites, and one for our GUI
+        viewport = (0, 0, DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT)
+        projection = (0, DEFAULT_SCREEN_WIDTH, 0, DEFAULT_SCREEN_HEIGHT)
+        self.camera_sprites = arcade.SimpleCamera(viewport=viewport, projection=projection)
+        self.camera_gui = arcade.SimpleCamera(viewport=viewport)
+
+        self.selected_camera = self.camera_minimap
+
+        # texts
+        text = 'Press "A" to select minimap camera. Press "B" to select main camera. Press "W" and "S" to increase ' \
+               'or decrease zoom level on the selected camera.\nPress "I" and "K" to enlarge or reduce minimap.'
+        self.instructions = arcade.Text(text, 10, 25, arcade.color.BLACK_BEAN, 10, multiline=True,
+                                        width=DEFAULT_SCREEN_WIDTH)
+
+    def setup(self):
+        """ Set up the game and initialize the variables. """
+
+        # Sprite lists
+        self.player_list = arcade.SpriteList()
+        self.wall_list = arcade.SpriteList()
+
+        # Set up the player
+        self.player_sprite = arcade.Sprite(":resources:images/animated_characters/female_person/"
+                                           "femalePerson_idle.png",
+                                           scale=0.4)
+        self.player_sprite.center_x = 256
+        self.player_sprite.center_y = 512
+        self.player_list.append(self.player_sprite)
+
+        # -- Set up several columns of walls
+        for x in range(0, MAP_WIDTH, 210):
+            for y in range(0, MAP_HEIGHT, 64):
+                # Randomly skip a box so the player can find a way through
+                if random.randrange(5) > 0:
+                    wall = arcade.Sprite(":resources:images/tiles/grassCenter.png", SPRITE_SCALING)
+                    wall.center_x = x
+                    wall.center_y = y
+                    self.wall_list.append(wall)
+
+        self.physics_engine = arcade.PhysicsEngineSimple(self.player_sprite, self.wall_list)
+
+        # Set the background color
+        arcade.set_background_color(arcade.color.AMAZON)
+
+    def on_draw(self):
+        """
+        Render the screen.
+        """
+
+        # This command has to happen before we start drawing
+        self.clear()
+
+        # Select the camera we'll use to draw all our sprites
+        self.camera_sprites.use()
+
+        # Draw all the sprites.
+        self.wall_list.draw()
+        self.player_list.draw()
+
+        # Draw new minimap using the camera
+        self.camera_minimap.use()
+        self.clear(MINIMAP_BACKGROUND_COLOR)
+        self.wall_list.draw()
+        self.player_list.draw()
+
+        # Select the (unscrolled) camera for our GUI
+        self.camera_gui.use()
+
+        # Draw the GUI
+        arcade.draw_rectangle_filled(self.width // 2, 20, self.width, 40, arcade.color.ALMOND)
+        self.instructions.draw()
+
+    def on_key_press(self, key, modifiers):
+        """Called whenever a key is pressed. """
+
+        if key == arcade.key.UP:
+            self.player_sprite.change_y = PLAYER_MOVEMENT_SPEED
+        elif key == arcade.key.DOWN:
+            self.player_sprite.change_y = -PLAYER_MOVEMENT_SPEED
+        elif key == arcade.key.LEFT:
+            self.player_sprite.change_x = -PLAYER_MOVEMENT_SPEED
+        elif key == arcade.key.RIGHT:
+            self.player_sprite.change_x = PLAYER_MOVEMENT_SPEED
+        elif key == arcade.key.A:
+            self.selected_camera = self.camera_minimap
+        elif key == arcade.key.B:
+            self.selected_camera = self.camera_sprites
+        elif key == arcade.key.W:
+            self.selected_camera.zoom += 0.1
+        elif key == arcade.key.S:
+            if (self.selected_camera.zoom - 0.1) > 0:
+                self.selected_camera.zoom -= 0.1
+        elif key == arcade.key.I:
+            l, b, w, h = self.camera_minimap.viewport
+            self.camera_minimap.viewport = l+100, b+100, w-100, h-100
+        elif key == arcade.key.K:
+            l, b, w, h = self.camera_minimap.viewport
+            self.camera_minimap.viewport = l-100, b-100, w+100, h+100
+
+    def on_key_release(self, key, modifiers):
+        """Called when the user releases a key. """
+
+        if key == arcade.key.UP or key == arcade.key.DOWN:
+            self.player_sprite.change_y = 0
+        elif key == arcade.key.LEFT or key == arcade.key.RIGHT:
+            self.player_sprite.change_x = 0
+
+    def on_update(self, delta_time):
+        """ Movement and game logic """
+
+        # Call update on all sprites (The sprites don't do much in this
+        # example though.)
+        self.physics_engine.update()
+
+        # Center the screen to the player
+        self.camera_sprites.center(self.player_sprite.position, CAMERA_SPEED)
+
+        # Center the minimap viewport to the player in the minimap
+        self.camera_minimap.center(self.player_sprite.position, CAMERA_SPEED)
+        # print(self.camera_sprites.position, self.camera_sprites.get_adjusted_position(),
+        #       self.camera_minimap.position, self.camera_minimap.get_adjusted_position())
+        # print(self.camera_sprites.sync(self.camera_minimap))
+        print(self.camera_minimap.scale)
+        print(self.camera_minimap.projection)
+
+    def on_resize(self, width: int, height: int):
+        """
+        Resize window
+        Handle the user grabbing the edge and resizing the window.
+        """
+        self.camera_sprites.resize(width, height, resize_projection=False)
+        self.camera_gui.resize(width, height)
+        self.camera_minimap.viewport = (width - self.camera_minimap.viewport_width,
+                                        height - self.camera_minimap.viewport_height,
+                                        self.camera_minimap.viewport_width,
+                                        self.camera_minimap.viewport_height)
+
+
+def main():
+    """ Main function """
+    window = MyGame(DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT, SCREEN_TITLE)
+    window.setup()
+    arcade.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -157,10 +157,10 @@ class MyGame(arcade.Window):
                 self.selected_camera.zoom -= 0.1
         elif key == arcade.key.I:
             l, b, w, h = self.camera_minimap.viewport
-            self.camera_minimap.viewport = l+100, b+100, w-100, h-100
+            self.camera_minimap.viewport = l + 100, b + 100, w - 100, h - 100
         elif key == arcade.key.K:
             l, b, w, h = self.camera_minimap.viewport
-            self.camera_minimap.viewport = l-100, b-100, w+100, h+100
+            self.camera_minimap.viewport = l - 100, b - 100, w + 100, h + 100
 
     def on_key_release(self, key, modifiers):
         """Called when the user releases a key. """

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -4,7 +4,7 @@ Work with a mini-map
 Artwork from https://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.minimap
+python -m arcade.examples.minimap_camera
 """
 
 import random


### PR DESCRIPTION
This PR changes a bit how zoom is controlled and applied to cameras.

@einarf sorry to ping but I would like you to review if this is somehow the right approach. In the end what's send to the gl context should be the same, but now the users gets correct and consistent info about the zoom applied.

**A)** Before, you could set a zoom that would change the projection matrix, but you could also change the ratio between the viewport and the projection effectively changing the zoom level again:

```python
# ...
camera = arcade.Camera(viewport=(0, 0, 800, 600))
# at this point projection and viewport matches

camera.zoom = 0.5
# now camera zoom is 0.5

camera.projection = (0, camera.viewport[2] / 2, 0, camera.viewport[3] / 2)
# now, by changing the projection I have applied a zoom indirectly,

# BUT. camera.zoom still says 0.5 when it's not:
print(camera.zoom)  # returns 0.5
```

With this PR, a change in zoom will effectively change the projection (adding or removing width and height to the projection).
Getting `camera.zoom` will show the ratio between projection and viewport (not an scalar value set by the user).
Setting `camera.zoom` will effectively change the projection like this: 

```python
left, right, bottom, top =  camera.projection
camera.projection = left, right * camera.zoom, bottom, top * camera.zoom
```

Also if the user decides to not change camera.zoom but instead change the ratio between viewport and projection the `camera.zoom` property will return a good value, effectively showing the zoom applied.

**Also, as you may probably notice by now, changing the projection so it's 1/2 of the viewport or setting `camera.zoom` to 0.5 will produce the same effect and reflect the same values across all camera attributes.**

**B)** I've added a `camera.scale` property that returns the x, y ratio between projection and viewport. And camera.zoom will return the width scale (if x, y scale is not the same, then zoom will return a result that's not completely correct).
Setting camera.zoom will set camera.scale to the same value. 

**C)** As a result of this change, zoom is now available in `SimpleCamera` (as `SimpleCamera` allows to change viewport and projection).

**D)** This also fixes an error in `camera.center`. Later the center method was not taking into account the projection to view ratio.

**E)** I've also added an example so you can see all this changes in action and also show how you can draw into the screen using cameras instead of using atlas render into.
