### PR TITLE
Drop obsolete use of importlib-meta package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ def get_long_description() -> str:
 REQUIREMENTS_DEV = [
     "pytest",
     "flake8",
-    # importlib-metadata: drop after arcade drops Python 3.7 support (https://github.com/PyCQA/flake8/issues/1701)
-    "importlib-metadata==4.13.0",
     "mypy",
     "coverage",
     "coveralls",


### PR DESCRIPTION
tl;dr remove a dev requirement marked for removal after 3.7 support is dropped.

We're already past that point due to a dependency, and the PR helps clean up setup.py a little in preparation for #1302.

Grepping indicates arcade doesn't use the dependency directly. It appears to be a transitive dependency of other packages which [backports features to earlier python versions](https://pypi.org/project/importlib-metadata/).