### PR TITLE
Sprite: Change velocity into a tuple

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -180,7 +180,7 @@ class Sprite:
         self._scale: Tuple[float, float] = (scale, scale)
         self._position: Point = (center_x, center_y)
         self._angle = angle
-        self.velocity = [0.0, 0.0]
+        self._velocity = 0.0, 0.0
         self.change_angle: float = 0.0
 
         # Hit box and collision property
@@ -778,6 +778,27 @@ class Sprite:
             sprite_list.update_location(self)
 
     @property
+    def velocity(self) -> Point:
+        """
+        Get or set the velocity of the sprite.
+
+        The x and y velocity can also be set separately using the
+        ``sprite.change_x`` and ``sprite.change_y`` properties.
+
+        Example::
+
+            sprite.velocity = 1.0, 0.0
+
+        Returns:
+            Tuple[float, float]
+        """
+        return self._velocity
+
+    @velocity.setter
+    def velocity(self, new_value: Point):
+        self._velocity = new_value
+
+    @property
     def change_x(self) -> float:
         """Get the velocity in the x plane of the sprite."""
         return self.velocity[0]
@@ -785,7 +806,7 @@ class Sprite:
     @change_x.setter
     def change_x(self, new_value: float):
         """Set the velocity in the x plane of the sprite."""
-        self.velocity[0] = new_value
+        self._velocity = new_value, self._velocity[1]
 
     @property
     def change_y(self) -> float:
@@ -795,7 +816,7 @@ class Sprite:
     @change_y.setter
     def change_y(self, new_value: float):
         """Set the velocity in the y plane of the sprite."""
-        self.velocity[1] = new_value
+        self._velocity = self._velocity[0], new_value
 
     @property
     def angle(self) -> float:

--- a/tests/unit2/test_sprite.py
+++ b/tests/unit2/test_sprite.py
@@ -5,6 +5,17 @@ import arcade
 frame_counter = 0
 
 
+def test_velocity():
+    sprite = arcade.SpriteSolidColor(10, 10, arcade.color.WHITE)
+    sprite.velocity = 1, 2
+    assert sprite.velocity == (1, 2)
+    assert sprite.change_x == 1
+    assert sprite.change_y == 2
+    sprite.change_x = 3
+    sprite.change_y = 4
+    assert sprite.velocity == (3, 4)
+
+
 def test_sprite(window: arcade.Window):
     CHARACTER_SCALING = 0.5
     arcade.set_background_color(arcade.color.AMAZON)


### PR DESCRIPTION
This solves a a few problems
* `velocity` is now a publicly documented member of Sprite
* Users setting `sprite.velocity = 1, 1` will no longer get weird crashes
* Even if the users supplies a list they will be fine
