### PR TITLE
Upgrade Pyglet to 2.0.3

### DIFF
--- a/arcade/camera.py
+++ b/arcade/camera.py
@@ -2,14 +2,14 @@
 Camera class
 """
 import math
-from typing import Optional, Tuple, Union, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from pyglet.math import Mat4, Vec2, Vec3
 
 import arcade
 
 if TYPE_CHECKING:
-    from arcade import Point, SpriteList, Sprite
+    from arcade import Point, Sprite, SpriteList
 
 # type aliases
 FourIntTuple = Tuple[int, int, int, int]
@@ -152,7 +152,7 @@ class SimpleCamera:
 
     def _set_combined_matrix(self) -> None:
         """ Helper method. This will just precompute the combined matrix"""
-        self._combined_matrix = self._projection_matrix @ self._view_matrix
+        self._combined_matrix = self._view_matrix @ self._projection_matrix
 
     def move_to(self, vector: Union[Vec2, tuple], speed: float = 1.0) -> None:
         """

--- a/arcade/examples/gl/3d_cube.py
+++ b/arcade/examples/gl/3d_cube.py
@@ -63,7 +63,7 @@ class MyGame(arcade.Window):
         translate = Mat4.from_translation((0, 0, -1.75))
         rx = Mat4.from_rotation(self.time, (1, 0, 0))
         ry = Mat4.from_rotation(self.time * 0.77, (0, 1, 0))
-        modelview = rx @ ry @ translate
+        modelview = translate @ rx @ ry
         self.program['modelview'] = modelview
 
         self.cube.render(self.program)

--- a/arcade/examples/gl/3d_cube_with_cubes.py
+++ b/arcade/examples/gl/3d_cube_with_cubes.py
@@ -115,7 +115,7 @@ class MyGame(arcade.Window):
         translate = Mat4.from_translation((0, 0, -1.75))
         rx = Mat4.from_rotation(self.time, (1, 0, 0))
         ry = Mat4.from_rotation(self.time, (0, 1, 0))
-        modelview = rx @ ry @ translate
+        modelview = translate @ rx @ ry
 
         if self.frame > 0:
             self.program['use_texture'] = 1

--- a/arcade/examples/perspective.py
+++ b/arcade/examples/perspective.py
@@ -118,7 +118,7 @@ class Perspective(arcade.Window):
         # Move the plane into camera view and rotate it
         translate = Mat4.from_translation((0, 0, -2))
         rotate = Mat4.from_rotation(self.time / 2, (1, 0, 0))
-        self.program["model"] = rotate @ translate
+        self.program["model"] = translate @ rotate
 
         # Scroll the texture coordinates
         self.program["scroll"] = 0, -self.time / 5

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     url="https://api.arcade.academy",
     download_url="https://api.arcade.academy",
     install_requires=[
-        "pyglet~=2.0.2.1",
+        "pyglet~=2.0.3",
         "pillow~=9.3.0",
         "pymunk~=6.4.0",
         "pytiled-parser~=2.2.0",


### PR DESCRIPTION
This upgrades pyglet to 2.0.3 and additionally fixes the `camera.py` module and any necessary example code to reflect the changes to matrix multiplication order in `pyglet.math`. 

This currently breaks the example tests with Arcade due to a left-over print statement in Pyglet causing output when loading a freetype font. The tests for examples on Arcade check that the example has no output, so this extra print statement is breaking them. I've submitted a PR to Pyglet to fix this here: https://github.com/pyglet/pyglet/pull/742. This PR will need merged and a release done on Pyglet before we can merge this without breaking the example tests.