### PR TITLE
Build is platform dependent, not independent.

### DIFF
--- a/doc/tutorials/compiling_with_nuitka/index.rst
+++ b/doc/tutorials/compiling_with_nuitka/index.rst
@@ -21,8 +21,8 @@ bundles your application's source code in dll files. This way, you get two benef
 * The resulting executable's size is small.
 
 We are using Windows for this tutorial, but most of the commands can be used as-it-is
-on other platforms including Linux and Mac. **Note that the build is platform independent,
-meaning a Windows build will not work out-of-the-box on other OS**
+on other platforms including Linux and Mac. **Note that the build is platform dependent,
+meaning a Windows build will not work out-of-the-box on another OS.**
 
 
 Compiling a Simple Arcade Script


### PR DESCRIPTION
Just saw this contradiction on the website and thought I could quickly fix it.