### PR TITLE
Simplify initialization of lazy spritelists

### DIFF
--- a/tests/unit2/test_spritelist.py
+++ b/tests/unit2/test_spritelist.py
@@ -128,23 +128,6 @@ def test_can_shuffle(ctx):
             assert slot == index_data[i]
 
 
-def test_spritelist_lazy():
-    """Test lazy creation of spritelist"""
-    spritelist = arcade.SpriteList(lazy=True, use_spatial_hash=True)
-    assert spritelist._sprite_pos_buf == None
-    assert spritelist._geometry == None
-    for x in range(100):
-        spritelist.append(
-            arcade.Sprite(":resources:images/items/coinGold.png", center_x=x * 64)
-        )
-    assert len(spritelist) == 100
-    assert spritelist.spatial_hash
-    assert spritelist._initialized is False
-    spritelist.initialize()
-    assert spritelist._initialized
-    assert spritelist._sprite_pos_buf
-    assert spritelist._geometry
-
 def test_sort(ctx):
     s1 = arcade.SpriteSolidColor(10, 10, arcade.color.WHITE)
     s1.set_position(100, 100)

--- a/tests/unit2/test_spritelist_lazy.py
+++ b/tests/unit2/test_spritelist_lazy.py
@@ -1,0 +1,33 @@
+import pytest
+import arcade
+
+
+def test_create():
+    """Test lazy creation of spritelist"""
+    spritelist = arcade.SpriteList(lazy=True, use_spatial_hash=True)
+    assert spritelist._sprite_pos_buf == None
+    assert spritelist._geometry == None
+    for x in range(100):
+        spritelist.append(
+            arcade.Sprite(":resources:images/items/coinGold.png", center_x=x * 64)
+        )
+    assert len(spritelist) == 100
+    assert spritelist.spatial_hash
+    assert spritelist._initialized is False
+
+    arcade.set_window(None)
+    with pytest.raises(RuntimeError):
+        spritelist.initialize()
+
+
+def test_create_2(window):
+    spritelist = arcade.SpriteList(lazy=True)
+    sprite = arcade.SpriteSolidColor(10, 10, (255, 255, 255, 255))
+    spritelist.append(sprite)
+    spritelist.remove(sprite)
+
+    spritelist.initialize()  
+    assert spritelist._initialized
+    assert spritelist._sprite_pos_buf
+    assert spritelist._geometry
+    spritelist.draw()


### PR DESCRIPTION
We no longer need to store added sprites in a separate set for deferred initialization dealing with textures. We can simply use the existing internal sprite_list.

Ref : https://github.com/pythonarcade/arcade/issues/1494