### PR TITLE
Documentation: Fixed typo in platform tutorial

### DIFF
--- a/doc/tutorials/platform_tutorial/step_02.rst
+++ b/doc/tutorials/platform_tutorial/step_02.rst
@@ -39,7 +39,7 @@ Sprite Lists
 Sprites are managed in lists. The ``SpriteList`` class optimizes drawing, movement,
 and collision detection.
 
-We are using three logical groups in our game. A ``player_list`` for the player.
+We are using two logical groups in our game. A ``player_list`` for the player.
 A ``wall_list`` for walls we can't move through.
 
 .. code-block::


### PR DESCRIPTION
> SnakeDoc — Today at 1:32 PM
https://api.arcade.academy/en/latest/examples/platform_tutorial/step_02.html#sprite-lists
"We are using three logical groups in our game. A player_list for the player. A wall_list for walls we can’t move through." 
Mentions 3 lists but only describes 2 of them 🙂

Quoted from arcade discord server.