### PR TITLE
UI: Updated grid_layout.py example with size hint

### DIFF
--- a/arcade/gui/examples/grid_layout.py
+++ b/arcade/gui/examples/grid_layout.py
@@ -13,15 +13,16 @@ class UIMockup(arcade.Window):
 
         dummy1 = UIDummy(width=100, height=100)
         dummy2 = UIDummy(width=50, height=50)
-        dummy3 = UIDummy(width=50, height=50)
+        dummy3 = UIDummy(width=50, height=50, size_hint=(.5, .5))
         dummy4 = UIDummy(width=100, height=100)
         dummy5 = UIDummy(width=200, height=100)
-        dummy6 = UIDummy(width=100, height=200)
+        dummy6 = UIDummy(width=100, height=300)
 
         subject = (
             UIGridLayout(
                 column_count=3,
                 row_count=3,
+                size_hint=(.5, .5),
             )
             .with_border()
             .with_padding()

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -674,7 +674,7 @@ class UIGridLayout(UILayout):
                 width_expand_ratio = expandable_width_ratio[row_num]
                 available_width = constant_width + total_available_width * width_expand_ratio
 
-                if child is not None and available_width != 0 and available_height != 0:
+                if child is not None and constant_width != 0 and constant_height != 0:
                     new_rect = child.rect
                     sh_w, sh_h = 0, 0
 


### PR DESCRIPTION
Added `size_hint` example in `arcade/gui/examples/grid_layout.py`