### PR TITLE
Fix line highlights for animated explosion example

### DIFF
--- a/doc/example_code/how_to_examples/sprite_explosion_bitmapped.rst
+++ b/doc/example_code/how_to_examples/sprite_explosion_bitmapped.rst
@@ -13,5 +13,4 @@ Sprite Explosions Bitmapped
 .. literalinclude:: ../../../arcade/examples/sprite_explosion_bitmapped.py
     :caption: sprite_explosion_bitmapped.py
     :linenos:
-    :emphasize-lines: 27, 32-50, 81-93, 109, 149, 190, 201-212
-
+    :emphasize-lines: 26, 29-47, 62, 71-87, 99, 140, 181, 192-203


### PR DESCRIPTION
The highlights for this example were incorrect on the development branch.

Built & tested locally.