### PR TITLE
UI: Fix bug of size hints not updating when setting border

### DIFF
--- a/arcade/gui/examples/box_layout.py
+++ b/arcade/gui/examples/box_layout.py
@@ -13,15 +13,19 @@ class UIMockup(arcade.Window):
 
         anchor = self.manager.add(UIAnchorLayout())
 
-        self.v_box = UIBoxLayout(
-            children=[
-                UIDummy(width=200, color=arcade.color.RED),
-                UIDummy(width=200, color=arcade.color.YELLOW),
-                UIDummy(width=200, color=arcade.color.GREEN),
-            ],
-            space_between=20,
+        self.v_box = (
+            UIBoxLayout(
+                children=[
+                    UIDummy(width=200, color=arcade.color.RED),
+                    UIDummy(width=200, color=arcade.color.YELLOW),
+                    UIDummy(width=200, color=arcade.color.GREEN),
+                ],
+                space_between=20,
+            )
+            .with_border()
         )
         anchor.add(
+            align_x=200,
             anchor_x="center_x",
             anchor_y="center_y",
             child=self.v_box,
@@ -33,15 +37,14 @@ class UIMockup(arcade.Window):
                 UIDummy(width=100, color=arcade.color.RED),
                 UISpace(width=20, height=100),
                 UIDummy(width=50, color=arcade.color.YELLOW).with_padding(right=30),
-                UIDummy(width=20, color=arcade.color.GREEN),
+                UIDummy(width=100, color=arcade.color.GREEN),
             ],
         )
         anchor.add(
             child=self.h_box.with_border(),
-            align_x=20,
-            anchor_x="left",
-            align_y=20,
-            anchor_y="bottom",
+            anchor_x="center_x",
+            anchor_y="center_y",
+            align_x=-200,
         )
 
     def on_draw(self):

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -189,9 +189,6 @@ class UIBoxLayout(UILayout):
         style=None,
         **kwargs
     ):
-        self.align = align
-        self.vertical = vertical
-        self._space_between = space_between
         super().__init__(
             x=x,
             y=y,
@@ -205,7 +202,12 @@ class UIBoxLayout(UILayout):
             **kwargs
         )
 
+        self.align = align
+        self.vertical = vertical
+        self._space_between = space_between
+
         bind(self, "_children", self._update_size_hints)
+        bind(self, "_border_width", self._update_size_hints)
 
         # initially update size hints
         self._update_size_hints()
@@ -470,6 +472,7 @@ class UIGridLayout(UILayout):
         self.align_vertical = align_vertical
 
         bind(self, "_children", self._update_size_hints)
+        bind(self, "_border_width", self._update_size_hints)
 
         # initially update size hints
         self._update_size_hints()


### PR DESCRIPTION
The bug: WIdgets in Layout ate up the border.
![image](https://user-images.githubusercontent.com/74553450/218339543-ce4ee7a9-c301-487c-9468-0039b4daac0f.png)

After fix:
![2023-02-13_03-25](https://user-images.githubusercontent.com/74553450/218339611-a6f2fcc6-e02d-41e6-a646-299d2fa27344.png)
