### PR TITLE
1502 create lines fix

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -217,6 +217,7 @@ from .buffered_draw_commands import create_rectangle_filled_with_colors
 from .buffered_draw_commands import create_rectangle_outline
 from .buffered_draw_commands import create_rectangles_filled_with_colors
 from .buffered_draw_commands import create_triangles_filled_with_colors
+from .buffered_draw_commands import create_triangles_strip_filled_with_colors
 from .buffered_draw_commands import get_rectangle_points
 
 from .draw_commands import draw_arc_filled

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -454,6 +454,7 @@ __all__ = [
     'create_rectangles_filled_with_colors',
     'create_text_sprite',
     'create_triangles_filled_with_colors',
+    'create_triangles_strip_filled_with_colors',
     'disable_timings',
     'draw_arc_filled',
     'draw_arc_outline',

--- a/arcade/buffered_draw_commands.py
+++ b/arcade/buffered_draw_commands.py
@@ -481,6 +481,7 @@ def create_triangles_filled_with_colors(point_list, color_list) -> Shape:
     shape_mode = gl.GL_TRIANGLES
     return create_line_generic_with_colors(point_list, color_list, shape_mode)
 
+
 def create_triangles_strip_filled_with_colors(point_list, color_list) -> Shape:
     """
     This function creates multiple triangles using a vertex buffer object. 
@@ -502,6 +503,7 @@ def create_triangles_strip_filled_with_colors(point_list, color_list) -> Shape:
     """
     shape_mode = gl.GL_TRIANGLE_STRIP
     return create_line_generic_with_colors(point_list, color_list, shape_mode)
+
 
 def create_ellipse_filled(center_x: float, center_y: float,
                           width: float, height: float, color: Color,

--- a/arcade/buffered_draw_commands.py
+++ b/arcade/buffered_draw_commands.py
@@ -74,7 +74,7 @@ def create_line(start_x: float, start_y: float, end_x: float, end_y: float,
     points = get_points_for_thick_line(start_x, start_y, end_x, end_y, line_width)
     color_list = [color, color, color, color]
     triangle_point_list = points[1], points[0], points[2], points[3]
-    return create_triangles_filled_with_colors(triangle_point_list, color_list)
+    return create_triangles_strip_filled_with_colors(triangle_point_list, color_list)
 
 
 def create_line_generic_with_colors(point_list: PointList,
@@ -169,7 +169,7 @@ def create_line_strip(point_list: PointList,
         new_color_list += color1, color2, color1, color2
         triangle_point_list += points[1], points[0], points[2], points[3]
 
-    return create_triangles_filled_with_colors(triangle_point_list, new_color_list)
+    return create_triangles_strip_filled_with_colors(triangle_point_list, new_color_list)
 
 
 def create_line_loop(point_list: PointList,
@@ -206,6 +206,16 @@ def create_lines(point_list: PointList,
 def create_lines_with_colors(point_list: PointList,
                              color_list: Sequence[Color],
                              line_width: float = 1):
+    """
+    Create a line segments to be rendered later. This works faster than draw_line because
+    the vertexes are only loaded to the graphics card once, rather than each frame.
+
+    :param PointList point_list: Line segments start and end point tuples list
+    :param Color color: Three or four byte tuples list for every point
+    :param float line_width:
+
+    :Returns Shape:
+    """
 
     if line_width == 1:
         return create_line_generic_with_colors(point_list, color_list, gl.GL_LINES, line_width)
@@ -450,7 +460,9 @@ def create_rectangles_filled_with_colors(point_list, color_list) -> Shape:
 
 def create_triangles_filled_with_colors(point_list, color_list) -> Shape:
     """
-    This function creates multiple rectangle/quads using a vertex buffer object.
+    This function creates multiple triangles using a vertex buffer object.
+    Triangles are build for every 3 sequential vertices with step of 3 vertex
+    Total amount of triangles to be rendered: len(point_list) / 3
 
     The function returns a Shape object that can be drawn with ``my_shape.draw()``.
     Don't create the shape in the draw method, create it in the setup method and then
@@ -459,10 +471,37 @@ def create_triangles_filled_with_colors(point_list, color_list) -> Shape:
     For even faster performance, add multiple shapes into a ShapeElementList and
     draw that list. This allows nearly unlimited shapes to be drawn just as fast
     as one.
+
+    :param PointList point_list: Triangles vertices tuples.
+    :param Color color: Three or four byte tuples list for every point
+
+    :Returns Shape:
+
     """
     shape_mode = gl.GL_TRIANGLES
     return create_line_generic_with_colors(point_list, color_list, shape_mode)
 
+def create_triangles_strip_filled_with_colors(point_list, color_list) -> Shape:
+    """
+    This function creates multiple triangles using a vertex buffer object. 
+    Triangles are built for every 3 sequential vertices with step of 1 vertex
+    Total amount of triangles to be rendered: len(point_list) - 2
+
+    The function returns a Shape object that can be drawn with ``my_shape.draw()``.
+    Don't create the shape in the draw method, create it in the setup method and then
+    draw it in ``on_draw``.
+
+    For even faster performance, add multiple shapes into a ShapeElementList and
+    draw that list. This allows nearly unlimited shapes to be drawn just as fast
+    as one.
+
+    :param PointList point_list: Triangles vertices tuples.
+    :param Color color: Three or four byte tuples list for every point
+
+    :Returns Shape:
+    """
+    shape_mode = gl.GL_TRIANGLE_STRIP
+    return create_line_generic_with_colors(point_list, color_list, shape_mode)
 
 def create_ellipse_filled(center_x: float, center_y: float,
                           width: float, height: float, color: Color,

--- a/arcade/buffered_draw_commands.py
+++ b/arcade/buffered_draw_commands.py
@@ -220,8 +220,8 @@ def create_lines_with_colors(point_list: PointList,
         color1 = color_list[i - 1]
         color2 = color_list[i]
         points = get_points_for_thick_line(start_x, start_y, end_x, end_y, line_width)
-        new_color_list += color1, color1, color2, color2
-        triangle_point_list += points[1], points[0], points[2], points[3]
+        new_color_list += color1, color1, color2, color1, color2, color2
+        triangle_point_list += points[0], points[1], points[2], points[0], points[2], points[3]
 
     return create_triangles_filled_with_colors(triangle_point_list, new_color_list)
 
@@ -460,7 +460,7 @@ def create_triangles_filled_with_colors(point_list, color_list) -> Shape:
     draw that list. This allows nearly unlimited shapes to be drawn just as fast
     as one.
     """
-    shape_mode = gl.GL_TRIANGLE_STRIP
+    shape_mode = gl.GL_TRIANGLES
     return create_line_generic_with_colors(point_list, color_list, shape_mode)
 
 


### PR DESCRIPTION
1. added fix to create_lines_with_colors
2. created triangles_strip wrapper to handle other functions which use that option
3. added some comments to documentation section of changed functions

sidenote regarding related code: 
create_line_strip function in original version of code causes twice more triangles to be rendered due to call to triangle_strip function (one triangle per vertex, so 4 triangles per line segment).
This behavior could be changed (2 triangles would be rendered for one line segment) by using no strip triangles function, but vertex array would increase 1.5 times (6 vertex for one line segment vs 4)

Built and tested locally

Closes #1502 
