### PR TITLE
Allow adding empty sprite lists to a scene

### DIFF
--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -113,7 +113,7 @@ class Scene:
         :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
         :param SpriteList sprite_list: The SpriteList to add, optional.
         """
-        if not sprite_list:
+        if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)
         self.name_mapping[name] = sprite_list
         self.sprite_lists.append(sprite_list)
@@ -138,7 +138,7 @@ class Scene:
         :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
         :param SpriteList sprite_list: The SpriteList to add, optional.
         """
-        if not sprite_list:
+        if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)
         self.name_mapping[name] = sprite_list
         before_list = self.name_mapping[before]
@@ -190,7 +190,7 @@ class Scene:
         :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
         :param SpriteList sprite_list: The SpriteList to add, optional.
         """
-        if not sprite_list:
+        if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)
         self.name_mapping[name] = sprite_list
         after_list = self.name_mapping[after]


### PR DESCRIPTION
Checking for existence of the list with `not sprite_list` causes a new list to be created if the caller passes an empty sprite list. The new check with `sprite_list is None` ensures that the given list is used, even if empty.