### PR TITLE
Sprite initializer changes

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -58,10 +58,9 @@ class Sprite:
     def __init__(
         self,
         path_or_texture: PathOrTexture = None,
-        *,
+        scale: float = 1.0,
         center_x: float = 0.0,
         center_y: float = 0.0,
-        scale: float = 1.0,
         angle: float = 0.0,
     ):
         """ Constructor """

--- a/arcade/sprite/simple.py
+++ b/arcade/sprite/simple.py
@@ -31,7 +31,6 @@ class SpriteSolidColor(Sprite):
         self,
         width: int,
         height: int,
-        *,
         center_x: float = 0,
         center_y: float = 0,
         color: Color = (255, 255, 255, 255),


### PR DESCRIPTION
* Don't enforce keyword arguments for now
* Use scale as second argument for backwards compatibility