### PR TITLE
Disable shapely for `are_polygons_intersecting` and `is_point_in_polygon`

### DIFF
--- a/arcade/geometry/__init__.py
+++ b/arcade/geometry/__init__.py
@@ -8,19 +8,27 @@ from .geometry_python import (
     are_lines_intersecting,
     is_point_in_box,
 )
-try:
+
+# Shapely is disabled due to https://github.com/pythonarcade/arcade/pull/1535
+# We are leaving the code in-place to make it easier for someone to revisit
+# in the future and improve shapely's performance.
+use_shapely = False
+# try:
+#     import shapely  # noqa: F401
+#     use_shapely = True
+# except ImportError:
+#     use_shapely = False
+
+if use_shapely:
     from .geometry_shapely import (
         are_polygons_intersecting,
         is_point_in_polygon,
     )
-    shapely_installed = True
-except ImportError:
+else:
     from .geometry_python import (
         are_polygons_intersecting,
         is_point_in_polygon,
     )
-    shapely_installed = False
-
 
 __all__ = [
     "are_polygons_intersecting",

--- a/arcade/geometry/__init__.py
+++ b/arcade/geometry/__init__.py
@@ -18,7 +18,6 @@ use_shapely = False
 #     use_shapely = True
 # except ImportError:
 #     use_shapely = False
-
 if use_shapely:
     from .geometry_shapely import (
         are_polygons_intersecting,

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -1,12 +1,10 @@
 """
 Classic A-star algorithm for path finding.
 """
-import sys
 from arcade.types import Point
 from arcade import check_for_collision_with_list, SpriteList, Sprite
 from typing import Union, List, Tuple, Set, Optional
 
-use_shapely = False
 try:
     import shapely  # noqa: F401
     use_shapely = True

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -6,11 +6,16 @@ from arcade.types import Point
 from arcade import check_for_collision_with_list, SpriteList, Sprite
 from typing import Union, List, Tuple, Set, Optional
 
-if 'shapely' in sys.modules:
+use_shapely = False
+try:
+    import shapely  # noqa: F401
+    use_shapely = True
+except ImportError:
+    use_shapely = False
+if use_shapely:
     from .paths_shapely import has_line_of_sight  # noqa: F401
 else:
     from .paths_python import has_line_of_sight  # noqa: F401
-
 
 def _spot_is_blocked(position: Point,
                      moving_sprite: Sprite,


### PR DESCRIPTION
We benchmarked shapely in #1535 and found that it's way slower when used in these two functions.  We discussed on Discord that we can disable shapely now, and leave the code in-place for someone to investigate in the future.

This does not disable using shapely in other parts of arcade, such as pathfinding.  Shapely may still be faster in those other areas, so we should not disable it.

