### PR TITLE
Window commands cleanup

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -91,7 +91,6 @@ from .window_commands import exit
 from .window_commands import finish_render
 from .window_commands import get_display_size
 from .window_commands import get_projection
-from .window_commands import get_scaling_factor
 from .window_commands import get_viewport
 from .window_commands import get_window
 from .window_commands import pause
@@ -333,7 +332,6 @@ __all__ = [
     'get_pixel',
     'get_points_for_thick_line',
     'get_projection',
-    'get_scaling_factor',
     'get_screens',
     'get_sprites_at_exact_point',
     'get_sprites_at_point',

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -100,7 +100,6 @@ from .window_commands import run
 from .window_commands import set_background_color
 from .window_commands import set_viewport
 from .window_commands import set_window
-from .window_commands import clear_window
 from .window_commands import start_render
 from .window_commands import unschedule
 from .window_commands import schedule_once
@@ -371,7 +370,6 @@ __all__ = [
     'set_background_color',
     'set_viewport',
     'set_window',
-    'clear_window',
     'start_render',
     'stop_sound',
     'timings_enabled',

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -90,7 +90,6 @@ from .window_commands import exit
 from .window_commands import finish_render
 from .window_commands import get_display_size
 from .window_commands import get_projection
-from .window_commands import get_viewport
 from .window_commands import get_window
 from .window_commands import pause
 from .window_commands import schedule
@@ -338,7 +337,6 @@ __all__ = [
     'get_three_float_color',
     'create_text_sprite',
     'clear_timings',
-    'get_viewport',
     'get_window',
     'get_fps',
     'has_line_of_sight',

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -89,7 +89,6 @@ from .window_commands import close_window
 from .window_commands import exit
 from .window_commands import finish_render
 from .window_commands import get_display_size
-from .window_commands import get_projection
 from .window_commands import get_window
 from .window_commands import pause
 from .window_commands import schedule
@@ -329,7 +328,6 @@ __all__ = [
     'get_joysticks',
     'get_pixel',
     'get_points_for_thick_line',
-    'get_projection',
     'get_screens',
     'get_sprites_at_exact_point',
     'get_sprites_at_point',

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -86,7 +86,6 @@ from .geometry import is_point_in_polygon
 
 # Complex imports with potential circularity
 from .window_commands import close_window
-from .window_commands import create_orthogonal_projection
 from .window_commands import exit
 from .window_commands import finish_render
 from .window_commands import get_display_size
@@ -337,7 +336,6 @@ __all__ = [
     'get_sprites_at_point',
     'get_timings',
     'get_three_float_color',
-    'create_orthogonal_projection',
     'create_text_sprite',
     'clear_timings',
     'get_viewport',

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -16,7 +16,6 @@ import arcade
 from arcade import get_display_size
 from arcade import set_viewport
 from arcade import set_window
-from arcade import clear_window
 from arcade.color import TRANSPARENT_BLACK
 from arcade.context import ArcadeContext
 from arcade.types import Color
@@ -274,7 +273,7 @@ class Window(pyglet.window.Window):
         """ Close the Window. """
         super().close()
         # Make sure we don't reference the window any more
-        clear_window()
+        set_window(None)
         pyglet.clock.unschedule(self._dispatch_updates)
 
     def set_fullscreen(self,

--- a/arcade/examples/gl/chip8_display.py
+++ b/arcade/examples/gl/chip8_display.py
@@ -17,7 +17,6 @@ from array import array
 
 import arcade
 from arcade.gl import geometry
-from arcade import get_projection
 
 # Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 64 * 10
@@ -67,7 +66,7 @@ class MyGame(arcade.Window):
             """
         )
         # 8 x 4 
-        self.program['projection'] = get_projection()
+        self.program['projection'] = self.projection
         self.program['screen'] = 0
         b = 0  # border to test scale
         self.quad = geometry.screen_rectangle(b, b, SCREEN_WIDTH - b * 2, SCREEN_HEIGHT - b * 2)

--- a/arcade/examples/gl/transform_point_grid.py
+++ b/arcade/examples/gl/transform_point_grid.py
@@ -20,6 +20,7 @@ import random
 import time
 from array import array
 
+from pyglet.math import Mat4
 import arcade
 from arcade import gl
 
@@ -75,7 +76,7 @@ class MyGame(arcade.Window):
         self.transform2 = self.ctx.geometry([gl.BufferDescription(self.buffer2, '2f 2f', ['in_pos', 'in_dest'])])
 
         # Let's make the coordinate system match the viewport
-        projection = arcade.create_orthogonal_projection(0, self.width, 0, self.height, -100, 100)
+        projection = Mat4.orthogonal_projection(0, self.width, 0, self.height, -100, 100)
 
         # Draw the points with the the supplied color
         self.points_program = self.ctx.program(

--- a/arcade/experimental/texture_render_target.py
+++ b/arcade/experimental/texture_render_target.py
@@ -1,4 +1,4 @@
-from arcade import get_window, get_scaling_factor
+from arcade import get_window
 from arcade.types import Color
 from arcade.gl import geometry
 from arcade.gl.texture import Texture
@@ -45,6 +45,6 @@ class RenderTargetTexture:
 
     def resize(self, width: int, height: int):
         """Resize the the internal texture"""
-        pixel_scale = get_scaling_factor(self.window)
+        pixel_scale = self.window.get_pixel_scale()
         self._size = width * pixel_scale, height * pixel_scale
         self._fbo = self.ctx.framebuffer(color_attachments=self.ctx.texture((width, height), components=4))

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -373,7 +373,7 @@ class UIManager(EventDispatcher, UIWidgetParent):
         return self.dispatch_ui_event(UITextMotionSelectEvent(self, motion))
 
     def on_resize(self, width, height):
-        scale = arcade.get_scaling_factor(self.window)
+        scale = self.window.get_pixel_ratio()
 
         for surface in self._surfaces.values():
             surface.resize(size=(width, height), pixel_ratio=scale)

--- a/arcade/texture_atlas.py
+++ b/arcade/texture_atlas.py
@@ -29,6 +29,7 @@ from weakref import WeakSet
 
 import PIL
 from PIL import Image, ImageDraw
+
 from arcade.gl.framebuffer import Framebuffer
 from arcade.texture_transforms import Transform
 import arcade
@@ -36,6 +37,7 @@ from pyglet.image.atlas import (
     Allocator,
     AllocatorException,
 )
+from pyglet.math import Mat4
 
 if TYPE_CHECKING:
     from arcade import ArcadeContext, Texture
@@ -716,7 +718,7 @@ class TextureAtlas:
         self._texture.use(1)
         image_uv_texture_old.use(2)
         self._image_uv_texture.use(3)
-        self._ctx.atlas_resize_program["projection"] = arcade.create_orthogonal_projection(
+        self._ctx.atlas_resize_program["projection"] = Mat4.orthogonal_projection(
             0, self.width, self.height, 0,
         )
 

--- a/arcade/texture_atlas.py
+++ b/arcade/texture_atlas.py
@@ -719,7 +719,7 @@ class TextureAtlas:
         image_uv_texture_old.use(2)
         self._image_uv_texture.use(3)
         self._ctx.atlas_resize_program["projection"] = Mat4.orthogonal_projection(
-            0, self.width, self.height, 0,
+            0, self.width, self.height, 0, -100, 100,
         )
 
         with self._fbo.activate():

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -17,7 +17,6 @@ from typing import (
     TYPE_CHECKING
 )
 from arcade.types import Color
-from pyglet.math import Mat4
 
 if TYPE_CHECKING:
     from arcade import Window

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -153,16 +153,6 @@ def set_viewport(left: float, right: float, bottom: float, top: float) -> None:
     window.ctx.projection_2d = left, right, bottom, top
 
 
-def get_viewport() -> Tuple[float, float, float, float]:
-    """
-    Get the current viewport settings.
-
-    :return: Tuple of floats, with ``(left, right, bottom, top)``
-
-    """
-    return get_window().ctx.projection_2d
-
-
 def close_window() -> None:
     """
     Closes the current window, and then runs garbage collection. The garbage collection

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -184,22 +184,6 @@ def close_window() -> None:
     gc.collect()
 
 
-def finish_render():
-    """
-    Swap buffers and displays what has been drawn.
-
-    .. Warning::
-
-        If you are extending the :py:class:`~arcade.Window` class, this function
-        should not be called. The event loop will automatically swap the window
-        framebuffer for you after ``on_draw``.
-
-    """
-    get_window().static_display = True
-    get_window().flip_count = 0
-    get_window().flip()
-
-
 def run():
     """
     Run the main loop.
@@ -294,6 +278,22 @@ def start_render() -> None:
     or :py:meth:`arcade.View.clear`.
     """
     get_window().clear()
+
+
+def finish_render():
+    """
+    Swap buffers and displays what has been drawn.
+
+    .. Warning::
+
+        If you are extending the :py:class:`~arcade.Window` class, this function
+        should not be called. The event loop will automatically swap the window
+        framebuffer for you after ``on_draw``.
+
+    """
+    get_window().static_display = True
+    get_window().flip_count = 0
+    get_window().flip()
 
 
 def set_background_color(color: Color) -> None:

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -123,26 +123,6 @@ def set_window(window: Optional["Window"]) -> None:
     _window = window
 
 
-def get_scaling_factor(window: Optional["Window"] = None) -> float:
-    """
-    Gets the scaling factor of the given Window.
-    This is the ratio between the window and framebuffer size.
-    If no window is supplied the currently active window will be used.
-
-    :param Window window: Handle to window we want to get scaling factor of.
-
-    :return: Scaling factor. E.g., 2.0 would indicate the framebuffer
-             width and height being 2.0 times the window width and height.
-             This means one "window pixel" is actual a 2 x 2 square of pixels
-             in the framebuffer.
-    :rtype: float
-    """
-    if window:
-        return window.get_pixel_ratio()
-    else:
-        return get_window().get_pixel_ratio()
-
-
 def set_viewport(left: float, right: float, bottom: float, top: float) -> None:
     """
     This sets what coordinates the window will cover.

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -28,7 +28,8 @@ _window: Optional["Window"] = None
 
 
 def get_display_size(screen_id: int = 0) -> Tuple[int, int]:
-    """Return the width and height of a monitor.
+    """
+    Return the width and height of a monitor.
 
     The size of the primary monitor is returned by default.
 
@@ -51,35 +52,6 @@ def get_projection() -> Mat4:
     :rtype: Mat4
     """
     return get_window().ctx.projection_2d_matrix
-
-
-def create_orthogonal_projection(
-    left: float,
-    right: float,
-    bottom: float,
-    top: float,
-    near: float = 1,
-    far: float = -1,
-) -> Mat4:
-    """
-    Creates an orthogonal projection matrix. Used internally with the
-    OpenGL shaders. It creates the same matrix as the deprecated/removed
-    ``glOrtho`` OpenGL function.
-
-    :param float left: The left of the near plane relative to the plane's center.
-    :param float right: The right of the near plane relative to the plane's center.
-    :param float top: The top of the near plane relative to the plane's center.
-    :param float bottom: The bottom of the near plane relative to the plane's center.
-    :param float near: The distance of the near plane from the camera's origin.
-                       It is recommended that the near plane is set to 1.0 or above to avoid
-                       rendering issues at close range.
-    :param float far: The distance of the far plane from the camera's origin.
-    :return: A projection matrix representing the specified orthogonal perspective.
-    :rtype: pyglet.math.Mat4
-
-    .. seealso:: https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml
-    """
-    return Mat4.orthogonal_projection(left, right, bottom, top, near, far)
 
 
 def pause(seconds: Number) -> None:

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -41,18 +41,6 @@ def get_display_size(screen_id: int = 0) -> Tuple[int, int]:
     return screen.width, screen.height
 
 
-def get_projection() -> Mat4:
-    """
-    Returns the current projection matrix used by sprites and shapes in arcade.
-
-    This is a shortcut for ```window.ctx.projection_2d_matrix``.
-
-    :return: Projection matrix
-    :rtype: Mat4
-    """
-    return get_window().ctx.projection_2d_matrix
-
-
 def pause(seconds: float) -> None:
     """
     Pause for the specified number of seconds. This is a convenience function that just calls time.sleep().

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -9,7 +9,6 @@ import os
 
 import pyglet
 
-from numbers import Number
 from typing import (
     Callable,
     Optional,
@@ -54,7 +53,7 @@ def get_projection() -> Mat4:
     return get_window().ctx.projection_2d_matrix
 
 
-def pause(seconds: Number) -> None:
+def pause(seconds: float) -> None:
     """
     Pause for the specified number of seconds. This is a convenience function that just calls time.sleep().
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -113,7 +113,7 @@ def get_window() -> "Window":
     return _window
 
 
-def set_window(window: "Window") -> None:
+def set_window(window: Optional["Window"]) -> None:
     """
     Set a handle to the current window.
 
@@ -121,14 +121,6 @@ def set_window(window: "Window") -> None:
     """
     global _window
     _window = window
-
-
-def clear_window():
-    """
-    Clear the window handle.
-    """
-    global _window
-    _window = None
 
 
 def get_scaling_factor(window: Optional["Window"] = None) -> float:

--- a/tests/unit2/test_opengl_program.py
+++ b/tests/unit2/test_opengl_program.py
@@ -2,6 +2,7 @@ import struct
 import pytest
 import arcade
 from pyglet import gl
+from pyglet.math import Mat4
 from arcade.gl import ShaderException
 from arcade.gl.uniform import UniformBlock
 from arcade.gl.glsl import ShaderSource
@@ -343,7 +344,7 @@ def test_uniform_block(ctx):
     assert ubo.name == "Projection"
 
     # Project a point (800, 600) into (1, 1) using a projection matrix
-    projection_matrix = arcade.create_orthogonal_projection(0, 800, 0, 600, -10, 10)
+    projection_matrix = Mat4.orthogonal_projection(0, 800, 0, 600, -10, 10)
     ubo_buffer = ctx.buffer(data=projection_matrix)
     buffer = ctx.buffer(reserve=8)
     vao = ctx.geometry()

--- a/tests/unit2/test_window.py
+++ b/tests/unit2/test_window.py
@@ -30,9 +30,6 @@ def test_window(window: arcade.Window):
     w.set_mouse_visible(True)
     w.set_size(width, height)
 
-    p = arcade.get_projection()
-    assert isinstance(p, Mat4)
-
     v = window.get_viewport()
     assert v[0] == 0
     assert v[1] == width

--- a/tests/unit2/test_window.py
+++ b/tests/unit2/test_window.py
@@ -33,7 +33,7 @@ def test_window(window: arcade.Window):
     p = arcade.get_projection()
     assert isinstance(p, Mat4)
 
-    v = arcade.get_viewport()
+    v = window.get_viewport()
     assert v[0] == 0
     assert v[1] == width
     assert v[2] == 0

--- a/tests/unit2/test_window.py
+++ b/tests/unit2/test_window.py
@@ -39,9 +39,8 @@ def test_window(window: arcade.Window):
     assert v[2] == 0
     assert v[3] == height
 
-    factor = arcade.get_scaling_factor()
-    assert factor > 0
-    factor = arcade.get_scaling_factor(w)
+    factor = window.get_pixel_ratio()
+    assert isinstance(factor, float) 
     assert factor > 0
 
     arcade.start_render()


### PR DESCRIPTION
* Remove `clear_window()` since this can be confused with `window.clear()`
* Removed redundant `get_pixel_scale(window)` since `window.get_pixel_scale()` already exists
* Remove redundant `create_orthogonal_projection()` now that we have Mat4.
* Removed `get_viewport`.