### PR TITLE
Clamp delta time in debugger, or other ways to control delta_time

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -4,6 +4,7 @@ derive from.
 """
 import logging
 import os
+import sys
 import time
 from typing import Tuple, Optional
 
@@ -31,6 +32,7 @@ MOUSE_BUTTON_RIGHT = 4
 
 _window: 'Window'
 
+_in_debugger = sys.gettrace() is not None
 
 def get_screens():
     """
@@ -323,6 +325,10 @@ class Window(pyglet.window.Window):
         Internal function that is scheduled with Pyglet's clock, this function gets run by the clock, and
         dispatches the on_update events.
         """
+        # Clamp delta_time in debugger, since long debugger pauses should not
+        # cause sky-high `delta_time` on the next frame.
+        if _in_debugger:
+            delta_time = min(delta_time, self._update_rate * 2.)
         self.dispatch_event('on_update', delta_time)
 
     def set_update_rate(self, rate: float):


### PR DESCRIPTION
There are a few different cases where it might be helpful to clamp or control `delta_time`.

## Debugger

When pausing in the debugger, the next frame's `delta_time` will be massive.  Makes sense, if you pause the debugger for a minute, then the delta is 60s.
But engines like Unity clamp delta time for this reason.  When you pause and then resume the game in Unity, it will not generate a massive `delta_time`.
Should we add something like that to arcade?

It could be as simple as `my_window.set_max_delta_time(1/30)` or `set_fixed_delta_time` or maybe there's something more auto-magic that would allow detecting when the debugger has paused? `if sys.gettrace() is not None`

## AI

I can't speak to this one, but people want to use arcade for AI simulation or visualization.  In these cases, I think the simulation and render loop should run in fast-forward, as fast as the CPU can handle.  We can update docs to explain how to do this easily.  Maybe we explain how to set a fixed `delta_time` but for arcade to tick as fast as possible, no sleeping.