### PR TITLE
Fix swallowing all exceptions in lazy loading classes

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -181,7 +181,7 @@ class SpriteList(Generic[_SpriteType]):
             get_window()
             if not self._lazy:
                 self._init_deferred()
-        except Exception:
+        except RuntimeError:
             pass
 
     def _init_deferred(self):

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -207,7 +207,7 @@ class TileMap:
         if not texture_atlas:
             try:
                 texture_atlas = get_window().ctx.default_atlas
-            except Exception:
+            except RuntimeError:
                 pass
 
         self._lazy = lazy


### PR DESCRIPTION
This PR makes lazy loading classes properly handle `RuntimeError` from `arcade.window_commands.get_window`.

It's worth keeping this in mind for other classes which could have lazy loading in the future, such as:
* GUI classes
* Backgrounds
* 9 patch
* Texture atlases
 