### PR TITLE
Clarify linting commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,11 @@ Discussion can happen in a GitHub issue's comments or on [Arcade's Discord serve
 ## After Making Changes
 
 After you finish your changes, you should do the following:
-1. Test your changes with Arcade's test suite as well as `mypy` & `flake8`
+1. Test your changes with Arcade's test suite as well as with `mypy arcade` & `flake8 arcade`
 2. Submit a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests)
 from your fork to Arcade's development branch.
 
-The rest of the guide will help you get to this point.
+The rest of the guide will help you get to this point & explain how to test in more detail.
 
 ## Requirements 
 
@@ -63,7 +63,7 @@ in this repo for current tests.
 
 ### Testing Code Changes
 
-First, run `mypy` and `flake8` from inside the arcade folder. You should fix
+First, run `mypy arcade` and then `flake8 arcade` from inside the arcade folder. You should fix
 any issues they report.
 
 Then run the framework's automated tests with the following command:


### PR DESCRIPTION
CONTRIBUTING.md does not currently limit linting to the arcade module, which produces a flood of errors due to the tests folder and local temp files the user might have around to help debug issues.