### PR TITLE
Experiment using numpy arrays to store, compute, operate on hitboxes

### DIFF
--- a/arcade/geometry_python.py
+++ b/arcade/geometry_python.py
@@ -6,7 +6,9 @@ from arcade.hit_box_utils import NumPyPointList
 from arcade.types import PointList
 import numpy as np
 from numpy import (
-    dot as np_dot, array as nparray, min as np_min, max as np_max, subtract as np_subtract, swapaxes as np_swapaxes, multiply as np_multiply, flip as np_flip
+    dot as np_dot, array as nparray, min as np_min, max as np_max, subtract as np_subtract, swapaxes as np_swapaxes, multiply as np_multiply, flip as np_flip,
+    maximum as np_maximum,
+    minimum as np_minimum,
 )
 
 
@@ -64,6 +66,7 @@ def _are_polygons_intersecting(poly_a: NumPyPointList,
     projected_a = np.empty(len(poly_a), dtype=np.float64)
     projected_b = np.empty(len(poly_b), dtype=np.float64)
     normal = np.empty(2, dtype=np.float64)
+    # normal = np_flip(normal_buf)
     for polygon in (poly_a, poly_b):
 
         for i1 in range(len(polygon)):
@@ -73,7 +76,7 @@ def _are_polygons_intersecting(poly_a: NumPyPointList,
 
             np_subtract(projection_1, projection_2, normal)
             np_multiply(perp, normal, normal)
-            np_flip(normal)
+            normal[0], normal[1] = normal[1], normal[0]
 
             np_dot(poly_a, normal, projected_a)
             # min_a = np_min(projected_a)
@@ -81,7 +84,7 @@ def _are_polygons_intersecting(poly_a: NumPyPointList,
             np_dot(poly_b, normal, projected_b)
             # min_b = np_min(projected_b)
             # max_b = np_max(projected_b)
-            if cast(float, np_max(projected_a)) <= cast(float, np_min(projected_b)) or cast(float, np_max(projected_b)) <= cast(float, np_min(projected_a)):
+            if cast(float, np_maximum.reduce(projected_a)) <= cast(float, np_minimum.reduce(projected_b)) or cast(float, np_maximum.reduce(projected_b)) <= cast(float, np_minimum.reduce(projected_a)):
                 return False
     return True
 

--- a/arcade/hit_box_utils.py
+++ b/arcade/hit_box_utils.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from arcade.types import PointList
+
+NumPyPointList = np.ndarray
+
+def point_list_to_ndarray(point_list: PointList) -> NumPyPointList:
+    print(point_list)
+    return np.array(point_list, dtype=np.float64)
+
+def ndarray_to_point_list(ndarray: NumPyPointList) -> PointList:
+    return ndarray.tolist()

--- a/arcade/sprite/simple.py
+++ b/arcade/sprite/simple.py
@@ -101,4 +101,4 @@ class SpriteCircle(Sprite):
         # apply results to the new sprite
         super().__init__(texture)
         self.color = color_rgba
-        self._points = self.texture.hit_box_points
+        self._points = self.texture._hit_box_points

--- a/arcade/sprite_list/spatial_hash.py
+++ b/arcade/sprite_list/spatial_hash.py
@@ -10,11 +10,11 @@ from typing import (
 
 from arcade import (
     Sprite,
-    are_polygons_intersecting,
     get_distance_between_sprites,
     is_point_in_polygon,
     get_window,
 )
+from arcade.geometry_python import _are_polygons_intersecting
 from arcade.types import Point
 from .sprite_list import SpriteList
 
@@ -230,8 +230,8 @@ def _check_for_collision(sprite1: Sprite, sprite2: Sprite) -> bool:
     if distance > radius_sum_x2:
         return False
 
-    return are_polygons_intersecting(
-        sprite1.get_adjusted_hit_box(), sprite2.get_adjusted_hit_box()
+    return _are_polygons_intersecting(
+        sprite1._get_adjusted_hit_box(), sprite2._get_adjusted_hit_box()
     )
 
 

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import PIL.Image
 import PIL.ImageOps
 import PIL.ImageDraw
+from arcade.hit_box_utils import ndarray_to_point_list, point_list_to_ndarray
 
 from arcade.types import Color
 from arcade.texture_transforms import (
@@ -167,7 +168,7 @@ class Texture:
             raise ValueError(
                 f"hit_box_algorithm must be an instance of HitBoxAlgorithm, not {type(self._hit_box_algorithm)}"
             )
-        self._hit_box_points: PointList = hit_box_points or self._calculate_hit_box_points()
+        self._hit_box_points = point_list_to_ndarray(hit_box_points or self._calculate_hit_box_points())
 
         # Optional filename for debugging
         self._origin: Optional[str] = None
@@ -305,6 +306,7 @@ class Texture:
 
         :return: PointList
         """
+        raise Exception("Disabled during prototyping")
         return self._hit_box_points
 
     @property
@@ -584,7 +586,7 @@ class Texture:
         :param Transform transform: Transform to apply
         :return: New texture
         """
-        points = transform.transform_hit_box_points(self._hit_box_points)
+        points = transform.transform_hit_box_points(ndarray_to_point_list(self._hit_box_points))
         texture = Texture(
             self.image_data,
             # Not relevant, but copy over the value

--- a/benchmarks/collisions/bench.py
+++ b/benchmarks/collisions/bench.py
@@ -30,7 +30,7 @@ window = arcade.Window()
 # like something I might create in a game.
 rng.seed(2)
 for i in range(0, WALLS_COUNT):
-    wall = arcade.SpriteSolidColor(rng.randint(WALL_DIM_MIN, WALL_DIM_MAX), rng.randint(WALL_DIM_MIN, WALL_DIM_MAX), arcade.color.BLACK)
+    wall = arcade.SpriteSolidColor(rng.randint(WALL_DIM_MIN, WALL_DIM_MAX), rng.randint(WALL_DIM_MIN, WALL_DIM_MAX), color=arcade.color.BLACK)
     wall.position = rng.randint(0, SCREEN_WIDTH), rng.randint(0, SCREEN_HEIGHT)
     walls.append(wall)
 


### PR DESCRIPTION
Short answer: numpy is way slower even when we try very hard to store hitboxes and adjusted hotboxes in numpy arrays and reuse those arrays (overwrite in-place) as much as possible.  There's simply way too much overhead for every `np` function call.

So I'm creating this pull request for the record, and closing it out.