### PR TITLE
Add support for simple shader includes

### DIFF
--- a/arcade/gui/nine_patch.py
+++ b/arcade/gui/nine_patch.py
@@ -60,7 +60,6 @@ class NinePatchTexture:
             vertex_shader=":resources:shaders/gui/nine_patch_vs.glsl",
             geometry_shader=":resources:shaders/gui/nine_patch_gs.glsl",
             fragment_shader=":resources:shaders/gui/nine_patch_fs.glsl",
-            common=(":resources:shaders/lib/sprite.glsl",),
         )
         # Configure texture channels
         self.program.set_uniform_safe("uv_texture", 0)

--- a/arcade/resources/shaders/atlas/resize_gs.glsl
+++ b/arcade/resources/shaders/atlas/resize_gs.glsl
@@ -1,7 +1,8 @@
 #version 330
-
 // The render target for this program is the new
 // texture atlas texture
+
+#include :resources:shaders/lib/sprite.glsl
 
 // Old and new texture coordiantes
 uniform sampler2D atlas_old;

--- a/arcade/resources/shaders/gui/nine_patch_gs.glsl
+++ b/arcade/resources/shaders/gui/nine_patch_gs.glsl
@@ -2,6 +2,8 @@
 // Geometry shader emitting 9 patch from point
 // This can be simplified somewhat, but the verbose version are easier to maintain
 
+#include :resources:shaders/lib/sprite.glsl
+
 uniform WindowBlock {
     mat4 projection;
     mat4 view;

--- a/arcade/resources/shaders/sprites/sprite_list_geometry_cull_geo.glsl
+++ b/arcade/resources/shaders/sprites/sprite_list_geometry_cull_geo.glsl
@@ -1,5 +1,7 @@
 #version 330
 
+#include :resources:shaders/lib/sprite.glsl
+
 layout (points) in;
 layout (triangle_strip, max_vertices = 4) out;
 

--- a/arcade/resources/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
+++ b/arcade/resources/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
@@ -1,5 +1,7 @@
 #version 330
 
+#include :resources:shaders/lib/sprite.glsl
+
 layout (points) in;
 layout (triangle_strip, max_vertices = 4) out;
 

--- a/tests/unit2/test_opengl_context.py
+++ b/tests/unit2/test_opengl_context.py
@@ -123,3 +123,29 @@ def test_load_texture(ctx):
     # Don't flip the texture
     texture = ctx.load_texture(":resources:images/test_textures/test_texture.png", flip=False, build_mipmaps=True)
     assert texture.read()[:4] == b'\xff\x00\x00\xff'  # Red
+
+
+def test_shader_include(ctx):
+    """Test shader include directive"""
+    # Without quotes
+    src = """
+        #version 330
+        #include :resources:shaders/lib/sprite.glsl
+    """
+    assert len(ctx.shader_inc(src)) > len(src)
+    # With quotes
+    src = """
+        #version 330
+        #include ":resources:shaders/lib/sprite.glsl"
+    """
+    assert len(ctx.shader_inc(src)) > len(src)
+
+
+def test_shader_include_fail(ctx):
+    """Test shader include directive"""
+    src = """
+        #version 330
+        #include "test_shader_include.vert"
+    """
+    with pytest.raises(FileNotFoundError):
+        ctx.shader_inc(src)


### PR DESCRIPTION
Shader sources can now use #include "filename" to include other shader. This path should use a resource handle.