### PR TITLE
Enforce naming convention on view examples label

### DIFF
--- a/doc/example_code/how_to_examples/index.rst
+++ b/doc/example_code/how_to_examples/index.rst
@@ -433,7 +433,7 @@ Cameras
 View Management
 ---------------
 
-.. _view-examples:
+.. _view_examples:
 
 Instruction and Game Over Screens
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/tutorials/views/index.rst
+++ b/doc/tutorials/views/index.rst
@@ -23,7 +23,7 @@ to. The ``View`` class has methods for ``on_update`` and ``on_draw`` just like
 managing what is drawn on the window and handling user input.
 
 If you know ahead of time you want to use views, you can build your code around
-the :ref:`view-examples`. However, typically a programmer wants to add these
+the :ref:`view_examples`. However, typically a programmer wants to add these
 items to a game that already exists.
 
 This tutorial steps you through how to do just that.


### PR DESCRIPTION
Fix a typo in the name of the view examples label.