### PR TITLE
GUI: Rendering fixes

### DIFF
--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import arcade
 from arcade import Texture
@@ -7,7 +7,7 @@ from arcade.color import TRANSPARENT_BLACK
 from arcade.gl import Framebuffer
 from arcade.gl import geometry
 from arcade.gui.nine_patch import NinePatchTexture
-from arcade.types import Color
+from arcade.types import Color, Point, Rect
 
 
 class Surface:
@@ -44,10 +44,20 @@ class Surface:
         )
 
         # Create 1 pixel rectangle we scale and move using pos and size
-        self._quad = geometry.screen_rectangle(0, 0, 1, 1)
+        self._geometry = self.ctx.geometry()
         self._program = self.ctx.program(
             vertex_shader="""
                 #version 330
+
+                void main() {
+                    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+                }
+                """,
+            geometry_shader="""
+                #version 330
+
+                layout (points) in;
+                layout (triangle_strip, max_vertices = 4) out;
 
                 uniform WindowBlock {
                     mat4 projection;
@@ -56,17 +66,34 @@ class Surface:
 
                 uniform vec2 pos;
                 uniform vec2 size;
-
-                in vec2 in_vert;
-                in vec2 in_uv;
+                uniform vec4 area;
 
                 out vec2 uv;
 
                 void main() {
-                    gl_Position = window.projection * window.view * vec4((in_vert * size) + pos, 0.0, 1.0);
-                    uv = in_uv;
+                    mat4 mvp = window.projection * window.view;    
+                
+                    // Create the 4 corners of the rectangle
+                    vec2 p_ll = pos;
+                    vec2 p_lr = pos + vec2(size.x, 0);
+                    vec2 p_ul = pos + vec2(0, size.y);
+                    vec2 p_ur = pos + size;
+
+                    gl_Position = mvp * vec4(p_ll, 0, 1);
+                    uv = vec2(area.x, area.y);
+                    EmitVertex();
+                    gl_Position = mvp * vec4(p_lr, 0, 1);
+                    uv = vec2(area.z, area.y);
+                    EmitVertex();
+                    gl_Position = mvp * vec4(p_ul, 0, 1);
+                    uv = vec2(area.x, area.w);
+                    EmitVertex();
+                    gl_Position = mvp * vec4(p_ur, 0, 1);
+                    uv = vec2(area.z, area.w);
+                    EmitVertex();
+                    EndPrimitive();
                 }
-                """,
+            """,
             fragment_shader="""
                 #version 330
 
@@ -82,7 +109,7 @@ class Surface:
         )
 
     @property
-    def position(self) -> Tuple[int, int]:
+    def position(self) -> Point:
         """Get or set the surface position"""
         return self._pos
 
@@ -191,8 +218,19 @@ class Surface:
         height = max(height, 1)
         self.ctx.projection_2d = 0, width, 0, height
 
-    def draw(self) -> None:
-        """Draws the current buffer on screen"""
+    def draw(
+        self,
+        area: Optional[Rect] = None,
+    ) -> None:
+        """
+        Draws the contents of the surface.
+
+        The surface will be rendered at the configured ``position``
+        and limited by the given ``area``.
+
+        :param Optional[Point] position: The position to draw the surface at.
+        :param Optional[Rect] area: The pixel area in the surface to draw.
+        """
         # Set blend function
         blend_func = self.ctx.blend_func
         self.ctx.blend_func = self.blend_func_render
@@ -200,7 +238,8 @@ class Surface:
         self.texture.use(0)
         self._program["pos"] = self._pos
         self._program["size"] = self._size
-        self._quad.render(self._program)
+        self._program["area"] = area or (0, 0, *self._size)
+        self._geometry.render(self._program, vertices=1)
 
         # Restore blend function
         self.ctx.blend_func = blend_func

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -72,25 +72,43 @@ class Surface:
 
                 void main() {
                     mat4 mvp = window.projection * window.view;    
-                
-                    // Create the 4 corners of the rectangle
-                    vec2 p_ll = pos;
-                    vec2 p_lr = pos + vec2(size.x, 0);
-                    vec2 p_ul = pos + vec2(0, size.y);
-                    vec2 p_ur = pos + size;
 
-                    gl_Position = mvp * vec4(p_ll, 0, 1);
-                    uv = vec2(area.x, area.y);
+                    // Clamp the area
+                    vec4 l_area = vec4(
+                        clamp(area.x, 0.0, size.x - area.z),
+                        clamp(area.y, 0.0, size.y - area.w),
+                        clamp(area.z, 0.0, size.x),
+                        clamp(area.w, 0.0, size.y)
+                    );
+
+                    // The local coordinates of the surface
+                    vec2 ll_local = l_area.xy;
+                    vec2 lr_local = l_area.xy + vec2(l_area.z, 0.0);
+                    vec2 ul_local = l_area.xy + vec2(0, l_area.w);
+                    vec2 ur_local = l_area.xy + l_area.zw;
+
+                    // Create the 4 corners of the rectangle
+                    vec2 p_ll = pos + ll_local;
+                    vec2 p_lr = pos + lr_local;
+                    vec2 p_ul = pos + ul_local;
+                    vec2 p_ur = pos + ur_local;
+
+                    gl_Position = mvp * vec4(p_ll, 0.0, 1.0);
+                    uv = vec2(0.0, 0.0);
                     EmitVertex();
-                    gl_Position = mvp * vec4(p_lr, 0, 1);
-                    uv = vec2(area.z, area.y);
+
+                    gl_Position = mvp * vec4(p_lr, 0.0, 1.0);
+                    uv = vec2(1.0, 0.0);
                     EmitVertex();
-                    gl_Position = mvp * vec4(p_ul, 0, 1);
-                    uv = vec2(area.x, area.w);
+
+                    gl_Position = mvp * vec4(p_ul, 0.0, 1.0);
+                    uv = vec2(0.0, 1.0);
                     EmitVertex();
-                    gl_Position = mvp * vec4(p_ur, 0, 1);
-                    uv = vec2(area.z, area.w);
+
+                    gl_Position = mvp * vec4(p_ur, 0.0, 1.0);
+                    uv = vec2(1.0, 1.0);
                     EmitVertex();
+
                     EndPrimitive();
                 }
             """,
@@ -229,7 +247,7 @@ class Surface:
         and limited by the given ``area``.
 
         :param Optional[Point] position: The position to draw the surface at.
-        :param Optional[Rect] area: The pixel area in the surface to draw.
+        :param Optional[Rect] area: Limit the area in the surface we're drawing (x, y, w, h)
         """
         # Set blend function
         blend_func = self.ctx.blend_func

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -5,7 +5,6 @@ import arcade
 from arcade import Texture
 from arcade.color import TRANSPARENT_BLACK
 from arcade.gl import Framebuffer
-from arcade.gl import geometry
 from arcade.gui.nine_patch import NinePatchTexture
 from arcade.types import Color, Point, Rect
 

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -73,14 +73,6 @@ class UIManager(EventDispatcher, UIWidgetParent):
         self._surfaces: Dict[int, Surface] = {}
         self.children: Dict[int, List[UIWidget]] = defaultdict(list)
         self._rendered = False
-        self._blend_func = (
-            *self.window.ctx.BLEND_DEFAULT,
-            *self.window.ctx.BLEND_DEFAULT,
-        )
-        self._blend_func_surface = (
-            *self.window.ctx.BLEND_DEFAULT,
-            *self.window.ctx.BLEND_ADDITIVE,
-        )
 
         self.register_event_type("on_event")
 
@@ -267,9 +259,6 @@ class UIManager(EventDispatcher, UIWidgetParent):
 
         ctx = self.window.ctx
 
-        # Set blend mode for drawing into surfaces
-        ctx.blend_func = self._blend_func_surface
-
         # Reset view matrix so content is not rendered into
         # the surface with offset
         prev_view = self.window.view
@@ -284,17 +273,11 @@ class UIManager(EventDispatcher, UIWidgetParent):
         self.window.view = prev_view
         self.window.projection = prev_proj
 
-        # Set the blend mode for drawing surfaces
-        ctx.blend_func = self._blend_func
-
         # Draw layers
         with ctx.enabled(ctx.BLEND):
             layers = sorted(self.children.keys())
             for layer in layers:
                 self._get_surface(layer).draw()
-
-        # Reset back to default blend function
-        ctx.blend_func = ctx.BLEND_DEFAULT
 
     def adjust_mouse_coordinates(self, x, y):
         """
@@ -389,27 +372,27 @@ class UIManager(EventDispatcher, UIWidgetParent):
     def rect(self) -> Rect:  # type: ignore
         return Rect(0, 0, *self.window.get_size())
 
-    @property
-    def blend_func_surface(self) -> Tuple[int, int, int, int]:
-        """
-        The blend function used when rendering into surfaces (read-write)
-        """
-        return self._blend_func_surface
+    # @property
+    # def blend_func_surface(self) -> Tuple[int, int, int, int]:
+    #     """
+    #     The blend function used when rendering into surfaces (read-write)
+    #     """
+    #     return self._blend_func_surface
 
-    @blend_func_surface.setter
-    def blend_func_surface(self, value: Tuple[int, int, int, int]):
-        self._blend_func_surface = value
+    # @blend_func_surface.setter
+    # def blend_func_surface(self, value: Tuple[int, int, int, int]):
+    #     self._blend_func_surface = value
 
-    @property
-    def blend_func(self):
-        """
-        The blend function used when rendering the surfaces (read-write)
-        """
-        return self._blend_func
+    # @property
+    # def blend_func(self):
+    #     """
+    #     The blend function used when rendering the surfaces (read-write)
+    #     """
+    #     return self._blend_func
 
-    @blend_func.setter
-    def blend_func(self, value: Tuple[int, int, int, int]):
-        self._blend_func = value
+    # @blend_func.setter
+    # def blend_func(self, value: Tuple[int, int, int, int]):
+    #     self._blend_func = value
 
     def debug(self):
         """Walks through all widgets of a UIManager and prints out the rect"""

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -372,28 +372,6 @@ class UIManager(EventDispatcher, UIWidgetParent):
     def rect(self) -> Rect:  # type: ignore
         return Rect(0, 0, *self.window.get_size())
 
-    # @property
-    # def blend_func_surface(self) -> Tuple[int, int, int, int]:
-    #     """
-    #     The blend function used when rendering into surfaces (read-write)
-    #     """
-    #     return self._blend_func_surface
-
-    # @blend_func_surface.setter
-    # def blend_func_surface(self, value: Tuple[int, int, int, int]):
-    #     self._blend_func_surface = value
-
-    # @property
-    # def blend_func(self):
-    #     """
-    #     The blend function used when rendering the surfaces (read-write)
-    #     """
-    #     return self._blend_func
-
-    # @blend_func.setter
-    # def blend_func(self, value: Tuple[int, int, int, int]):
-    #     self._blend_func = value
-
     def debug(self):
         """Walks through all widgets of a UIManager and prints out the rect"""
         for index, layer in self.children.items():

--- a/arcade/resources/shaders/gui/surface_fs.glsl
+++ b/arcade/resources/shaders/gui/surface_fs.glsl
@@ -1,0 +1,10 @@
+#version 330
+
+uniform sampler2D ui_texture;
+
+in vec2 uv;
+out vec4 fragColor;
+
+void main() {
+    fragColor = texture(ui_texture, uv);
+}

--- a/arcade/resources/shaders/gui/surface_gs.glsl
+++ b/arcade/resources/shaders/gui/surface_gs.glsl
@@ -1,0 +1,60 @@
+#version 330
+
+layout (points) in;
+layout (triangle_strip, max_vertices = 4) out;
+
+uniform WindowBlock {
+    mat4 projection;
+    mat4 view;
+} window;
+
+uniform vec2 pos;
+uniform vec2 size;
+uniform vec4 area;
+
+out vec2 uv;
+
+void main() {
+    mat4 mvp = window.projection * window.view;    
+
+    // Clamp the area inside the surface
+    // This is the local area inside the surface
+    // Format is (x, y, width, height)
+    vec2 b1 = clamp(area.xy, vec2(0.0), size);
+    vec2 b2 = clamp(area.xy + area.zw, vec2(0.0), size);
+    vec4 l_area = vec4(
+        clamp(area.xy, vec2(0.0), size),
+        b2 - b1
+    );
+
+    // Create the 4 corners of the rectangle
+    // These are the final/global coordinates rendered
+    vec2 p_ll = pos + l_area.xy;
+    vec2 p_lr = pos + l_area.xy + vec2(l_area.z, 0.0);
+    vec2 p_ul = pos + l_area.xy + vec2(0, l_area.w);;
+    vec2 p_ur = pos + l_area.xy + l_area.zw;
+
+    // Calculate the UV coordinates
+    float bottom = l_area.y / size.y;
+    float left = l_area.x / size.x;
+    float top = (l_area.y + l_area.w) / size.y;
+    float right = (l_area.x + l_area.z) / size.x;
+
+    gl_Position = mvp * vec4(p_ll, 0.0, 1.0);
+    uv = vec2(left, bottom);
+    EmitVertex();
+
+    gl_Position = mvp * vec4(p_lr, 0.0, 1.0);
+    uv = vec2(right, bottom);
+    EmitVertex();
+
+    gl_Position = mvp * vec4(p_ul, 0.0, 1.0);
+    uv = vec2(left, top);
+    EmitVertex();
+
+    gl_Position = mvp * vec4(p_ur, 0.0, 1.0);
+    uv = vec2(right, top);
+    EmitVertex();
+
+    EndPrimitive();
+}

--- a/arcade/resources/shaders/gui/surface_vs.glsl
+++ b/arcade/resources/shaders/gui/surface_vs.glsl
@@ -1,0 +1,5 @@
+#version 330
+
+void main() {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}


### PR DESCRIPTION
* `Surface.draw` now takes an optional `(x, y, w, h)` area limiting what part of the surface is rendered. This is sometimes simer to use than setting a scissor box.
* `UIManager` now has a `camera`. This is activated when drawing the surfaces to the screen
* `Surface` now has a "draw" and "draw into" blend function that is automatically set internally to reduce the chance of alpha issues.
* Moved the surface shader source to files