### PR TITLE
GPU Collision Experiment

### DIFF
--- a/arcade/experimental/spritelist_gpu_collision.py
+++ b/arcade/experimental/spritelist_gpu_collision.py
@@ -1,0 +1,45 @@
+import arcade
+from pyglet import gl
+
+coin_path = ":resources:images/items/coinGold.png"
+
+class Test(arcade.Window):
+    def __init__(self):
+        super().__init__(800, 600)
+        self.time = 0
+        self.texture = arcade.load_texture(coin_path)
+        print(self.ctx.limits.POINT_SIZE_RANGE)
+        self.spritelist = arcade.SpriteList()
+        for y in range(0, 600, 100):
+            for x in range(0, 800, 100):
+                sprite = arcade.Sprite(self.texture)
+                sprite.center_x = 50 + x
+                sprite.center_y = 50 + y
+                self.spritelist.append(sprite)
+                self.spritelist._update_points(sprite)
+
+        # print(self.spritelist._hit_points_data[0:8 * 400])
+        self.pos = 0, 0
+
+    def on_draw(self):
+        self.clear()
+        self.spritelist.draw()
+        self.ctx.point_size = 4.0
+        gl.glLineWidth(2.0)
+        # self.spritelist.collision_program.set_uniform_safe("pos", self.pos)
+        self.spritelist.collision_program["point"] = self.pos
+        self.spritelist.draw_gpu_collision()
+        # self.spritelist.draw_hit_boxes(color=arcade.color.RED, line_thickness=2.0)
+        arcade.draw_rectangle_outline(*self.pos, 100, 100, arcade.color.WHITE, 2.0)
+
+    def on_update(self, delta_time):
+        self.time += delta_time
+        for i, sprite in enumerate(self.spritelist):
+            sprite.angle = i * 50 + self.time * 100
+
+    def on_mouse_motion(self, x: int, y: int, dx: int, dy: int):
+        self.pos = x, y
+
+
+if __name__ == "__main__":
+    Test().run()

--- a/arcade/resources/shaders/collision/spritelist_collision_fs.glsl
+++ b/arcade/resources/shaders/collision/spritelist_collision_fs.glsl
@@ -1,0 +1,8 @@
+#version 330
+
+in vec4 color;
+out vec4 fragColor;
+
+void main() {
+    fragColor = color;
+}

--- a/arcade/resources/shaders/collision/spritelist_collision_gs.glsl
+++ b/arcade/resources/shaders/collision/spritelist_collision_gs.glsl
@@ -23,9 +23,9 @@ in float v_angle[1];
 out vec4 color;
 
 // Read the hit box points from the texture
-vec2[8] read_hit_box_points(sampler2D smp, int slot) {
+vec2[NUM_POINTS] read_hit_box_points(sampler2D smp, int slot) {
     slot *= 4;
-    return vec2[8](
+    return vec2[NUM_POINTS](
         texelFetch(smp, ivec2(slot, 0.0), 0).xy,
         texelFetch(smp, ivec2(slot, 0.0), 0).zw,
         texelFetch(smp, ivec2(slot + 1, 0.0), 0).xy,
@@ -64,6 +64,7 @@ void main() {
     for (int i = 0; i < NUM_POINTS; i++) {
         p[i] = rot * p[i] + pos;
     }
+    // Create box collider from the point
     vec2 collider[4] = vec2[4](
         point + vec2(50, 50.0),
         point + vec2(50.0, -50.0),
@@ -71,13 +72,13 @@ void main() {
         point + vec2(-50, 50)
     );
 
-    // color = vec4(1.0, 0.0, 0.0, 1.0);
+    // Default color
     color = vec4(0.0, 0.0, 0.0, .0);
 
     // Check if the point is inside the hit box
     bool found = false;
     for (int c = 0; c < 4; c++) {
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < NUM_POINTS; i++) {
             if (line_intersects(p[i], p[(i + 1) % 8], collider[c], collider[(c + 1) % 4])) {
                 color = vec4(1.0, 1.0, 1.0, 1.0);
                 found = true;
@@ -89,44 +90,11 @@ void main() {
         }
     }
 
-    gl_Position = mvp * vec4(p[0], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[1], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[2], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[3], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[4], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[5], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[6], 0.0, 1.0);
-    EmitVertex();
-    gl_Position = mvp * vec4(p[7], 0.0, 1.0);
-    EmitVertex();
+    for (int i = 0; i < NUM_POINTS; i++) {
+        gl_Position = mvp * vec4(p[i], 0.0, 1.0);
+        EmitVertex();
+    }
     gl_Position = mvp * vec4(p[0], 0.0, 1.0);
     EmitVertex();
     EndPrimitive();
-
-    // AABB lies
-    // vec2 min_point = vec2(0.0);
-    // vec2 max_point = vec2(0.0);
-    // get_bbox_for_points(p, min_point, max_point);
-
-    // // Upper right
-    // gl_Position = mvp * vec4(pos + max_point, 0.0, 1.0);
-    // EmitVertex();
-    // // Lower right
-    // gl_Position = mvp * vec4(pos + vec2(max_point.x, min_point.y), 0.0, 1.0);
-    // EmitVertex();
-    // // Lower left
-    // gl_Position = mvp * vec4(pos + min_point, 0.0, 1.0);
-    // EmitVertex();
-    // // Upper left
-    // gl_Position = mvp * vec4(pos + vec2(min_point.x, max_point.y), 0.0, 1.0);
-    // EmitVertex();
-    // // Upper right (repeat, complete strip)
-    // gl_Position = mvp * vec4(pos + max_point, 0.0, 1.0);
-    // EmitVertex();
 }

--- a/arcade/resources/shaders/collision/spritelist_collision_gs.glsl
+++ b/arcade/resources/shaders/collision/spritelist_collision_gs.glsl
@@ -1,0 +1,132 @@
+#version 330
+
+#define NUM_POINTS 8
+
+layout (points) in;
+layout (line_strip, max_vertices = 16) out;
+
+// Texture containing the hit box points
+uniform sampler2D hit_box_point_tex;
+// Number of hit box points
+float num_hit_box_points;
+
+// The point to pick sprites from
+uniform vec2 point;
+
+uniform WindowBlock {
+    mat4 projection;
+    mat4 view;
+} window;
+
+in vec2 v_size[1];
+in float v_angle[1];
+out vec4 color;
+
+// Read the hit box points from the texture
+vec2[8] read_hit_box_points(sampler2D smp, int slot) {
+    slot *= 4;
+    return vec2[8](
+        texelFetch(smp, ivec2(slot, 0.0), 0).xy,
+        texelFetch(smp, ivec2(slot, 0.0), 0).zw,
+        texelFetch(smp, ivec2(slot + 1, 0.0), 0).xy,
+        texelFetch(smp, ivec2(slot + 1, 0.0), 0).zw,
+        texelFetch(smp, ivec2(slot + 2, 0.0), 0).xy,
+        texelFetch(smp, ivec2(slot + 2, 0.0), 0).zw,
+        texelFetch(smp, ivec2(slot + 3, 0.0), 0).xy,
+        texelFetch(smp, ivec2(slot + 3, 0.0), 0).zw
+    );
+}
+
+bool line_intersects(vec2 p1, vec2 p2, vec2 p3, vec2 p4) {
+    float d = (p4.y - p3.y) * (p2.x - p1.x) - (p4.x - p3.x) * (p2.y - p1.y);
+    if (d == 0.0) {
+        return false;
+    }
+    float u = ((p4.x - p3.x) * (p1.y - p3.y) - (p4.y - p3.y) * (p1.x - p3.x)) / d;
+    float v = ((p2.x - p1.x) * (p1.y - p3.y) - (p2.y - p1.y) * (p1.x - p3.x)) / d;
+    return (u >= 0.0 && u <= 1.0) && (v >= 0.0 && v <= 1.0);
+}
+
+void main() {
+    // Unpack in values to more readable variables
+    vec2 pos = gl_in[0].gl_Position.xy;
+    vec2 size = v_size[0];
+    float angle = radians(v_angle[0]);
+    mat2 rot = mat2(
+        cos(angle), sin(angle),
+        -sin(angle), cos(angle)
+    );
+    mat4 mvp = window.projection * window.view;
+
+    // Get the hit box points from the texture
+    vec2[8] p = read_hit_box_points(hit_box_point_tex, int(gl_PrimitiveIDIn));
+    // Move and roate the points
+    for (int i = 0; i < NUM_POINTS; i++) {
+        p[i] = rot * p[i] + pos;
+    }
+    vec2 collider[4] = vec2[4](
+        point + vec2(50, 50.0),
+        point + vec2(50.0, -50.0),
+        point + vec2(-50, -50),
+        point + vec2(-50, 50)
+    );
+
+    // color = vec4(1.0, 0.0, 0.0, 1.0);
+    color = vec4(0.0, 0.0, 0.0, .0);
+
+    // Check if the point is inside the hit box
+    bool found = false;
+    for (int c = 0; c < 4; c++) {
+        for (int i = 0; i < 8; i++) {
+            if (line_intersects(p[i], p[(i + 1) % 8], collider[c], collider[(c + 1) % 4])) {
+                color = vec4(1.0, 1.0, 1.0, 1.0);
+                found = true;
+                break;
+            }
+            if (found) {
+                break;
+            }
+        }
+    }
+
+    gl_Position = mvp * vec4(p[0], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[1], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[2], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[3], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[4], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[5], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[6], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[7], 0.0, 1.0);
+    EmitVertex();
+    gl_Position = mvp * vec4(p[0], 0.0, 1.0);
+    EmitVertex();
+    EndPrimitive();
+
+    // AABB lies
+    // vec2 min_point = vec2(0.0);
+    // vec2 max_point = vec2(0.0);
+    // get_bbox_for_points(p, min_point, max_point);
+
+    // // Upper right
+    // gl_Position = mvp * vec4(pos + max_point, 0.0, 1.0);
+    // EmitVertex();
+    // // Lower right
+    // gl_Position = mvp * vec4(pos + vec2(max_point.x, min_point.y), 0.0, 1.0);
+    // EmitVertex();
+    // // Lower left
+    // gl_Position = mvp * vec4(pos + min_point, 0.0, 1.0);
+    // EmitVertex();
+    // // Upper left
+    // gl_Position = mvp * vec4(pos + vec2(min_point.x, max_point.y), 0.0, 1.0);
+    // EmitVertex();
+    // // Upper right (repeat, complete strip)
+    // gl_Position = mvp * vec4(pos + max_point, 0.0, 1.0);
+    // EmitVertex();
+}

--- a/arcade/resources/shaders/collision/spritelist_collision_vs.glsl
+++ b/arcade/resources/shaders/collision/spritelist_collision_vs.glsl
@@ -1,0 +1,15 @@
+#version 330
+
+in vec3 in_pos;
+in vec2 in_size;
+in float in_angle;
+
+out vec2 v_pos;
+out vec2 v_size;
+out float v_angle;
+
+void main() {
+    v_size = in_size;
+    v_angle = in_angle;
+    gl_Position = vec4(in_pos, 1.0);
+}


### PR DESCRIPTION
Experiment supporting GPU collision checking in the Spritelist. This has nothing to do with the spatial hash. Ignore the branch name.

* The idea is to write the original untransformed hit box into a floating point texture.
* The shader will have access to all the sprite properties for free and can (on the fly) transform the hit box points and do polygon intersection (really just line intersection checks).
* Running this collision check is of course expensive, but it completely eliminates the need for sprites to calculate adjusted hit box points and dealing with a spatial hash.
* Spritelists with this collision type will have a much lower capacity. Possibly 1024 as a cap.
* Another challenge is that the user needs to pre-determine the max number of hit box points the sprites have. We can assume 4-8 points if the simple hit box algo is used for now.
* This collision type is better suited for spritelist vs spritelist collision (collision with self or other list)