### PR TITLE
Rename flip transforms

### DIFF
--- a/arcade/examples/platform_tutorial/17_views.py
+++ b/arcade/examples/platform_tutorial/17_views.py
@@ -60,7 +60,7 @@ def load_texture_pair(filename):
     """
     texture = arcade.load_texture(filename)
     return [
-        texture, texture.flip_left_to_right()
+        texture, texture.flip_left_right()
     ]
 
 

--- a/arcade/experimental/texture_transforms.py
+++ b/arcade/experimental/texture_transforms.py
@@ -7,8 +7,8 @@ TRANSFORMS = [
     transforms.Rotate90Transform,
     transforms.Rotate180Transform,
     transforms.Rotate270Transform,
-    transforms.FlipLeftToRightTransform,
-    transforms.FlipTopToBottomTransform,
+    transforms.FlipLeftRightTransform,
+    transforms.FlipTopBottomTransform,
     transforms.TransposeTransform,
     transforms.TransverseTransform,
 ]

--- a/arcade/texture/loading.py
+++ b/arcade/texture/loading.py
@@ -172,7 +172,7 @@ def load_texture_pair(
     """
     LOG.info("load_texture_pair: %s ", file_name)
     texture = load_texture(file_name, hit_box_algorithm=hit_box_algorithm)
-    return texture, texture.flip_left_to_right()
+    return texture, texture.flip_left_right()
 
 
 def load_textures(
@@ -238,9 +238,9 @@ def load_textures(
             _cache.texture_cache.put(sub_texture)
 
         if mirrored:
-            sub_texture = sub_texture.flip_left_to_right()
+            sub_texture = sub_texture.flip_left_right()
         if flipped:
-            sub_texture = sub_texture.flip_top_to_bottom()
+            sub_texture = sub_texture.flip_top_bottom()
 
         sub_texture.file_path = file_name
         sub_texture.crop_values = x, y, width, height

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -10,8 +10,8 @@ import PIL.ImageDraw
 from arcade.types import Color
 from arcade.texture.transforms import (
     Transform,
-    FlipLeftToRightTransform,
-    FlipTopToBottomTransform,
+    FlipLeftRightTransform,
+    FlipTopBottomTransform,
     Rotate90Transform,
     Rotate180Transform,
     Rotate270Transform,
@@ -493,7 +493,7 @@ class Texture:
         """
         _cache.texture_cache.delete(self)
 
-    def flip_left_to_right(self) -> "Texture":
+    def flip_left_right(self) -> "Texture":
         """
         Flip the texture left to right / horizontally.
 
@@ -503,9 +503,9 @@ class Texture:
 
         :return: Texture 
         """
-        return self.transform(FlipLeftToRightTransform)
+        return self.transform(FlipLeftRightTransform)
 
-    def flip_top_to_bottom(self) -> "Texture":
+    def flip_top_bottom(self) -> "Texture":
         """
         Flip the texture top to bottom / vertically.
 
@@ -515,7 +515,7 @@ class Texture:
 
         :return: Texture
         """
-        return self.transform(FlipTopToBottomTransform)
+        return self.transform(FlipTopBottomTransform)
 
     def flip_horizontally(self) -> "Texture":
         """
@@ -527,7 +527,7 @@ class Texture:
 
         :return: Texture
         """
-        return self.flip_left_to_right()
+        return self.flip_left_right()
 
     def flip_vertically(self) -> "Texture":
         """
@@ -539,7 +539,7 @@ class Texture:
 
         :return: Texture
         """
-        return self.flip_top_to_bottom()
+        return self.flip_top_bottom()
 
     def flip_diagonally(self) -> "Texture":
         """

--- a/arcade/texture/transforms.py
+++ b/arcade/texture/transforms.py
@@ -137,7 +137,7 @@ class Rotate270Transform(Transform):
         return tuple(rotate_point(point[0], point[1], 0, 0, -270) for point in points)
 
 
-class FlipLeftToRightTransform(Transform):
+class FlipLeftRightTransform(Transform):
     """
     Flip texture horizontally / left to right.
     """
@@ -155,7 +155,7 @@ class FlipLeftToRightTransform(Transform):
         return tuple((-point[0], point[1]) for point in points)
 
 
-class FlipTopToBottomTransform(Transform):
+class FlipTopBottomTransform(Transform):
     """
     Flip texture vertically / top to bottom.
     """
@@ -188,7 +188,7 @@ class TransposeTransform(Transform):
     def transform_hit_box_points(
         points: PointList,
     ) -> PointList:
-        points = FlipLeftToRightTransform.transform_hit_box_points(points)
+        points = FlipLeftRightTransform.transform_hit_box_points(points)
         points = Rotate270Transform.transform_hit_box_points(points)
         return points
 
@@ -208,7 +208,7 @@ class TransverseTransform(Transform):
     def transform_hit_box_points(
         points: PointList,
     ) -> PointList:
-        points = FlipLeftToRightTransform.transform_hit_box_points(points)
+        points = FlipLeftRightTransform.transform_hit_box_points(points)
         points = Rotate90Transform.transform_hit_box_points(points)
         return points
 

--- a/tests/tilemap_tests/test_rotation_flip.py
+++ b/tests/tilemap_tests/test_rotation_flip.py
@@ -34,32 +34,32 @@ def test_rotation_mirror(window):
     # Horizontal flip
     wall = wall_list[1]
     assert wall.position == (192, 64)
-    assert wall.texture._vertex_order == tt.FlipLeftToRightTransform.order
+    assert wall.texture._vertex_order == tt.FlipLeftRightTransform.order
 
     # Transpose and flipped horizontally
     wall = wall_list[2]
     assert wall.position == (448, 64)
-    assert wall.texture._vertex_order == tt.FlipLeftToRightTransform.transform_vertex_order(tt.TransposeTransform.order)
+    assert wall.texture._vertex_order == tt.FlipLeftRightTransform.transform_vertex_order(tt.TransposeTransform.order)
 
     # Transposed, flipped vertically and horizontally
     wall = wall_list[3]
     assert wall.position == (576, 64)
-    assert wall.texture._vertex_order == _transform(tt.TransposeTransform, tt.FlipLeftToRightTransform, tt.FlipTopToBottomTransform)
+    assert wall.texture._vertex_order == _transform(tt.TransposeTransform, tt.FlipLeftRightTransform, tt.FlipTopBottomTransform)
 
     # Horizontal flip and flipped vertically
     wall = wall_list[4]
     assert wall.position == (832, 64)
-    assert wall.texture._vertex_order == _transform(tt.FlipLeftToRightTransform, tt.FlipTopToBottomTransform)
+    assert wall.texture._vertex_order == _transform(tt.FlipLeftRightTransform, tt.FlipTopBottomTransform)
 
     # Vertical flip
     wall = wall_list[5]
     assert wall.position == (960, 64)
-    assert wall.texture._vertex_order == tt.FlipTopToBottomTransform.order
+    assert wall.texture._vertex_order == tt.FlipTopBottomTransform.order
 
     # Transposed and flipped vertically
     wall = wall_list[6]
     assert wall.position == (1216, 64)
-    assert wall.texture._vertex_order == _transform(tt.TransposeTransform, tt.FlipTopToBottomTransform)
+    assert wall.texture._vertex_order == _transform(tt.TransposeTransform, tt.FlipTopBottomTransform)
 
     # Transposed
     wall = wall_list[7]

--- a/tests/unit2/test_load_textures.py
+++ b/tests/unit2/test_load_textures.py
@@ -16,7 +16,7 @@ def test_load_textures(window):
 
     texture = arcade.load_texture(":resources:images/animated_characters/robot/robot_idle.png")
     player.stand_right_textures = [texture]
-    player.stand_left_textures = [texture.flip_left_to_right()]
+    player.stand_left_textures = [texture.flip_left_right()]
 
     player.walk_right_textures = [
         arcade.load_texture(":resources:images/animated_characters/robot/robot_walk0.png"),
@@ -28,7 +28,7 @@ def test_load_textures(window):
         arcade.load_texture(":resources:images/animated_characters/robot/robot_walk6.png"),
         arcade.load_texture(":resources:images/animated_characters/robot/robot_walk7.png")
     ]
-    player.walk_left_textures = [tex.flip_left_to_right() for tex in player.walk_right_textures]
+    player.walk_left_textures = [tex.flip_left_right() for tex in player.walk_right_textures]
 
     player.texture_change_distance = 20
 

--- a/tests/unit2/test_sprite_animated_old.py
+++ b/tests/unit2/test_sprite_animated_old.py
@@ -20,7 +20,7 @@ def test_sprite_animated_old(window: arcade.Window):
     player.stand_right_textures = []
     player.stand_right_textures.append(
         arcade.load_texture(":resources:images/animated_characters/female_person/femalePerson_idle.png"))
-    player.stand_left_textures = [tex.flip_left_to_right() for tex in player.stand_right_textures]
+    player.stand_left_textures = [tex.flip_left_right() for tex in player.stand_right_textures]
 
     player.walk_right_textures = []
 
@@ -33,7 +33,7 @@ def test_sprite_animated_old(window: arcade.Window):
     player.walk_right_textures.append(
         arcade.load_texture(":resources:images/animated_characters/female_person/femalePerson_walk3.png"))
 
-    player.walk_left_textures = [tex.flip_left_to_right() for tex in player.walk_right_textures]
+    player.walk_left_textures = [tex.flip_left_right() for tex in player.walk_right_textures]
 
     player.texture_change_distance = 20
 

--- a/tests/unit2/test_texture_transform_render.py
+++ b/tests/unit2/test_texture_transform_render.py
@@ -9,8 +9,8 @@ from arcade.texture.transforms import (
     Rotate90Transform,
     Rotate180Transform,
     Rotate270Transform,
-    FlipLeftToRightTransform,
-    FlipTopToBottomTransform,
+    FlipLeftRightTransform,
+    FlipTopBottomTransform,
     TransposeTransform,
     TransverseTransform,
 )
@@ -19,8 +19,8 @@ TRANSFORMS = [
     (Rotate90Transform, Image.Transpose.ROTATE_270, 1),
     (Rotate180Transform, Image.Transpose.ROTATE_180, 2),
     (Rotate270Transform, Image.Transpose.ROTATE_90, 3),
-    (FlipLeftToRightTransform, Image.FLIP_LEFT_RIGHT, 4),
-    (FlipTopToBottomTransform, Image.FLIP_TOP_BOTTOM, 5),
+    (FlipLeftRightTransform, Image.FLIP_LEFT_RIGHT, 4),
+    (FlipTopBottomTransform, Image.FLIP_TOP_BOTTOM, 5),
     (TransposeTransform, Image.TRANSPOSE, 6),
     (TransverseTransform, Image.TRANSVERSE, 7)
 ]

--- a/tests/unit2/test_texture_transform_values.py
+++ b/tests/unit2/test_texture_transform_values.py
@@ -2,8 +2,8 @@ from arcade.texture.transforms import (
     Rotate90Transform,
     Rotate180Transform,
     Rotate270Transform,
-    FlipLeftToRightTransform,
-    FlipTopToBottomTransform,
+    FlipLeftRightTransform,
+    FlipTopBottomTransform,
     TransposeTransform,
     TransverseTransform,
     VertexOrder,
@@ -59,32 +59,32 @@ def test_rotate270_transform():
     assert result == (1, 3, 0, 2)
 
 
-def test_flip_left_to_right_transform():
+def test_flip_left_right_transform():
     # Flip left to right
-    result = FlipLeftToRightTransform.transform_hit_box_points(HIT_BOX_POINTS)
+    result = FlipLeftRightTransform.transform_hit_box_points(HIT_BOX_POINTS)
     assert result == ((64.0, -64.0), (-64.0, -64.0), (-64.0, 64.0), (64.0, 64.0))
     # Flip back
-    result = FlipLeftToRightTransform.transform_hit_box_points(result)
+    result = FlipLeftRightTransform.transform_hit_box_points(result)
     assert result == HIT_BOX_POINTS
 
     # Test vertex order
-    result = FlipLeftToRightTransform.transform_vertex_order(ORDER)
+    result = FlipLeftRightTransform.transform_vertex_order(ORDER)
     assert result == (1, 0, 3, 2)
-    result = FlipLeftToRightTransform.transform_vertex_order(result)
+    result = FlipLeftRightTransform.transform_vertex_order(result)
     assert result == ORDER
 
 
-def test_flip_top_to_bottom_transform():
+def test_flip_top_bottom_transform():
     # Flip top to bottom
-    result = FlipTopToBottomTransform.transform_hit_box_points(HIT_BOX_POINTS)
+    result = FlipTopBottomTransform.transform_hit_box_points(HIT_BOX_POINTS)
     assert result == ((-64.0, 64.0), (64.0, 64.0), (64.0, -64.0), (-64.0, -64.0))
     # Flip back
-    result = FlipTopToBottomTransform.transform_hit_box_points(result)
+    result = FlipTopBottomTransform.transform_hit_box_points(result)
     assert result == HIT_BOX_POINTS
 
-    result = FlipTopToBottomTransform.transform_vertex_order(ORDER)
+    result = FlipTopBottomTransform.transform_vertex_order(ORDER)
     assert result == (2, 3, 0, 1)
-    result = FlipTopToBottomTransform.transform_vertex_order(result)
+    result = FlipTopBottomTransform.transform_vertex_order(result)
     assert result == ORDER
 
 


### PR DESCRIPTION
As discussed: Rename some of the flip methods

* flip_left_to_right -> flip_left_right
* flip_top_to_bottom -> flip_top_bottom
* LeftToRightTransform -> LeftRightTransform
* ToToBottomTransform -> TopBottomTransform

This is also in line with the transform names in Pillow.
