### PR TITLE
Add usage in the docstring for UIAnchorLayout

### DIFF
--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -22,6 +22,14 @@ class UIAnchorLayout(UILayout):
     - anchor_y: str = None - uses `self.default_anchor_y` as default
     - align_y: float = 0
 
+    Usage:
+
+    .. code::py
+        manager: UIManager
+        anchor = manager.add(UIAnchorLayout())
+
+        anchor.add(child=child, ...)
+
     """
 
     default_anchor_x = "center"

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -22,12 +22,11 @@ class UIAnchorLayout(UILayout):
     - anchor_y: str = None - uses `self.default_anchor_y` as default
     - align_y: float = 0
 
-    Usage:
+    Usage::
 
-    .. code::py
-        manager: UIManager
+        manager = UIManager()
+        manager.enable()
         anchor = manager.add(UIAnchorLayout())
-
         anchor.add(child=child, ...)
 
     """


### PR DESCRIPTION
https://discord.com/channels/458662222697070613/696054807840030740/1082248678850441286

The linked conversation shows someone trying to migrate to 3.0.0dev17 and facing unexpected result with `UIAnchorLayout`, As we have updated the usage of the class, I have added the current usage to the docstring.