### PR TITLE
Fix initial Sprite hitbox when dummy texture is used.

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -340,15 +340,11 @@ class BasicSprite:
 
     @property
     def texture(self) -> Texture:
-        # TODO: Remove this when we require a texture
-        if not self._texture:
-            raise ValueError("Sprite has not texture")
         return self._texture
 
     @texture.setter
     def texture(self, texture: Texture):
-        """Sets texture by texture id. Should be renamed but keeping
-        this for backwards compatibility."""
+        """Set the texture for this sprite"""
         if texture == self._texture:
             return
 

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -279,7 +279,6 @@ class Sprite(BasicSprite, PymunkMixin):
         """Set the velocity in the y plane of the sprite."""
         self._velocity = self._velocity[0], new_value
 
-
     @property
     def hit_box(self) -> PointList:
         return self.get_hit_box()
@@ -287,6 +286,31 @@ class Sprite(BasicSprite, PymunkMixin):
     @hit_box.setter
     def hit_box(self, points: PointList):
         self.set_hit_box(points)
+
+    @property
+    def texture(self) -> Texture:
+        """Get or set the texture for this sprite"""
+        return self._texture
+
+    @texture.setter
+    def texture(self, texture: Texture):
+        if texture == self._texture:
+            return
+
+        if __debug__ and not isinstance(texture, Texture):
+            raise TypeError(f"The 'texture' parameter must be an instance of arcade.Texture,"
+                            f" but is an instance of '{type(texture)}'.")
+
+        # If sprite is using default texture, update the hit box
+        if self._texture is get_default_texture():
+            self.hit_box = texture.hit_box_points
+
+        self._texture = texture
+        self._width = texture.width * self._scale[0]
+        self._height = texture.height * self._scale[1]
+        self.update_spatial_hash()
+        for sprite_list in self.sprite_lists:
+            sprite_list._update_texture(self)
 
     @property
     def properties(self) -> Dict[str, Any]:

--- a/arcade/texture/tools.py
+++ b/arcade/texture/tools.py
@@ -4,6 +4,7 @@ from .texture import ImageData, Texture
 from arcade.types import Point
 from arcade import cache
 
+_DEFAULT_TEXTURE = None
 _DEFAULT_IMAGE_SIZE = (128, 128)
 
 
@@ -23,15 +24,15 @@ def get_default_texture(size: Point = _DEFAULT_IMAGE_SIZE) -> Texture:
     :param size: Size of the texture to create
     :return: The default texture.
     """
-    name = f"arcade-default-texture|{size}"
-    algo = arcade.hitbox.algo_bounding_box
-    texture = cache.texture_cache.get_with_config(name, algo)
-    if texture:
-        return texture
+    global _DEFAULT_TEXTURE
+    if _DEFAULT_TEXTURE:
+        return _DEFAULT_TEXTURE
 
-    texture = Texture(get_default_image(size), hit_box_algorithm=algo)
-    cache.texture_cache.put(texture)
-    return texture
+    _DEFAULT_TEXTURE = Texture(
+        get_default_image(size),
+        hit_box_algorithm=arcade.hitbox.algo_bounding_box,
+    )
+    return _DEFAULT_TEXTURE
 
 
 def get_default_image(size: Point = _DEFAULT_IMAGE_SIZE) -> ImageData:

--- a/tests/unit/texture/test_texture_tools.py
+++ b/tests/unit/texture/test_texture_tools.py
@@ -26,10 +26,3 @@ def test_default_texture():
 
     # Ensure we get cached version
     assert id(get_default_texture()) == id(texture)
-    cleanup_texture_cache()
-    assert id(get_default_texture()) != id(texture)
-
-
-if __name__ == "__main__":
-    test_default_image()
-    test_default_texture()


### PR DESCRIPTION
When making a sprite with no texture it gets the default texture hit box. This is not intuitive.