### PR TITLE
Camera rollback

### DIFF
--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -56,7 +56,7 @@ class MyGame(arcade.Window):
                             DEFAULT_SCREEN_HEIGHT - MINIMAP_HEIGHT,
                             MINIMAP_WIDTH, MINIMAP_HEIGHT)
         minimap_projection = (0, MAP_PROJECTION_WIDTH, 0, MAP_PROJECTION_HEIGHT)
-        self.camera_minimap = arcade.SimpleCamera(viewport=minimap_viewport, projection=minimap_projection)
+        self.camera_minimap = arcade.Camera(viewport=minimap_viewport, projection=minimap_projection)
 
         # Set up the player
         self.player_sprite = None
@@ -66,7 +66,7 @@ class MyGame(arcade.Window):
         # Camera for sprites, and one for our GUI
         viewport = (0, 0, DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT)
         projection = (0, DEFAULT_SCREEN_WIDTH, 0, DEFAULT_SCREEN_HEIGHT)
-        self.camera_sprites = arcade.SimpleCamera(viewport=viewport, projection=projection)
+        self.camera_sprites = arcade.Camera(viewport=viewport, projection=projection)
         self.camera_gui = arcade.SimpleCamera(viewport=viewport)
 
         self.selected_camera = self.camera_minimap


### PR DESCRIPTION
This just rollback the camera implementation.

Zoom works as expected but is disconnected from the projection to view ratio.

Solves issue #1493 

Note that SimpleCamera no longer have zoom (as was planned initialy)
