### PR TITLE
Remove a meaningless entry in types

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -30,7 +30,6 @@ IPoint = Tuple[int, int]
 Vector = Point
 NamedPoint = namedtuple("NamedPoint", ["x", "y"])
 
-Sequence[int]
 PointList = Sequence[Point]
 Rect = Union[Tuple[int, int, int, int], List[int]]  # x, y, width, height
 RectList = Union[Tuple[Rect, ...], List[Rect]]


### PR DESCRIPTION
This PR removes a leftover line that doesn't get bound to a name from our custom type definitions.