### PR TITLE
Raise error on invalid value for emit_interval in class EmitInterval

### DIFF
--- a/arcade/particles/emitter.py
+++ b/arcade/particles/emitter.py
@@ -51,6 +51,8 @@ class EmitMaintainCount(EmitController):
 class EmitInterval(EmitController):
     """Base class used to configure an Emitter to have a constant rate of emitting. Will emit indefinitely."""
     def __init__(self, emit_interval: float):
+        if emit_interval <= 0:
+            raise ValueError("Invalid value for emit_interval. Must be larger than 0.")
         self._emit_interval = emit_interval
         self._carryover_time = 0.0
 


### PR DESCRIPTION
Here is my attempt at fixing this issue (https://github.com/pythonarcade/arcade/issues/1628).
What do you think?
