### PR TITLE
Fix broken early exit in BasicSprite.color setter

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -327,7 +327,7 @@ class BasicSprite:
     def color(self, color: RGBA):
         if len(color) == 4:
             if (
-                self._color == color[0]
+                self._color[0] == color[0]
                 and self._color[1] == color[1]
                 and self._color[2] == color[2]
                 and self._color[3] == color[3]
@@ -336,7 +336,7 @@ class BasicSprite:
             self._color = color[0], color[1], color[2], color[3]
         elif len(color) == 3:
             if (
-                self._color == color[0]
+                self._color[0] == color[0]
                 and self._color[1] == color[1]
                 and self._color[2] == color[2]
             ):


### PR DESCRIPTION
tl;dr this PR fixes a missing index which makes early exit never happen

1. `self._color` is a 4-length tuple
2. `color[0]` is expected to be an int
3. Early exit will never happen because a 4-length tuple to an int will always be false

Discovered while working on #1639 