### PR TITLE
Remove Python 2 build flag from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,6 @@ version = {attr = "arcade.version.VERSION"}
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.distutils.bdist_wheel]
-universal = true
 
 [tool.ruff]
 # --- Description of what we ignore ---


### PR DESCRIPTION
Per discord discussion with einarf and [the python packaging doc](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels), the universal flag is what's causing our wheels to be marked as Python 2 compatible. This PR should remove it from our project.