### PR TITLE
Deprecate `lrtb` (left, right, top, bottom)

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -126,7 +126,9 @@ from .draw_commands import draw_line
 from .draw_commands import draw_line_strip
 from .draw_commands import draw_lines
 from .draw_commands import draw_lrtb_rectangle_filled
+from .draw_commands import draw_lrbt_rectangle_filled
 from .draw_commands import draw_lrtb_rectangle_outline
+from .draw_commands import draw_lrbt_rectangle_outline
 from .draw_commands import draw_lrwh_rectangle_textured
 from .draw_commands import draw_parabola_filled
 from .draw_commands import draw_parabola_outline
@@ -301,7 +303,9 @@ __all__ = [
     'draw_line_strip',
     'draw_lines',
     'draw_lrtb_rectangle_filled',
+    'draw_lrbt_rectangle_filled',
     'draw_lrtb_rectangle_outline',
+    'draw_lrbt_rectangle_outline',
     'draw_lrwh_rectangle_textured',
     'draw_parabola_filled',
     'draw_parabola_outline',

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -620,7 +620,7 @@ def draw_triangle_outline(x1: float, y1: float,
 
 @warning(
     message=\
-        "Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_outline.",
+        "`draw_lrtb_rectangle_outline` is deprecated. Use `draw_lrbt_rectangle_outline` instead.",
     warning_type=NameChangeWarning,
 )
 def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
@@ -743,7 +743,7 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
 
 @warning(
     message=\
-        "Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_filled.",
+        "`draw_lrtb_rectangle_filled` is deprecated. Use `draw_lrbt_rectangle_filled` instead.",
     warning_type =NameChangeWarning,
 )
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -619,8 +619,9 @@ def draw_triangle_outline(x1: float, y1: float,
 
 
 @warning(
-    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_outline.",
-    warning_type=NameChangeWarning
+    message=\
+        "Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_outline.",
+    warning_type=NameChangeWarning,
 )
 def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
                                 bottom: float, color: Color,
@@ -741,8 +742,9 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
 
 
 @warning(
-    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_filled.",
-    warning_type=NameChangeWarning
+    message=\
+        "Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_filled.",
+    warning_type =NameChangeWarning,
 )
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
                                bottom: float, color: Color):

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -753,7 +753,7 @@ def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
     Draw a rectangle by specifying left, right, top and bottom edges.
 
     .. deprecated:: 3.0
-        Use :py:func:`draw_lrbt_rectangle_filled` instead!
+       Use :py:func:`draw_lrbt_rectangle_filled` instead!
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -656,12 +656,12 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
 def draw_lrbt_rectangle_outline(left: float, right: float, bottom: float, top: float, color: Color,
                                 border_width: float = 1):
     """
-    Draw a rectangle by specifying left, right, top, and bottom edges.
+    Draw a rectangle by specifying left, right, bottom, and top edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
-    :param float top: The y coordinate of the top of the rectangle.
     :param float bottom: The y coordinate of the rectangle bottom.
+    :param float top: The y coordinate of the top of the rectangle.
     :param Color color: The color of the rectangle.
     :param float border_width: The width of the border in pixels. Defaults to one.
     :Raises AttributeError: Raised if left > right or top < bottom.
@@ -771,12 +771,12 @@ def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
 
 def draw_lrbt_rectangle_filled(left: float, right: float, bottom: float, top: float, color: Color):
     """
-    Draw a rectangle by specifying left, right, top, and bottom edges.
+    Draw a rectangle by specifying left, right, bottom, and top edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
-    :param float top: The y coordinate of the top of the rectangle.
     :param float bottom: The y coordinate of the rectangle bottom.
+    :param float top: The y coordinate of the top of the rectangle.
     :param Color color: The color of the rectangle.
     :Raises AttributeError: Raised if left > right or top < bottom.
     """

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -25,7 +25,7 @@ from arcade import (
     Texture,
     get_window,
 )
-from arcade.utils import warning, NameChangeWarning
+from arcade.utils import warning, ReplacementWarning
 
 # --- BEGIN ARC FUNCTIONS # # #
 
@@ -619,7 +619,7 @@ def draw_triangle_outline(x1: float, y1: float,
 
 
 @warning(
-    warning_type=NameChangeWarning,
+    warning_type=ReplacementWarning,
     new_name="draw_lrbt_rectangle_outline"
 )
 def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
@@ -637,15 +637,15 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
     :param float bottom: The y coordinate of the rectangle bottom.
     :param Color color: The color of the rectangle.
     :param float border_width: The width of the border in pixels. Defaults to one.
-    :Raises AttributeError: Raised if left > right or top < bottom.
+    :Raises ValueError: Raised if left > right or top < bottom.
 
     """
     if left > right:
-        raise AttributeError("Left coordinate must be less than or equal to "
+        raise ValueError("Left coordinate must be less than or equal to "
                              "the right coordinate")
 
     if bottom > top:
-        raise AttributeError("Bottom coordinate must be less than or equal to "
+        raise ValueError("Bottom coordinate must be less than or equal to "
                              "the top coordinate")
 
     center_x = (left + right) / 2
@@ -744,7 +744,7 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
 
 
 @warning(
-    warning_type=NameChangeWarning,
+    warning_type=ReplacementWarning,
     new_name="draw_lrbt_rectangle_filled"
 )
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
@@ -784,13 +784,13 @@ def draw_lrbt_rectangle_filled(left: float, right: float, bottom: float, top: fl
     :param float bottom: The y coordinate of the rectangle bottom.
     :param float top: The y coordinate of the top of the rectangle.
     :param Color color: The color of the rectangle.
-    :Raises AttributeError: Raised if left > right or top < bottom.
+    :Raises ValueError: Raised if left > right or top < bottom.
     """
     if left > right:
-        raise AttributeError(f"Left coordinate {left} must be less than or equal to the right coordinate {right}")
+        raise ValueError(f"Left coordinate {left} must be less than or equal to the right coordinate {right}")
 
     if bottom > top:
-        raise AttributeError(f"Bottom coordinate {bottom} must be less than or equal to the top coordinate {top}")
+        raise ValueError(f"Bottom coordinate {bottom} must be less than or equal to the top coordinate {top}")
 
     center_x = (left + right) / 2
     center_y = (top + bottom) / 2

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -629,7 +629,7 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
     Draw a rectangle by specifying left, right, top and bottom edges.
 
     .. deprecated:: 3.0
-        Use :py:func:`draw_lrbt_rectangle_outline` instead!
+       Use :py:func:`draw_lrbt_rectangle_outline` instead!
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -626,7 +626,7 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
                                 bottom: float, color: Color,
                                 border_width: float = 1):
     """
-    Draw a rectangle by specifying left, right, top, and bottom edges.
+    Draw a rectangle by specifying left, right, top and bottom edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
@@ -656,7 +656,7 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
 def draw_lrbt_rectangle_outline(left: float, right: float, bottom: float, top: float, color: Color,
                                 border_width: float = 1):
     """
-    Draw a rectangle by specifying left, right, bottom, and top edges.
+    Draw a rectangle by specifying left, right, bottom and top edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
@@ -747,7 +747,7 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
                                bottom: float, color: Color):
     """
-    Draw a rectangle by specifying left, right, top, and bottom edges.
+    Draw a rectangle by specifying left, right, top and bottom edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
@@ -771,7 +771,7 @@ def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
 
 def draw_lrbt_rectangle_filled(left: float, right: float, bottom: float, top: float, color: Color):
     """
-    Draw a rectangle by specifying left, right, bottom, and top edges.
+    Draw a rectangle by specifying left, right, bottom and top edges.
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -619,15 +619,17 @@ def draw_triangle_outline(x1: float, y1: float,
 
 
 @warning(
-    message=\
-        "`draw_lrtb_rectangle_outline` is deprecated. Use `draw_lrbt_rectangle_outline` instead.",
     warning_type=NameChangeWarning,
+    new_name="draw_lrbt_rectangle_outline"
 )
 def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
                                 bottom: float, color: Color,
                                 border_width: float = 1):
     """
     Draw a rectangle by specifying left, right, top and bottom edges.
+
+    .. deprecated:: 3.0
+        Use :py:func:`draw_lrbt_rectangle_outline` instead!
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.
@@ -742,14 +744,16 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
 
 
 @warning(
-    message=\
-        "`draw_lrtb_rectangle_filled` is deprecated. Use `draw_lrbt_rectangle_filled` instead.",
-    warning_type =NameChangeWarning,
+    warning_type=NameChangeWarning,
+    new_name="draw_lrbt_rectangle_filled"
 )
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
                                bottom: float, color: Color):
     """
     Draw a rectangle by specifying left, right, top and bottom edges.
+
+    .. deprecated:: 3.0
+        Use :py:func:`draw_lrbt_rectangle_filled` instead!
 
     :param float left: The x coordinate of the left edge of the rectangle.
     :param float right: The x coordinate of the right edge of the rectangle.

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -25,6 +25,7 @@ from arcade import (
     Texture,
     get_window,
 )
+from arcade.utils import warning, NameChangeWarning
 
 # --- BEGIN ARC FUNCTIONS # # #
 
@@ -617,6 +618,10 @@ def draw_triangle_outline(x1: float, y1: float,
 # --- BEGIN RECTANGLE FUNCTIONS # # #
 
 
+@warning(
+    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_outline.",
+    warning_type=NameChangeWarning
+)
 def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
                                 bottom: float, color: Color,
                                 border_width: float = 1):
@@ -632,7 +637,36 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
     :Raises AttributeError: Raised if left > right or top < bottom.
 
     """
+    if left > right:
+        raise AttributeError("Left coordinate must be less than or equal to "
+                             "the right coordinate")
 
+    if bottom > top:
+        raise AttributeError("Bottom coordinate must be less than or equal to "
+                             "the top coordinate")
+
+    center_x = (left + right) / 2
+    center_y = (top + bottom) / 2
+    width = right - left
+    height = top - bottom
+    draw_rectangle_outline(center_x, center_y, width, height, color,
+                           border_width)
+
+
+def draw_lrbt_rectangle_outline(left: float, right: float, bottom: float, top: float, color: Color,
+                                border_width: float = 1):
+    """
+    Draw a rectangle by specifying left, right, top, and bottom edges.
+
+    :param float left: The x coordinate of the left edge of the rectangle.
+    :param float right: The x coordinate of the right edge of the rectangle.
+    :param float top: The y coordinate of the top of the rectangle.
+    :param float bottom: The y coordinate of the rectangle bottom.
+    :param Color color: The color of the rectangle.
+    :param float border_width: The width of the border in pixels. Defaults to one.
+    :Raises AttributeError: Raised if left > right or top < bottom.
+
+    """
     if left > right:
         raise AttributeError("Left coordinate must be less than or equal to "
                              "the right coordinate")
@@ -706,8 +740,36 @@ def draw_rectangle_outline(center_x: float, center_y: float, width: float,
     _generic_draw_line_strip(point_list, color, gl.GL_TRIANGLE_STRIP)
 
 
+@warning(
+    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_filled.",
+    warning_type=NameChangeWarning
+)
 def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
                                bottom: float, color: Color):
+    """
+    Draw a rectangle by specifying left, right, top, and bottom edges.
+
+    :param float left: The x coordinate of the left edge of the rectangle.
+    :param float right: The x coordinate of the right edge of the rectangle.
+    :param float top: The y coordinate of the top of the rectangle.
+    :param float bottom: The y coordinate of the rectangle bottom.
+    :param Color color: The color of the rectangle.
+    :Raises AttributeError: Raised if left > right or top < bottom.
+    """
+    if left > right:
+        raise AttributeError(f"Left coordinate {left} must be less than or equal to the right coordinate {right}")
+
+    if bottom > top:
+        raise AttributeError(f"Bottom coordinate {bottom} must be less than or equal to the top coordinate {top}")
+
+    center_x = (left + right) / 2
+    center_y = (top + bottom) / 2
+    width = right - left + 1
+    height = top - bottom + 1
+    draw_rectangle_filled(center_x, center_y, width, height, color)
+
+
+def draw_lrbt_rectangle_filled(left: float, right: float, bottom: float, top: float, color: Color):
     """
     Draw a rectangle by specifying left, right, top, and bottom edges.
 

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -637,15 +637,15 @@ def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
     :param float bottom: The y coordinate of the rectangle bottom.
     :param Color color: The color of the rectangle.
     :param float border_width: The width of the border in pixels. Defaults to one.
-    :Raises ValueError: Raised if left > right or top < bottom.
+    :Raises AttributeError: Raised if left > right or top < bottom.
 
     """
     if left > right:
-        raise ValueError("Left coordinate must be less than or equal to "
+        raise AttributeError("Left coordinate must be less than or equal to "
                              "the right coordinate")
 
     if bottom > top:
-        raise ValueError("Bottom coordinate must be less than or equal to "
+        raise AttributeError("Bottom coordinate must be less than or equal to "
                              "the top coordinate")
 
     center_x = (left + right) / 2
@@ -667,15 +667,15 @@ def draw_lrbt_rectangle_outline(left: float, right: float, bottom: float, top: f
     :param float top: The y coordinate of the top of the rectangle.
     :param Color color: The color of the rectangle.
     :param float border_width: The width of the border in pixels. Defaults to one.
-    :Raises AttributeError: Raised if left > right or top < bottom.
+    :Raises ValueError: Raised if left > right or top < bottom.
 
     """
     if left > right:
-        raise AttributeError("Left coordinate must be less than or equal to "
+        raise ValueError("Left coordinate must be less than or equal to "
                              "the right coordinate")
 
     if bottom > top:
-        raise AttributeError("Bottom coordinate must be less than or equal to "
+        raise ValueError("Bottom coordinate must be less than or equal to "
                              "the top coordinate")
 
     center_x = (left + right) / 2

--- a/arcade/examples/net_process_animal_facts.py
+++ b/arcade/examples/net_process_animal_facts.py
@@ -92,7 +92,7 @@ class AnimalFacts(arcade.View):
         # Draw a progress bar to show how long until we request a new fact
         progress = 1.0 - ((time.time() - self.last_updated) / self.update_interval)
         if progress > 0:
-            arcade.draw_lrtb_rectangle_filled(
+            arcade.draw_lrbt_rectangle_filled(
                 left=0, right=self.window.width * progress,
                 bottom=0, top=20,
                 color=arcade.color.LIGHT_KHAKI

--- a/arcade/examples/particle_fireworks.py
+++ b/arcade/examples/particle_fireworks.py
@@ -340,9 +340,9 @@ class FireworksApp(arcade.Window):
         self.clear()
         for e in self.emitters:
             e.draw()
-        arcade.draw_lrtb_rectangle_filled(0, SCREEN_WIDTH, 25, 0, arcade.color.DARK_GREEN)
+        arcade.draw_lrbt_rectangle_filled(0, SCREEN_WIDTH, 0, 25, arcade.color.DARK_GREEN)
         mid = SCREEN_WIDTH / 2
-        arcade.draw_lrtb_rectangle_filled(mid - 2, mid + 2, SPINNER_HEIGHT, 10, arcade.color.DARK_BROWN)
+        arcade.draw_lrbt_rectangle_filled(mid - 2, mid + 2, 10, SPINNER_HEIGHT, arcade.color.DARK_BROWN)
 
     def on_key_press(self, key, modifiers):
         if key == arcade.key.ESCAPE:

--- a/arcade/examples/sections_demo_1.py
+++ b/arcade/examples/sections_demo_1.py
@@ -69,8 +69,8 @@ class ScreenPart(arcade.Section):
         """ Draw this section """
         if self.selected:
             # Section is selected when mouse is within its boundaries
-            arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
-                                              self.bottom, arcade.color.GRAY)
+            arcade.draw_lrbt_rectangle_filled(self.left, self.right, self.bottom,
+                                              self.top, arcade.color.GRAY)
             arcade.draw_text(f'You\'re are on the {self.name}', self.left + 30,
                              self.top - 50, arcade.color.BLACK, 16)
 

--- a/arcade/examples/sections_demo_3.py
+++ b/arcade/examples/sections_demo_3.py
@@ -65,10 +65,10 @@ class ModalSection(Section):
 
     def on_draw(self):
         # draw modal frame and button
-        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
-                                          self.bottom, arcade.color.GRAY)
-        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
-                                           self.bottom, arcade.color.WHITE)
+        arcade.draw_lrbt_rectangle_filled(self.left, self.right, self.bottom,
+                                          self.top, arcade.color.GRAY)
+        arcade.draw_lrbt_rectangle_outline(self.left, self.right, self.bottom,
+                                           self.top, arcade.color.WHITE)
         self.draw_button()
 
     def draw_button(self):
@@ -100,10 +100,10 @@ class InfoBar(Section):
 
     def on_draw(self):
         # draw game info
-        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
-                                          self.bottom, COLOR_DARK)
-        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
-                                           self.bottom, COLOR_LIGHT)
+        arcade.draw_lrbt_rectangle_filled(self.left, self.right, self.bottom,
+                                          self.top, COLOR_DARK)
+        arcade.draw_lrbt_rectangle_outline(self.left, self.right, self.bottom,
+                                           self.top, COLOR_LIGHT)
         arcade.draw_text(f'Ball bounce count: {self.ball.bounce_count}',
                          self.left + 20, self.top - self.height / 1.6,
                          COLOR_LIGHT)
@@ -158,10 +158,10 @@ class Panel(Section):
                          self.bottom + 95, COLOR_DARK, 10)
 
     def on_draw(self):
-        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
-                                          self.bottom, COLOR_DARK)
-        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
-                                           self.bottom, COLOR_LIGHT)
+        arcade.draw_lrbt_rectangle_filled(self.left, self.right, self.bottom,
+                                          self.top, COLOR_DARK)
+        arcade.draw_lrbt_rectangle_outline(self.left, self.right, self.bottom,
+                                           self.top, COLOR_LIGHT)
         self.draw_button_stop()
         self.draw_button_toggle_info_bar()
 
@@ -234,10 +234,10 @@ class Map(Section):
             self.ball.bounce_count += 1
 
     def on_draw(self):
-        arcade.draw_lrtb_rectangle_filled(self.left, self.right, self.top,
-                                          self.bottom, COLOR_DARK)
-        arcade.draw_lrtb_rectangle_outline(self.left, self.right, self.top,
-                                           self.bottom, COLOR_LIGHT)
+        arcade.draw_lrbt_rectangle_filled(self.left, self.right, self.bottom,
+                                          self.top, COLOR_DARK)
+        arcade.draw_lrbt_rectangle_outline(self.left, self.right, self.bottom,
+                                           self.top, COLOR_LIGHT)
         self.sprite_list.draw()
 
     def on_key_press(self, symbol: int, modifiers: int):

--- a/arcade/examples/sprite_move_scrolling_box.py
+++ b/arcade/examples/sprite_move_scrolling_box.py
@@ -122,7 +122,7 @@ class MyGame(arcade.Window):
         right_boundary = self.width - VIEWPORT_MARGIN
         top_boundary = self.height - VIEWPORT_MARGIN
         bottom_boundary = VIEWPORT_MARGIN
-        arcade.draw_lrtb_rectangle_outline(left_boundary, right_boundary, top_boundary, bottom_boundary,
+        arcade.draw_lrbt_rectangle_outline(left_boundary, right_boundary, bottom_boundary, top_boundary,
                                            arcade.color.RED, 2)
 
     def on_key_press(self, key, modifiers):

--- a/arcade/examples/view_pause_screen.py
+++ b/arcade/examples/view_pause_screen.py
@@ -94,10 +94,10 @@ class PauseView(arcade.View):
         player_sprite.draw()
 
         # draw an orange filter over him
-        arcade.draw_lrtb_rectangle_filled(left=player_sprite.left,
+        arcade.draw_lrbt_rectangle_filled(left=player_sprite.left,
                                           right=player_sprite.right,
-                                          top=player_sprite.top,
                                           bottom=player_sprite.bottom,
+                                          top=player_sprite.top,
                                           color=arcade.color.ORANGE[:3] + (200,))
 
         arcade.draw_text("PAUSED", WIDTH / 2, HEIGHT / 2 + 50,

--- a/arcade/experimental/shapes_perf.py
+++ b/arcade/experimental/shapes_perf.py
@@ -31,7 +31,7 @@ TITLE = "Shape Test"
 # [x] draw_triangle_outline
 # [x] draw_rectangle_outline
 # [x] draw_xywh_rectangle_outline
-# [x] draw_lrtb_rectangle_filled
+# [x] draw_lrbt_rectangle_filled
 # [x] draw_xywh_rectangle_filled
 # [x] draw_rectangle_filled
 # [x] draw_scaled_texture_rectangle

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -540,10 +540,10 @@ class Text:
         bottom = self.bottom
 
         # Draw background
-        arcade.draw_lrtb_rectangle_filled(left, right, top, bottom, color=background_color)
+        arcade.draw_lrbt_rectangle_filled(left, right, bottom, top, color=background_color)
 
         # Draw outline
-        arcade.draw_lrtb_rectangle_outline(left, right, top, bottom, color=outline_color)
+        arcade.draw_lrbt_rectangle_outline(left, right, bottom, top, color=outline_color)
 
         # Draw anchor
         arcade.draw_point(self.x, self.y, color=anchor_color, size=6)

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -17,6 +17,11 @@ class PerformanceWarning(Warning):
     pass
 
 
+class NameChangeWarning(Warning):
+    """Use this for issuing warnings about naming changes."""
+    pass
+
+
 def warning(message: str, warning_type: Type[Warning]):
     def actual_warning_decorator(func):
         @functools.wraps(func)

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -17,15 +17,15 @@ class PerformanceWarning(Warning):
     pass
 
 
-class NameChangeWarning(Warning):
-    """Use this for issuing warnings about naming changes."""
+class ReplacementWarning(Warning):
+    """Use this for issuing warnings about naming and functionality changes."""
     pass
 
 
 def warning(warning_type: Type[Warning], message: str = "", **kwargs):
     def actual_warning_decorator(func):
         nonlocal message
-        if warning_type == NameChangeWarning and not message:
+        if warning_type == ReplacementWarning and not message:
             message = f"{func.__name__} is deprecated. Use {kwargs.get('new_name', '')} instead."
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -22,8 +22,11 @@ class NameChangeWarning(Warning):
     pass
 
 
-def warning(message: str, warning_type: Type[Warning]):
+def warning(warning_type: Type[Warning], message: str = "", **kwargs):
     def actual_warning_decorator(func):
+        nonlocal message
+        if warning_type == NameChangeWarning and not message:
+            message = f"{func.__name__} is deprecated. Use {kwargs.get('new_name', '')} instead."
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             warnings.warn(message, warning_type)

--- a/doc/tutorials/crt_filter/bloom_filter_example.py
+++ b/doc/tutorials/crt_filter/bloom_filter_example.py
@@ -39,7 +39,7 @@ class MyGame(arcade.Window):
             self.bloom_filter.use()
             self.bloom_filter.clear()
             self.sprite_list.draw()
-            # arcade.draw_lrtb_rectangle_outline(0, self.width - 25, self.height - 5, 0, arcade.color.WHITE, 5)
+            # arcade.draw_lrbt_rectangle_outline(0, self.width - 25, 0, self.height - 5, arcade.color.WHITE, 5)
 
             # Switch back to our window and draw the CRT filter do
             # draw its stuff to the screen


### PR DESCRIPTION
Relevant discussion: https://discord.com/channels/458662222697070613/1087007892575617086/1087015976157073428


Mentions for the world `lrtb` in the whole arcade package after deprecation: 
```shell
$ grep -nr -I --exclude-dir='.[^.]*' 'lrtb' .
./arcade/draw_commands.py:622:    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_outline.",
./arcade/draw_commands.py:625:def draw_lrtb_rectangle_outline(left: float, right: float, top: float,
./arcade/draw_commands.py:744:    message="Drawing with lrtb(left, right, top, bottom) is deprecated use lrbt instead i.e draw_lrbt_rectangle_filled.",
./arcade/draw_commands.py:747:def draw_lrtb_rectangle_filled(left: float, right: float, top: float,
./arcade/__init__.py:128:from .draw_commands import draw_lrtb_rectangle_filled
./arcade/__init__.py:130:from .draw_commands import draw_lrtb_rectangle_outline
./arcade/__init__.py:305:    'draw_lrtb_rectangle_filled',
./arcade/__init__.py:307:    'draw_lrtb_rectangle_outline',
```