### PR TITLE
Remove mention of isometric from `__all__`

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -383,7 +383,6 @@ __all__ = [
     'get_default_image',
     'hitbox',
     'experimental',
-    'isometric',
     'color',
     'csscolor',
     'key',


### PR DESCRIPTION
```shell
>>> 'isometric' in arcade.__all__
True
>>> arcade.isometric
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'arcade' has no attribute 'isometric'
```

Relevant conversation: https://discord.com/channels/458662222697070613/458662458198982676/1087269080072978523