### PR TITLE
Make thumbnails in GUI programming guide index clickable

### DIFF
--- a/doc/programming_guide/gui/index.rst
+++ b/doc/programming_guide/gui/index.rst
@@ -5,21 +5,25 @@ GUI
 
 .. figure:: ../../example_code/how_to_examples/thumbs/gui_flat_button.png
    :figwidth: 170px
+   :target: ../../example_code/how_to_examples/gui_flat_button.html
 
    :ref:`gui_flat_button`
 
 .. figure:: ../../example_code/how_to_examples/gui_widgets.png
    :figwidth: 170px
+   :target: ../../example_code/how_to_examples/gui_widgets.html
 
    :ref:`gui_widgets`
 
 .. figure:: ../../example_code/how_to_examples/gui_ok_messagebox.png
    :figwidth: 170px
+   :target: ../../example_code/how_to_examples/gui_ok_messagebox.html
 
    :ref:`gui_ok_messagebox`
 
 .. figure:: ../../example_code/how_to_examples/gui_scrollable_text.png
    :figwidth: 170px
+   :target: ../../example_code/how_to_examples/gui_scrollable_text.html
 
    :ref:`gui_scrollable_text`
 


### PR DESCRIPTION
Same nasty kludge as #1181 to make our docs compliant with touch-friendly design. Why? https://github.com/sphinx-doc/sphinx/issues/4351 is still unsolved. :upside_down_face: 

Doc built & tested locally.