### PR TITLE
Touch-up top-level docstrings for Sprite & BasicSprite

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -17,10 +17,9 @@ class BasicSprite:
     """
     The absolute minimum needed for a sprite.
 
-    .. warning:: Beginners should see :py:class:`~arcade.Sprite` instead!
-
-                 This class is best used for performance optimization or
-                 internal arcade components.
+    It does not support features like rotation or changing the hitbox
+    after creation. For more built-in features, please see
+    :py:class:`~arcade.Sprite`.
 
     :param texture: The texture data to use for this sprite.
     :param scale: The scaling factor for drawing the texture.

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -16,6 +16,16 @@ SpriteType = TypeVar("SpriteType", bound="BasicSprite")
 class BasicSprite:
     """
     The absolute minimum needed for a sprite.
+
+    .. warning:: Beginners should see :py:class:`~arcade.Sprite` instead!
+
+                 This class is best used for performance optimization or
+                 internal arcade components.
+
+    :param texture: The texture data to use for this sprite.
+    :param scale: The scaling factor for drawing the texture.
+    :param center_x: Location of the sprite along the X axis in pixels.
+    :param center_y: Location of the sprite along the Y axis in pixels.
     """
 
     __slots__ = (

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -31,8 +31,7 @@ class Sprite(BasicSprite, PymunkMixin):
 
     .. tip:: Advanced users should see :py:class:`~arcade.BasicSprite`
 
-             ``BasicSprite`` is useful for performance optimization. It
-             uses fewer resources at the cost of having fewer features.
+             It uses fewer resources at the cost of having fewer features.
 
     :param str path_or_texture: Path to an image file, or a texture object.
     :param float center_x: Location of the sprite in pixels.

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -17,13 +17,26 @@ if TYPE_CHECKING:  # handle import cycle caused by type hinting
 
 class Sprite(BasicSprite, PymunkMixin):
     """
-    Class that represents a 'sprite' on-screen. Most games center around sprites.
-    For examples on how to use this class, see:
-    https://api.arcade.academy/en/latest/examples/index.html#sprites
+    Sprites are used to render image data to the screen & perform collisions.
 
-    :param str path_or_texture: Path to the image file, or a texture object.
-    :param float center_x: Location of the sprite
-    :param float center_y: Location of the sprite
+    Most games center around sprites. They are most frequently used as follows:
+
+    1. Create ``Sprite`` instances from image data
+    2. Add the sprites to a :py:class:`~arcade.SpriteList` instance
+    3. Call :py:meth:`SpriteList.draw() <arcade.SpriteList.draw>` on the
+       instance inside your ``on_draw`` method.
+
+    For runnable examples of how to do this, please see arcade's
+    :ref:`built-in Sprite examples <sprites>`.
+
+    .. tip:: Advanced users should see :py:class:`~arcade.BasicSprite`
+
+             ``BasicSprite`` is useful for performance optimization. It
+             uses fewer resources at the cost of having fewer features.
+
+    :param str path_or_texture: Path to an image file, or a texture object.
+    :param float center_x: Location of the sprite in pixels.
+    :param float center_y: Location of the sprite in pixels.
     :param float scale: Scale the image up or down. Scale of 1.0 is none.
     :param float angle: The initial rotation of the sprite in degrees
     """

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -36,7 +36,7 @@ class Sprite(BasicSprite, PymunkMixin):
     :param str path_or_texture: Path to an image file, or a texture object.
     :param float center_x: Location of the sprite in pixels.
     :param float center_y: Location of the sprite in pixels.
-    :param float scale: Scale the image up or down. Scale of 1.0 is none.
+    :param float scale: Show the image at this many times its original size.
     :param float angle: The initial rotation of the sprite in degrees
     """
 


### PR DESCRIPTION
tl;dr

1. Replace the hard URL link from `Sprite`'s top-level docstring with a `:ref:` to this doc build's version
2. Rephrase `Sprite`'s docstring to be more PEP-compliant
3. Add a top-level docstring for `BasicSprite`

Doc built & tested locally.