### PR TITLE
Remove duplicated / unreachable return from BasicSprite

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -620,4 +620,3 @@ class BasicSprite:
 
         # noinspection PyTypeChecker
         return check_for_collision_with_list(self, sprite_list)
-        return check_for_collision_with_list(self, sprite_list)


### PR DESCRIPTION
This PR removes a duplicated line found while following up on the comments for #1687 