### PR TITLE
Shapelist optimize

### DIFF
--- a/arcade/examples/lines_buffered.py
+++ b/arcade/examples/lines_buffered.py
@@ -29,6 +29,7 @@ class MyGame(arcade.Window):
         Set up the application.
         """
         super().__init__(width, height, title)
+        self.set_vsync(True)
 
         self.shape_list = ShapeElementList()
         point_list = ((0, 50),
@@ -72,9 +73,9 @@ class MyGame(arcade.Window):
         self.shape_list.draw()
 
     def on_update(self, delta_time):
-        self.shape_list.angle += 1
-        self.shape_list.center_x += 0.1
-        self.shape_list.center_y += 0.1
+        self.shape_list.angle += 1 * 60 * delta_time
+        self.shape_list.center_x += 0.1 * 60 * delta_time
+        self.shape_list.center_y += 0.1 * 60 * delta_time
 
 
 def main():

--- a/arcade/examples/shape_list_demo_skylines.py
+++ b/arcade/examples/shape_list_demo_skylines.py
@@ -13,7 +13,6 @@ from arcade.shape_list import (
     create_rectangle_filled,
     create_rectangles_filled_with_colors,
 )
-import time
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 600
@@ -21,11 +20,10 @@ SCREEN_TITLE = "Skyline Using Buffered Shapes"
 
 
 def make_star_field(star_count):
-    """ Make a bunch of circles for stars. """
-
+    """Make a bunch of circles for stars"""
     shape_list = ShapeElementList()
 
-    for star_no in range(star_count):
+    for _ in range(star_count):
         x = random.randrange(SCREEN_WIDTH)
         y = random.randrange(SCREEN_HEIGHT)
         radius = random.randrange(1, 4)
@@ -41,8 +39,7 @@ def make_skyline(width, skyline_height, skyline_color,
                  gap_chance=0.70, window_chance=0.30, light_on_chance=0.5,
                  window_color=(255, 255, 200), window_margin=3, window_gap=2,
                  cap_chance=0.20):
-    """ Make a skyline """
-
+    """Make a skyline of buildings"""
     shape_list = ShapeElementList()
 
     # Add the "base" that we build the buildings on
@@ -74,11 +71,8 @@ def make_skyline(width, skyline_height, skyline_color,
         y2 = skyline_height + building_height
 
         skyline_point_list.append([x1, y1])
-
         skyline_point_list.append([x1, y2])
-
         skyline_point_list.append([x2, y2])
-
         skyline_point_list.append([x2, y1])
 
         for i in range(4):
@@ -92,6 +86,7 @@ def make_skyline(width, skyline_height, skyline_color,
             y1 = y2 = building_center_y + building_height / 2
             y3 = y1 + building_width / 2
 
+            # Roof
             shape = create_polygon([[x1, y1], [x2, y2], [x3, y3]], skyline_color)
             shape_list.append(shape)
 
@@ -141,6 +136,8 @@ class MyGame(arcade.Window):
         """ Initializer """
         # Call the parent class initializer
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
+        # Enable vertical sync to make scrolling smoother
+        self.set_vsync(True)
 
         self.stars = make_star_field(150)
         self.skyline1 = make_skyline(SCREEN_WIDTH * 5, 250, (80, 80, 80))
@@ -148,37 +145,32 @@ class MyGame(arcade.Window):
 
         self.background_color = arcade.color.BLACK
 
-    def setup(self):
-        """ Set up the game and initialize the variables. """
-
     def on_draw(self):
-        """
-        Render the screen.
-        """
-
-        # This command has to happen before we start drawing
-
-        start_time = int(round(time.time() * 1000))
+        """Draw to screen"""
         self.clear()
 
         self.stars.draw()
         self.skyline1.draw()
         self.skyline2.draw()
-        end_time = int(round(time.time() * 1000))
-        total_time = end_time - start_time
-
-        arcade.draw_text(f"Time: {total_time}", 10, 10, arcade.color.WHITE)
 
     def on_update(self, delta_time):
-        """ Movement and game logic """
-        self.skyline1.center_x -= 0.5
-        self.skyline2.center_x -= 1
+        """Per frame update logic"""
+        # Scroll each shape list with a slight offset to give a parallax effect
+        self.skyline1.center_x -= 0.5 * 60 * delta_time
+        self.skyline2.center_x -= 1 * 60 * delta_time
+
+    def on_mouse_drag(self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int):
+        """Make it possible scroll the scene around by dragging the mouse"""
+        self.skyline1.center_x += dx
+        self.skyline1.center_y += dy
+
+        self.skyline2.center_x += dx
+        self.skyline2.center_y += dy
 
 
 def main():
     window = MyGame()
-    window.setup()
-    arcade.run()
+    window.run()
 
 
 if __name__ == "__main__":

--- a/arcade/resources/system/shaders/shape_element_list_vs.glsl
+++ b/arcade/resources/system/shaders/shape_element_list_vs.glsl
@@ -20,5 +20,5 @@ void main() {
         -sin(angle), cos(angle)
     );
     gl_Position = window.projection * window.view * vec4(Position + (rotate * in_vert), 0.0, 1.0);
-    v_color = in_color;
+    v_color = in_color / 255.0;
 }

--- a/arcade/resources/system/shaders/shapes/line/line_generic_with_colors_vs.glsl
+++ b/arcade/resources/system/shaders/shapes/line/line_generic_with_colors_vs.glsl
@@ -11,5 +11,5 @@ out vec4 v_color;
 
 void main() {
     gl_Position = window.projection * window.view * vec4(in_vert, 0.0, 1.0);
-    v_color = in_color;
+    v_color = in_color / 255.0; // Normalize the color
 }

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -880,9 +880,7 @@ class _Batch(Generic[TShape]):
     """
     A collection of shapes with the same configuration.
 
-    The group uniqueness is based on:
-    - The primitive mode
-    - The line width
+    The group uniqueness is based on the primitive mode
     """
     # Flags for keeping track of changes
     ADD = 1

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -63,7 +63,7 @@ class Shape:
         # Ensure colors have 4 components
         self.colors = [Color.from_iterable(color) for color in colors]
         # Pack the data into a single array
-        self.data = array("f", [c for a in zip(points, colors) for b in a for c in b])
+        self.data = array("f", [c for a in zip(self.points, self.colors) for b in a for c in b])
         self.vertices = len(points)
 
         self.geometry = None
@@ -820,6 +820,11 @@ class _Batch(Generic[TShape]):
 
     def draw(self):
         """Draw the batch."""
+        if self.elements == 0:
+            return
+
+        # if self.mode == gl.GL_TRIANGLE_STRIP:
+
         self.geometry.render(self.program, vertices=self.elements, mode=self.mode)
 
     def append(self, item: TShape):

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -838,7 +838,7 @@ class _Batch(Generic[TShape]):
             return
 
         # If only add flag is set we simply copy in the new data
-        if self.FLAGS == self.ADD and False:
+        if self.FLAGS == self.ADD:
             new_data = array('f')
             new_ibo = array('I')
             counter = itertools.count(self.vertices)

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -2,6 +2,7 @@
 Module specifying data custom types used for type hinting.
 """
 from array import array
+import random
 from collections import namedtuple
 from collections.abc import ByteString
 from pathlib import Path
@@ -345,6 +346,47 @@ class Color(RGBA255):
             return cls(int(code[:2], 16), int(code[2:4], 16), int(code[4:6], 16), int(code[6:8], 16))
 
         raise ValueError(f"Improperly formatted color: '{code}'")
+
+    @classmethod
+    def random(
+        cls,
+        r: Optional[int] = None,
+        g: Optional[int] = None,
+        b: Optional[int] = None,
+        a: Optional[int] = None,
+    ) -> "Color":
+        """
+        Return a random color.
+
+        The parameters are optional and can be used to fix the value of
+        a particular channel. If a channel is not fixed, it will be
+        randomly generated.
+
+        Examples::
+
+            # Randomize all channels
+            >>> Color.random()
+            Color(r=35, g=145, b=4, a=200)
+
+            # Random color with fixed alpha
+            >>> Color.random(a=255)
+            Color(r=25, g=99, b=234, a=255)
+
+        :param int r: Fixed value for red channel
+        :param int g: Fixed value for green channel
+        :param int b: Fixed value for blue channel
+        :param int a: Fixed value for alpha channel
+        """
+        if r is None:
+            r = random.randint(0, 255)
+        if g is None:
+            g = random.randint(0, 255)
+        if b is None:
+            b = random.randint(0, 255)
+        if a is None:
+            a = random.randint(0, 255)
+
+        return cls(r, g, b, a)
 
 
 ColorLike = Union[RGB, RGBA255]


### PR DESCRIPTION
Optimize `ShapeElementList`.

* Creation is around 25% faster
* Adding new shapes is `O(1)` instead of `O(N)`
* Added `Color.random()`

Also cleaned the module a bit. There are so many things we could improve in this module. There are lingering issues from arcade 1.x when line OpenGL line width was actually a thing. Indeally all the create methods should just be removed and instead located in a subclass of Shape.

This is too much work even think about for 3.0. We will probably just rely on pyglet shapes.