### PR TITLE
Improve Color's inheritance safety & type annotation accuracy

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -170,7 +170,7 @@ class Color(RGBA255):
         return self[0] / 255, self[1] / 255, self[2] / 255, self[3] / 255
 
     @classmethod
-    def from_gray(cls, brightness: int, a: int = 255) -> "Color":
+    def from_gray(cls, brightness: int, a: int = 255) -> Self:
         """
         Return a shade of gray of the given brightness.
 
@@ -195,7 +195,7 @@ class Color(RGBA255):
         if not 0 <= a <= 255:
             raise ByteRangeError("a", a)
 
-        return Color(brightness, brightness, brightness, a=a)
+        return cls(brightness, brightness, brightness, a=a)
 
     @classmethod
     def from_uint24(cls, color: int, a: int = 255) -> "Color":

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -257,7 +257,7 @@ class Color(RGBA255):
         )
 
     @classmethod
-    def from_normalized(cls, color_normalized: RGBANormalized) -> "Color":
+    def from_normalized(cls, color_normalized: RGBANormalized) -> Self:
         """
         Convert normalized (0.0 to 1.0) channels into an RGBA Color
 
@@ -303,7 +303,7 @@ class Color(RGBA255):
         return cls(int(255 * r), int(255 * g), int(255 * b), a=int(255 * a))
 
     @classmethod
-    def from_hex_string(cls, code: str) -> "Color":
+    def from_hex_string(cls, code: str) -> Self:
         """
         Make a color from a hex code that is 3, 4, 6, or 8 hex digits long
 

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
     TYPE_CHECKING, TypeVar
 )
+from typing_extensions import Self
 
 from pytiled_parser import Properties
 
@@ -93,9 +94,9 @@ class Color(RGBA255):
         # https://github.com/python/mypy/issues/8541
         return super().__new__(cls, (r, g, b, a))  # type: ignore
 
-    def __deepcopy__(self, _):
+    def __deepcopy__(self, _) -> Self:
         """Allow to deepcopy Colors"""
-        return Color(r=self.r, g=self.g, b=self.b, a=self.a)
+        return self.__class__(r=self.r, g=self.g, b=self.b, a=self.a)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(r={self.r}, g={self.g}, b={self.b}, a={self.a})"

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -230,7 +230,7 @@ class Color(RGBA255):
         )
 
     @classmethod
-    def from_uint32(cls, color: int) -> "Color":
+    def from_uint32(cls, color: int) -> Self:
         """
         Return a Color tuple for a given unsigned 4-byte (32-bit) integer
 

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -355,7 +355,7 @@ class Color(RGBA255):
         g: Optional[int] = None,
         b: Optional[int] = None,
         a: Optional[int] = None,
-    ) -> "Color":
+    ) -> Self:
         """
         Return a random color.
 

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -118,7 +118,7 @@ class Color(RGBA255):
         return self[3]
 
     @classmethod
-    def from_iterable(cls, iterable: Iterable[int]) -> "Color":
+    def from_iterable(cls, iterable: Iterable[int]) -> Self:
         """
         Create a color from an :py:class`Iterable` with 3-4 elements
 
@@ -148,7 +148,7 @@ class Color(RGBA255):
         else:
             a = 255
 
-        return Color(r, g, b, a=a)
+        return cls(r, g, b, a=a)
 
     @property
     def normalized(self) -> RGBANormalized:

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -198,7 +198,7 @@ class Color(RGBA255):
         return cls(brightness, brightness, brightness, a=a)
 
     @classmethod
-    def from_uint24(cls, color: int, a: int = 255) -> "Color":
+    def from_uint24(cls, color: int, a: int = 255) -> Self:
         """
         Return a Color from an unsigned 3-byte (24 bit) integer.
 

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -95,7 +95,7 @@ class Color(RGBA255):
         return super().__new__(cls, (r, g, b, a))  # type: ignore
 
     def __deepcopy__(self, _) -> Self:
-        """Allow to deepcopy Colors"""
+        """Allow :py:func:`~copy.deepcopy` to be used with Color"""
         return self.__class__(r=self.r, g=self.g, b=self.b, a=self.a)
 
     def __repr__(self) -> str:

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -85,6 +85,11 @@ def test_color_from_uint32():
         Color.from_uint32("bad")
 
 
+def test_color_from_uint32_inheritance():
+    color = ColorSubclass.from_uint32(0xFFFFFFFF)
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_from_normalized():
     # spot check conversion of acceptable human-ish values
     float_steps = (1 / 255, 2 / 255, 3 / 255, 4 / 255)

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -156,9 +156,18 @@ def test_color_normalized_property():
     assert colors.GRAY.normalized == (128 / 255, 128 / 255, 128 / 255, 1.0)
 
 
-def test_deepcopy_color():
+def test_deepcopy_color_values():
     expected_color = Color(255, 255, 255, 255)
     assert deepcopy(expected_color) == expected_color
+
+
+def test_deepcopy_color_inheritance():
+    class ColorSubclass(Color):
+        pass
+
+    original = ColorSubclass(255, 255, 255, 255)
+    deep = deepcopy(original)
+    assert isinstance(deep, ColorSubclass)
 
 
 RANDINT_RETURN_RESULT = 128

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -70,6 +70,11 @@ def test_color_from_uint24():
         Color.from_uint24("moo")
 
 
+def test_color_from_uint24_inheritance():
+    color = ColorSubclass.from_uint24(0xFFFFFF)
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_from_uint32():
     assert Color.from_uint32(4294967295) == (255, 255, 255, 255)
     assert Color.from_uint32((1 << 24) + (2 << 16) + (3 << 8) + 4) == (1, 2, 3, 4)

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -16,6 +16,15 @@ BAD_NORMALIZED = (-0.01, 1.01)
 MIXED_NORMALIZED = OK_NORMALIZED + BAD_NORMALIZED
 
 
+class ColorSubclass(Color):
+    pass
+
+
+@pytest.fixture
+def color_subclass_instance() -> Color:
+    return ColorSubclass(255, 255, 255, a=255)
+
+
 def at_least_one_in(i: Iterable) -> Callable[[Iterable], bool]:
     """Return a callable which returns true when at least one elt is in iterable i"""
 
@@ -161,12 +170,8 @@ def test_deepcopy_color_values():
     assert deepcopy(expected_color) == expected_color
 
 
-def test_deepcopy_color_inheritance():
-    class ColorSubclass(Color):
-        pass
-
-    original = ColorSubclass(255, 255, 255, 255)
-    deep = deepcopy(original)
+def test_deepcopy_color_inheritance(color_subclass_instance):
+    deep = deepcopy(color_subclass_instance)
     assert isinstance(deep, ColorSubclass)
 
 

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -54,6 +54,11 @@ def test_color_from_iterable_returns_same_color():
         assert Color.from_iterable(color) is color
 
 
+def test_color_from_iterable_inheritance():
+    color = ColorSubclass.from_iterable(colors.AO)
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_from_uint24():
     assert Color.from_uint24(0xFFFFFF) == (255, 255, 255, 255)
     assert Color.from_uint24((1 << 16) + (2 << 8) + 3) == (1, 2, 3, 255)

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -133,6 +133,11 @@ def test_color_from_gray():
             Color.from_gray(bad_arg)
 
 
+def test_color_from_gray_inheritance():
+    color = ColorSubclass.from_gray(255, a=255)
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_from_hex_string():
     with pytest.raises(ValueError):
         Color.from_hex_string("#ff0000ff0")

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -183,6 +183,11 @@ def test_color_from_hex_string():
             Color.from_hex_string(bad_value)
 
 
+def test_color_from_hex_string_inheritance():
+    color = ColorSubclass.from_hex_string("#fff")
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_normalized_property():
     assert colors.BLACK.normalized == (0.0, 0.0, 0.0, 1.0)
     assert colors.WHITE.normalized == (1.0, 1.0, 1.0, 1.0)

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -20,11 +20,6 @@ class ColorSubclass(Color):
     pass
 
 
-@pytest.fixture
-def color_subclass_instance() -> Color:
-    return ColorSubclass(255, 255, 255, a=255)
-
-
 def at_least_one_in(i: Iterable) -> Callable[[Iterable], bool]:
     """Return a callable which returns true when at least one elt is in iterable i"""
 
@@ -200,7 +195,8 @@ def test_deepcopy_color_values():
     assert deepcopy(expected_color) == expected_color
 
 
-def test_deepcopy_color_inheritance(color_subclass_instance):
+def test_deepcopy_color_inheritance():
+    color_subclass_instance = ColorSubclass(255, 255, 255, a=255)
     deep = deepcopy(color_subclass_instance)
     assert isinstance(deep, ColorSubclass)
 

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -224,3 +224,8 @@ def test_color_random(randint_is_constant):
                 expected = 0
 
             assert channel_value == expected
+
+
+def test_color_random_inheritance(randint_is_constant):
+    color = ColorSubclass.random()
+    assert isinstance(color, ColorSubclass)

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -120,6 +120,11 @@ def test_color_from_normalized():
             Color.from_normalized(bad_rgba_channels)
 
 
+def test_from_normalized_inheritance():
+    color = ColorSubclass.from_normalized((1.0, 1.0, 1.0, 1.0))
+    assert isinstance(color, ColorSubclass)
+
+
 def test_color_from_gray():
     OK_255 = (0, 255)
     BAD_255 = (-1, 256)


### PR DESCRIPTION
1. Improve inheritance safety by using `cls` or `self.__class__` where appropriate instead of `Color`
2. Add inheritance safety to Color's unit tests
2. Use the `Self` annotation for accuracy since we have access to a backport of it on 3.8+ via `typing_extensions`
