### PR TITLE
Pyinstaller Fixes for VERSION file

### DIFF
--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -23,6 +23,10 @@ datas = [
         arcade_path / "resources" / "system",
         "./arcade/resources/system",
     ),
+    (
+        arcade_path / "VERSION",
+        "./arcade/VERSION",
+    )
 ]
 
 if is_win:

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -37,7 +37,6 @@ def _get_version():
         data = _rreplace(data, '-', '.', 1)
     except Exception:
         print(f"ERROR: Unable to load version number via '{my_path}'.")
-        print(f"Files in that directory: {os.listdir(my_path)}")
         data = "0.0.0"
 
     return data


### PR DESCRIPTION
This addresses the issue in #1712.

In addition to adding to the version file to the pyinstaller hook, this removes an error printing from the version check which can cause a second crash in the block which is supposed to prevent the missing `VERSION` file from crashing the application.