### PR TITLE
Add `__len__` and `__delitem__` to Scene

### DIFF
--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -6,7 +6,7 @@ a name, as well as control the draw order. In addition it provides a
 helper function to create a Scene directly from a TileMap object.
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from arcade import Sprite, SpriteList
 from arcade.types import Color, RGBA255
@@ -28,6 +28,24 @@ class Scene:
     def __init__(self) -> None:
         self._sprite_lists: List[SpriteList] = []
         self._name_mapping: Dict[str, SpriteList] = {}
+
+    def __len__(self) -> int:
+        """
+        Get length of `_sprite_lists`.
+        """
+        return len(self._sprite_lists)
+
+    def __delitem__(self, sprite_list: Union[str, SpriteList]) -> None:
+        """
+        Remove the SpriteList from `_sprite_lists` and `_name_mapping`.
+
+        :param Union[str, SpriteList] sprite_list: which SpriteList to delete - can
+        be either the name of the SpriteList or the SpriteList object.
+        """
+        if isinstance(sprite_list, str):
+            self.remove_sprite_list_by_name(sprite_list)
+        else:
+            self.remove_sprite_list_by_object(sprite_list)
 
     @classmethod
     def from_tilemap(cls, tilemap: TileMap) -> "Scene":
@@ -188,7 +206,7 @@ class Scene:
 
         :param str name: The name to give the SpriteList.
         :param str after: The name of the SpriteList to place this one after.
-        :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
+        :param bool use_spatial_hash: Whether or not to use spatial hash if creating a new SpriteList.
         :param SpriteList sprite_list: The SpriteList to add, optional.
         """
         if sprite_list is None:
@@ -355,4 +373,3 @@ class Scene:
 
         for sprite_list in self._sprite_lists:
             sprite_list.draw_hit_boxes(color, line_thickness)
-

--- a/tests/unit/scene/test_scene_len_delitem.py
+++ b/tests/unit/scene/test_scene_len_delitem.py
@@ -1,0 +1,28 @@
+import arcade
+import pytest
+
+
+def test_len():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Player")
+
+    assert len(scene) == 1
+
+    scene.add_sprite_list("Walls")
+    scene.add_sprite_list("Coins")
+
+    assert len(scene) == 3
+
+def test_delitem():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Walls")
+    scene.add_sprite_list("Player")
+    del scene["Player"]
+
+    with pytest.raises(KeyError):
+        scene["Player"]
+
+    del scene[scene._sprite_lists[0]]
+
+    with pytest.raises(KeyError):
+        scene["Walls"]


### PR DESCRIPTION
For Issue[https://github.com/pythonarcade/arcade/issues/1651](https://github.com/pythonarcade/arcade/issues/1651)

## What was done

- Added `__len__` and `__delitem__` methods to `scene.py`. 
- Added tests for these new scene methods.

## How to test
- Run the pytests; both tests should pass (the individual tests are in `tests/unit/scene/test_scene_len_delitem.py`).

Special thanks to @Cleptomania for the hands on help at PyCon 2023! 