### PR TITLE
Add `remove_sprite_list_by_index` to Scene

### DIFF
--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -6,7 +6,7 @@ a name, as well as control the draw order. In addition it provides a
 helper function to create a Scene directly from a TileMap object.
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from arcade import Sprite, SpriteList
 from arcade.types import Color, RGBA255
@@ -28,6 +28,24 @@ class Scene:
     def __init__(self) -> None:
         self._sprite_lists: List[SpriteList] = []
         self._name_mapping: Dict[str, SpriteList] = {}
+
+    def __len__(self) -> int:
+        """
+        Get length of `_sprite_lists`.
+        """
+        return len(self._sprite_lists)
+
+    def __delitem__(self, sprite_list: Union[str, SpriteList]) -> None:
+        """
+        Remove the SpriteList from `_sprite_lists` and `_name_mapping`.
+
+        :param Union[str, SpriteList] sprite_list: which SpriteList to delete - can
+        be either the name of the SpriteList or the SpriteList object.
+        """
+        if isinstance(sprite_list, str):
+            self.remove_sprite_list_by_name(sprite_list)
+        else:
+            self.remove_sprite_list_by_object(sprite_list)
 
     @classmethod
     def from_tilemap(cls, tilemap: TileMap) -> "Scene":
@@ -188,7 +206,7 @@ class Scene:
 
         :param str name: The name to give the SpriteList.
         :param str after: The name of the SpriteList to place this one after.
-        :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
+        :param bool use_spatial_hash: Whether or not to use spatial hash if creating a new SpriteList.
         :param SpriteList sprite_list: The SpriteList to add, optional.
         """
         if sprite_list is None:
@@ -355,4 +373,3 @@ class Scene:
 
         for sprite_list in self._sprite_lists:
             sprite_list.draw_hit_boxes(color, line_thickness)
-

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -35,14 +35,17 @@ class Scene:
         """
         return len(self._sprite_lists)
 
-    def __delitem__(self, sprite_list: Union[str, SpriteList]) -> None:
+    def __delitem__(self, sprite_list: Union[int, str, SpriteList]) -> None:
         """
         Remove the SpriteList from `_sprite_lists` and `_name_mapping`.
 
-        :param Union[str, SpriteList] sprite_list: which SpriteList to delete - can
-        be either the name of the SpriteList or the SpriteList object.
+        :param Union[int, str, SpriteList] sprite_list: which SpriteList to delete - can
+        be the index of the SpriteList in `_sprite_lists`, the name of the SpriteList or
+        the SpriteList object.
         """
-        if isinstance(sprite_list, str):
+        if isinstance(sprite_list, int):
+            self.remove_sprite_list_by_index(sprite_list)
+        elif isinstance(sprite_list, str):
             self.remove_sprite_list_by_name(sprite_list)
         else:
             self.remove_sprite_list_by_object(sprite_list)
@@ -244,12 +247,25 @@ class Scene:
         old_index = self._sprite_lists.index(name_list)
         self._sprite_lists.insert(new_index, self._sprite_lists.pop(old_index))
 
+    def remove_sprite_list_by_index(
+        self,
+        index: int
+    ) -> None:
+        """
+        Remove a SpriteList by its index.
+
+        This function serves to completely remove the SpriteList from the Scene.
+
+        :param int index: The index of the SpriteList to remove.
+        """
+        self.remove_sprite_list_by_object(self._sprite_lists[index])
+
     def remove_sprite_list_by_name(
         self,
         name: str,
     ) -> None:
         """
-        Remove a SpriteList by it's name.
+        Remove a SpriteList by its name.
 
         This function serves to completely remove the SpriteList from the Scene.
 
@@ -260,6 +276,13 @@ class Scene:
         del self._name_mapping[name]
 
     def remove_sprite_list_by_object(self, sprite_list: SpriteList) -> None:
+        """
+        Remove a SpriteList by object.
+
+        This function serves to completely remove the SpriteList from the Scene.
+
+        :param SpriteList sprite_list: The SpriteList to remove.
+        """
         self._sprite_lists.remove(sprite_list)
         self._name_mapping = {
             key: val for key, val in self._name_mapping.items() if val != sprite_list

--- a/tests/unit/scene/test_scene_len_delitem.py
+++ b/tests/unit/scene/test_scene_len_delitem.py
@@ -1,0 +1,28 @@
+import arcade
+import pytest
+
+
+def test_len():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Player")
+
+    assert len(scene) == 1
+
+    scene.add_sprite_list("Walls")
+    scene.add_sprite_list("Coins")
+
+    assert len(scene) == 3
+
+def test_delitem():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Walls")
+    scene.add_sprite_list("Player")
+    del scene["Player"]
+
+    with pytest.raises(KeyError):
+        scene["Player"]
+
+    del scene[scene._sprite_lists[0]]
+
+    with pytest.raises(KeyError):
+        scene["Walls"]

--- a/tests/unit/scene/test_scene_len_delitem.py
+++ b/tests/unit/scene/test_scene_len_delitem.py
@@ -17,6 +17,7 @@ def test_delitem():
     scene = arcade.Scene()
     scene.add_sprite_list("Walls")
     scene.add_sprite_list("Player")
+    scene.add_sprite_list("Coins")
     del scene["Player"]
 
     with pytest.raises(KeyError):
@@ -26,3 +27,8 @@ def test_delitem():
 
     with pytest.raises(KeyError):
         scene["Walls"]
+
+    del scene[0]
+
+    with pytest.raises(KeyError):
+        scene["Coins"]

--- a/tests/unit/scene/test_scene_remove_sprite_lists.py
+++ b/tests/unit/scene/test_scene_remove_sprite_lists.py
@@ -1,0 +1,29 @@
+import arcade
+import pytest
+
+def test_remove_sprite_list_by_index():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Player")
+
+    scene.remove_sprite_list_by_index(0)
+
+    with pytest.raises(KeyError):
+        scene["Player"]
+
+def test_remove_sprite_list_by_name():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Walls")
+
+    scene.remove_sprite_list_by_name("Walls")
+
+    with pytest.raises(KeyError):
+        scene["Walls"]
+
+def test_remove_sprite_list_by_object():
+    scene = arcade.Scene()
+    scene.add_sprite_list("Coins")
+
+    scene.remove_sprite_list_by_object(scene.get_sprite_list("Coins"))
+
+    with pytest.raises(KeyError):
+        scene["Coins"]


### PR DESCRIPTION
Request for this function from: [https://github.com/pythonarcade/arcade/pull/1721#pullrequestreview-1398875020](https://github.com/pythonarcade/arcade/pull/1721#pullrequestreview-1398875020)
## What was done

- Added `remove_sprite_list_by_index()` to `scene.py` to delete SpriteLists from the scene by index
- Added delete by index in `__delitem__()`
- Added test cases for remove_sprite_by_[method]

## How to test
- Run the pytests (`tests/unit/scene/test_scene_remove_sprite_lists.py` and `tests/unit/scene/test_scene_len_delitem.py` have been updated).
