### PR TITLE
Add Programming Guide index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,6 +67,7 @@ The Python Arcade Library
 .. image:: images/example_games.svg
    :alt: Programming guide icon
    :class: heading-icon
+   :target: programming_guide
 
 .. toctree::
    :maxdepth: 1
@@ -91,6 +92,7 @@ The Python Arcade Library
    programming_guide/gui/index
    programming_guide/performance_tips
    programming_guide/sections
+   programming_guide/index
 
 .. image:: images/API.svg
    :alt: API icon

--- a/doc/programming_guide/index.rst
+++ b/doc/programming_guide/index.rst
@@ -3,7 +3,17 @@
 Arcade Programming Guide Index
 ==============================
 
-This is the index of the programming guide.
+This section provides both instructions on getting started and overviews
+overviews of the following concepts:
+
+* Arcade's overall structure
+* Basic drawing techniques & concepts
+* Avoiding common problems
+* General OpenGL notes
+* Advanced techniques & concepts
+
+Pages may also include links to relevant examples, tutorials, or
+external documentation where applicable.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/programming_guide/index.rst
+++ b/doc/programming_guide/index.rst
@@ -1,0 +1,30 @@
+.. _pg_index:
+
+Arcade Programming Guide Index
+==============================
+
+This is the index of the programming guide.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Programming Guide
+
+   install/index
+   get_started
+   how_to_get_help
+   directory_structure
+   edge_artifacts/index
+   how_to_submit_changes
+   how_to_contribute
+   how_to_build
+   logging
+   release_checklist
+   pygame_comparison
+   headless
+   vsync
+   textures
+   texture_atlas
+   opengl_notes.rst
+   gui/index
+   performance_tips
+   sections


### PR DESCRIPTION
tl;dr stop new or otherwise unlinked sections from causing toctree inclusion warnings / errors

#1691 has been in the review queue for  a while. Splitting this part off unblocks adding new sections more quickly since pages not in a toctree produce warnings during build which are treated as errors.