### PR TITLE
Remove duplicated docs dependency declaration from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,6 @@ dev = [
     "wheel",
 ]
 
-docs = [
-    "pygments==2.14.0",
-    "docutils==0.19",
-    "furo",
-    "pyyaml==6.0",
-    "sphinx==6.1.3",
-    "sphinx-copybutton==0.5.1",
-    "sphinx-sitemap==2.5.0",
-    "wheel",
-]
-
 [project.scripts]
 arcade = "arcade.management:execute_from_command_line"
 


### PR DESCRIPTION
I asked about this on Discord.  People guessed this might have been from old build scripts that installed only documentation dependencies.  I couldn't find any scripts doing this, so they must have been removed.  The dev dependencies already include all necessary documentation dependencies.  So this avoids duplication, avoids two dependency declarations getting out of sync.