### PR TITLE
Improve make script ergonomics & documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ Upgrade by running the following command:
 pip install --upgrade pip
 ```
 
-### Optional: Enable running the build script with `./make.py` on Mac & Linux
+### Optional: Improve Ergonomics on Mac and Linux
+
+#### Enable `./make.py`
 
 On Mac & Linux, you can enable running `make.py` using `./make.py` instead
 of `python make.py` as follows:
@@ -84,6 +86,36 @@ can now be run this way:
 ```shell
 ./make.py lint
 ```
+
+#### Enable Shell Completions
+
+After enabling the short-form syntax as outlined above, you can also enable tab
+completion for commands on the following supported shells:
+
+* `bash` (the most common default shell)
+* `zsh`
+* `fish`
+* `powershell`
+* `powersh`
+
+For example, if you have typed the following...
+```shell
+./make.py h
+```
+
+Tab completion would allow you to press tab to auto-complete the command:
+```shell
+./make.py html
+```
+
+To enable this feature, most users can follow these steps:
+
+1. Run `./make.py whichshell` to find out what your default shell is
+2. If it is one of the supported shells, run `./make.py --install-completion $(basename "$SHELL")`
+3. Restart your terminal
+
+If your default shell is not the shell you prefer using for arcade development,
+you may need to specify it to completion install command directly.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,27 @@ Upgrade by running the following command:
 pip install --upgrade pip
 ```
 
+### Optional: Enable running the build script with `./make.py` on Mac & Linux
+
+On Mac & Linux, you can enable running `make.py` using `./make.py` instead
+of `python make.py` as follows:
+
+1. Make sure you are in the root directory of the repo
+2. Run `chmod +x make.py`
+
+You can now substitute `./make.py` anywhere the rest of this document
+says `python make.py`.
+
+For example, this command:
+```commandline
+python make.py lint
+```
+
+can now be run this way:
+```shell
+./make.py lint
+```
+
 ## Testing
 
 You should test your changes locally before submitting a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,58 +64,8 @@ Upgrade by running the following command:
 pip install --upgrade pip
 ```
 
-### Optional: Improve Ergonomics on Mac and Linux
-
-#### Enable `./make.py`
-
-On Mac & Linux, you can enable running `make.py` using `./make.py` instead
-of `python make.py` as follows:
-
-1. Make sure you are in the root directory of the repo
-2. Run `chmod +x make.py`
-
-You can now substitute `./make.py` anywhere the rest of this document
-says `python make.py`.
-
-For example, this command:
-```commandline
-python make.py lint
-```
-
-can now be run this way:
-```shell
-./make.py lint
-```
-
-#### Enable Shell Completions
-
-After enabling the short-form syntax as outlined above, you can also enable tab
-completion for commands on the following supported shells:
-
-* `bash` (the most common default shell)
-* `zsh`
-* `fish`
-* `powershell`
-* `powersh`
-
-For example, if you have typed the following...
-```shell
-./make.py h
-```
-
-Tab completion would allow you to press tab to auto-complete the command:
-```shell
-./make.py html
-```
-
-To enable this feature, most users can follow these steps:
-
-1. Run `./make.py whichshell` to find out what your default shell is
-2. If it is one of the supported shells, run `./make.py --install-completion $(basename "$SHELL")`
-3. Restart your terminal
-
-If your default shell is not the shell you prefer using for arcade development,
-you may need to specify it to completion install command directly.
+Mac & Linux users can improve their development experience further by following the optional
+steps at the end of this document.
 
 ## Testing
 
@@ -188,3 +138,55 @@ python -m http.server -d doc/build/html
 You can now open [http://localhost:8000](http://localhost:8000) in your browser to preview the doc.
 
 Be sure to re-run build & refresh to update after making changes!
+
+## Optional: Improve Ergonomics on Mac and Linux
+
+### Enable `./make.py`
+
+On Mac & Linux, you can enable running `make.py` using `./make.py` instead
+of `python make.py` as follows:
+
+1. Make sure you are in the root directory of the repo
+2. Run `chmod +x make.py`
+
+You can run the make script with `./make.py` instead of `python make.py`.
+
+For example, this command:
+```commandline
+python make.py lint
+```
+
+can now be run this way:
+```shell
+./make.py lint
+```
+
+### Enable Shell Completions
+
+After enabling the short-form syntax as outlined above, you can also enable tab
+completion for commands on the following supported shells:
+
+* `bash` (the most common default shell)
+* `zsh`
+* `fish`
+* `powershell`
+* `powersh`
+
+For example, if you have typed the following...
+```shell
+./make.py h
+```
+
+Tab completion would allow you to press tab to auto-complete the command:
+```shell
+./make.py html
+```
+
+To enable this feature, most users can follow these steps:
+
+1. Run `./make.py whichshell` to find out what your default shell is
+2. If it is one of the supported shells, run `./make.py --install-completion $(basename "$SHELL")`
+3. Restart your terminal
+
+If your default shell is not the shell you prefer using for arcade development,
+you may need to specify it to the completion install command directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ On Mac & Linux, you can enable running `make.py` using `./make.py` instead
 of `python make.py` as follows:
 
 1. Make sure you are in the root directory of the repo
-2. Run `chmod +x make.py`
+2. Run `chmod u+x make.py`
 
 You can run the make script with `./make.py` instead of `python make.py`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,4 +189,5 @@ To enable this feature, most users can follow these steps:
 3. Restart your terminal
 
 If your default shell is not the shell you prefer using for arcade development,
-you may need to specify it to the completion install command directly.
+you may need to specify it to the command above directly instead of using
+autodetection.

--- a/make.py
+++ b/make.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """
-Build script for documentation
+Build script to simplify running:
+
+* Tests
+* Code quality checks
+* Documentation builds
+
+For help, see the following:
+
+* CONTRIBUTING.md
+* The output of python make.py --help
 """
 import os
 from contextlib import contextmanager

--- a/make.py
+++ b/make.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Build script for documentation
 """

--- a/make.py
+++ b/make.py
@@ -454,12 +454,25 @@ def test():
     run([PYTEST, UNITTESTS])
 
 
+SHELLS_WITH_AUTOCOMPLETE = (
+    'bash',
+    'zsh',
+    'fish',
+    'powershell',
+    'powersh'
+)
+
+
 @app.command()
 def whichshell():
     """to find out which shell your system seems to be running"""
 
     shell_name = Path(os.environ.get('SHELL')).stem
-    print(f"Your current shell appears to be: {shell_name}")
+    print(f"Your default shell appears to be: {shell_name}")
+
+    if shell_name in SHELLS_WITH_AUTOCOMPLETE:
+        print("This shell is known to support tab-completion!")
+        print("See CONTRIBUTING.md for more information on how to enable it.")
 
 
 if __name__ == "__main__":

--- a/make.py
+++ b/make.py
@@ -454,5 +454,13 @@ def test():
     run([PYTEST, UNITTESTS])
 
 
+@app.command()
+def whichshell():
+    """to find out which shell your system seems to be running"""
+
+    shell_name = Path(os.environ.get('SHELL')).stem
+    print(f"Your current shell appears to be: {shell_name}")
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
### Changes

* Document how to enable running `./make.py` instead of `python make.py` for Mac & Linux users
* Document how to enable tab completions for `./make.py`
* Add a `./make.py whichshell` sub-command to assist users with setting up tab completion

### How to test

Both sets of instructions assume you are on Linux or a Mac

#### Testing short-form invocation & Shell Checking

1. Follow the instructions for enabling `./make.py`
2. Run `./make.py whichshell` to make sure it reports your default shell correctly

#### Testing Shell Completion

1. If you are running a supported shell, follow the included instructions
2. Type `./make.py h`
3. Press tab
4. Observe the result; it should auto-complete to `./make.py html`
