### PR TITLE
Correct coordinate calculation for rectangle

### DIFF
--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -918,12 +918,14 @@ class TileMap:
 
                     shape = [x + offset[0], y + offset[1]]
                 else:
-                    x = cur_object.coordinates.x + offset[0]
-                    y = cur_object.coordinates.y + offset[1]
-                    sx = x
-                    sy = -y
-                    ex = x + cur_object.size.width
-                    ey = -(y + cur_object.size.height)
+                    sx = cur_object.coordinates.x * scaling + offset[0]
+                    sy = (
+                        self.tiled_map.map_size.height * self.tiled_map.tile_size[1]
+                        - cur_object.coordinates.y
+                    ) * scaling + offset[1]
+
+                    ex = sx + cur_object.size.width * scaling
+                    ey = sy - cur_object.size.height * scaling
 
                     p1 = [sx, sy]
                     p2 = [ex, sy]

--- a/tests/unit/tilemap/test_tilemap_objects.py
+++ b/tests/unit/tilemap/test_tilemap_objects.py
@@ -1,3 +1,4 @@
+from math import isclose
 import arcade
 from pytiled_parser.common_types import Color
 
@@ -33,6 +34,12 @@ def test_one():
     #
     assert sprite_1.properties["class"] == "crate"
     assert sprite_1.properties["name"] == "crate1"
+
+    assert "Shapes" in tile_map.object_lists
+    rectangle = tile_map.object_lists["Shapes"][0]
+    assert isclose(rectangle.shape[2][0] - rectangle.shape[0][0], 573.60, abs_tol=0.02)
+    assert isclose(rectangle.shape[0][1] - rectangle.shape[2][1], 469.04, abs_tol=0.02)
+    assert isclose(tile_map.tiled_map.map_size.height * tile_map.tiled_map.tile_size[1] - rectangle.shape[0][1], 630.37, abs_tol=0.02)
 
     # #
     # # Test getting layer in group


### PR DESCRIPTION
The new computation
- scale the rectangle as anyother coordinate
- use self.tiled_map.map_size.height * self.tiled_map.tile_size[1] to offset the y coordinate, otherwise they are negative.

Fix  #1740