### PR TITLE
Fix test that erroneously calls itself instead of waiting for pytest to call it

### DIFF
--- a/tests/unit/sprite/test_sprite_gif.py
+++ b/tests/unit/sprite/test_sprite_gif.py
@@ -4,7 +4,3 @@ import arcade
 def test_sprite_gif():
     sprite = arcade.load_animated_gif(":resources:images/test_textures/anim.gif")
     assert len(sprite.textures) == 8
-
-
-
-test_sprite_gif()


### PR DESCRIPTION
`test_sprite_gif` was calling itself.  This means a failure in that test would prevent any other tests from running.

You can verify this with `pytest --collect-only tests`  This tells pytest to discover the list of tests but not run any of them.  So it should not fail even if there are test failures.