### PR TITLE
Bump min pyglet to 2.0.6 for RGBA caret support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.3,<2.1",
+    "pyglet>=2.0.6,<2.1",
     "pillow~=9.4.0",
     "pymunk~=6.4.0",
     "pytiled-parser~=2.2.0"


### PR DESCRIPTION
### Changes

* Bump the minimum pyglet version to 2.0.6 so we can guarantee RGBA caret support in labels

### How to test

1. `pytest tests/unit` as usual
2. Run sound examples locally?

I've held off on further action on #1690 until pyglet shipped https://github.com/pyglet/pyglet/pull/806.

### Potential Issue

The one potential issue with this PR is an ignored exception related to OpenAL:
```console
============================= 558 passed, 2 xfailed, 2 warnings in 13.40s ==============================
Exception ignored in: <function OpenALDriver.__del__ at 0x7fabdc82bc10>
Traceback (most recent call last):
  File "/home/user/src/arcade/.venv/lib/python3.9/site-packages/pyglet/media/drivers/openal/adaptation.py", line 27, in __del__
    self.delete()
  File "/home/user/src/arcade/.venv/lib/python3.9/site-packages/pyglet/media/drivers/openal/adaptation.py", line 34, in delete
    self.worker.stop()
  File "/home/user/src/arcade/.venv/lib/python3.9/site-packages/pyglet/media/mediathreads.py", line 59, in stop
    self._thread.join()
  File "/usr/lib/python3.9/threading.py", line 1030, in join
    raise RuntimeError("cannot join current thread")
RuntimeError: cannot join current thread
```

System info:
```console
$ python -m arcade

Arcade 3.0.0.dev21
------------------
vendor: Intel
renderer: Mesa Intel(R) UHD Graphics 620 (KBL GT2)
version: (4, 6)
python: 3.9.2 (default, Feb 28 2021, 17:03:44) 
[GCC 10.2.1 20210110]
platform: linux
pyglet version: 2.0.6
PIL version: 9.4.0
```