### PR TITLE
Fix doc build warning misattributions by upgrading Sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "docutils==0.19",
     "furo",
     "pyyaml==6.0",
-    "sphinx==6.1.3",
+    "sphinx==6.2.1",
     "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.1",
     # Intentionally kept at 2.3 until this bugfix is published: https://github.com/jdillard/sphinx-sitemap/pull/62


### PR DESCRIPTION
### Changes

* Update sphinx to 6.2.1 in `pyproject.toml`

### Why

tl;dr 

1. Our current sphinx version does not correctly state the location of detected errors.
2. I've run into this issue before
3. At least one junior contributors has run into it in #1690.
4. `sphinx==6.2.1` fixes this issue
5. `6.2.1` is the last version before `7.0.0` makes breaking changes
6. Nothing seems to be obviously broken when running doc build locally

#### Before upgrading Sphinx

This is the error output received in our CI:
```
Warning, treated as error:
/home/runner/work/arcade/arcade/arcade/gui/widgets/text.py:docstring of arcade.gui.widgets.text.UITextWidget:1:Block quote ends without a blank line; unexpected unindent.
```
However, there is no block quote in the top level docstring.
```python
class UITextWidget(UIAnchorLayout):
    """
    Adds the ability to add text to a widget.

    The text can be placed within the widget using UIAnchorLayout parameters with `place_text()`.
    The text can be placed within the widget using
    :py:class:`~arcade.gui.UIAnchorLayout` parameters with
    :py:meth:`~arcade.gui.UITextWidget.place_text`.
    """
```

#### After upgrading Sphinx

Upgrading makes the location of the issue more legible:
```
/home/user/src/arcade/arcade/gui/widgets/text.py:docstring of arcade.gui.UITextWidget.multiline:4: WARNING: Block quote ends without a blank line; unexpected unindent.
```
At first glance, there doesn't seem to be anything immediately wrong. However, closer inspection allows us to understand it's the unescaped `\n`.
```python
  @property
  def multiline(self):
      """
      Multiline state of the widget. Newlines indicated with ``\n`` will only
      be honored if this is set to true. If you want a scrollable text widget,
      use :py:class:`~arcade.gui.TextArea`.
      """
      return self.label.multiline
```
