### PR TITLE
Improvements to make.py and pyright configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,8 @@ Tab completion would allow you to press tab to auto-complete the command:
 ./make.py html
 ```
 
+Note that this may interfere if you work on other projects that also have a `make.py` file.
+
 To enable this feature, most users can follow these steps:
 
 1. Run `./make.py whichshell` to find out what your default shell is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,15 +141,9 @@ Be sure to re-run build & refresh to update after making changes!
 
 ## Optional: Improve Ergonomics on Mac and Linux
 
-### Enable `./make.py`
+### `./make.py` shorthand
 
-On Mac & Linux, you can enable running `make.py` using `./make.py` instead
-of `python make.py` as follows:
-
-1. Make sure you are in the root directory of the repo
-2. Run `chmod u+x make.py`
-
-You can run the make script with `./make.py` instead of `python make.py`.
+On Mac & Linux, you can run the make script as `./make.py` instead of `python make.py`.
 
 For example, this command:
 ```commandline
@@ -163,8 +157,7 @@ can now be run this way:
 
 ### Enable Shell Completions
 
-After enabling the short-form syntax as outlined above, you can also enable tab
-completion for commands on the following supported shells:
+On Mac & Linux, you can enable tab completion for commands on the following supported shells:
 
 * `bash` (the most common default shell)
 * `zsh`

--- a/make.py
+++ b/make.py
@@ -151,7 +151,7 @@ def run_doc(args: Union[str, List[str]]) -> None:
     run(args, cd=FULL_DOC_DIR)
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def clean():
     """
     Delete built website files.
@@ -161,7 +161,7 @@ def clean():
             os.remove(item) if os.path.isfile(item) else rmtree(item)
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def html():
     """
     to make standalone HTML files
@@ -171,7 +171,7 @@ def html():
     print(f"Build finished. The HTML pages are in {FULL_BUILD_PREFIX}/html.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def serve():
     """
     Build and serve standalone HTML files, with automatic rebuilds and live reload.
@@ -179,7 +179,7 @@ def serve():
     run_doc([SPHINXAUTOBUILD, *SPHINXAUTOBUILDOPTS, '-b', 'html', *ALLSPHINXOPTS, f'{BUILDDIR}/html'])
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def dirhtml():
     """
     to make HTML files named index.html in directories
@@ -189,7 +189,7 @@ def dirhtml():
     print(f"Build finished. The HTML pages are in {FULL_BUILD_PREFIX}/dirhtml.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def singlehtml():
     """
     to make a single large HTML file
@@ -199,7 +199,7 @@ def singlehtml():
     print(f"Build finished. The HTML page is in {FULL_BUILD_PREFIX}/singlehtml.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def pickle():
     """
     to make pickle files
@@ -209,7 +209,7 @@ def pickle():
     print("Build finished; now you can process the pickle files.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def json():
     """
     to make JSON files
@@ -219,7 +219,7 @@ def json():
     print("Build finished; now you can process the JSON files.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def htmlhelp():
     """
     to make HTML files and a HTML help project
@@ -230,7 +230,7 @@ def htmlhelp():
           f".hhp project file in {FULL_BUILD_PREFIX}/htmlhelp.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def qthelp():
     """
     to make HTML files and a qthelp project
@@ -244,7 +244,7 @@ def qthelp():
     print(f"# assistant -collectionFile {FULL_BUILD_PREFIX}/qthelp/Arcade.qhc")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def applehelp():
     """
     to make an Apple Help Book
@@ -257,7 +257,7 @@ def applehelp():
           "bundle.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def devhelp():
     """
     to make HTML files and a Devhelp project
@@ -272,7 +272,7 @@ def devhelp():
     print("# devhelp")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def epub():
     """
     to make an epub
@@ -282,7 +282,7 @@ def epub():
     print(f"Build finished. The epub file is in {FULL_BUILD_PREFIX}/epub.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def latex():
     """
     to make LaTeX files, you can set PAPER_SIZE=a4 or PAPER_SIZE=letter
@@ -294,7 +294,7 @@ def latex():
           "(use \`make latexpdf' here to do that automatically).")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def latexpdf():
     """
     to make LaTeX files and run them through pdflatex
@@ -305,7 +305,7 @@ def latexpdf():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_PREFIX}/latex.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def latexpdfja():
     """
     to make LaTeX files and run them through platex/dvipdfmx
@@ -316,7 +316,7 @@ def latexpdfja():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_PREFIX}/latex.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def text():
     """
     to make text files
@@ -326,7 +326,7 @@ def text():
     print(f"Build finished. The text files are in {FULL_BUILD_PREFIX}/text.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def man():
     """
     to make manual pages
@@ -336,7 +336,7 @@ def man():
     print(f"Build finished. The manual pages are in {FULL_BUILD_PREFIX}/man.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def texinfo():
     """
     to make Texinfo files
@@ -348,7 +348,7 @@ def texinfo():
           "(use \`make info' here to do that automatically).")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def info():
     """
     to make Texinfo files and run them through makeinfo
@@ -359,7 +359,7 @@ def info():
     print(f"makeinfo finished; the Info files are in {FULL_BUILD_PREFIX}/texinfo.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def gettext():
     """
     to make PO message catalogs
@@ -369,7 +369,7 @@ def gettext():
     print(f"Build finished. The message catalogs are in {FULL_BUILD_PREFIX}/locale.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def changes():
     """
     to make an overview of all changed/added/deprecated items
@@ -379,7 +379,7 @@ def changes():
     print(f"The overview file is in {FULL_BUILD_PREFIX}/changes.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def linkcheck():
     """
     to check all external links for integrity
@@ -390,7 +390,7 @@ def linkcheck():
           f"or in {FULL_BUILD_PREFIX}/linkcheck/output.txt.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def doctest():
     """
     to run all doctests embedded in the documentation (if enabled)
@@ -400,7 +400,7 @@ def doctest():
           f"results in {FULL_BUILD_PREFIX}/doctest/output.txt.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def coverage():
     """
     to run coverage check of the documentation (if enabled)
@@ -410,21 +410,21 @@ def coverage():
           f"results in {FULL_BUILD_PREFIX}/coverage/python.txt.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def xml():
     run_doc([SPHINXBUILD, "-b", "xml", *ALLSPHINXOPTS, f"{BUILDDIR}/xml"])
     print()
     print(f"Build finished. The XML files are in {FULL_BUILD_PREFIX}/xml.")
 
 
-@app.command()
+@app.command(rich_help_panel="Docs")
 def pseudoxml():
     run_doc([SPHINXBUILD, "-b", "pseudoxml", *ALLSPHINXOPTS, f"{BUILDDIR}/pseudoxml"])
     print()
     print(f"Build finished. The pseudo-XML files are in {FULL_BUILD_PREFIX}/pseudoxml.")
 
 
-@app.command()
+@app.command(rich_help_panel="Coding")
 def lint():
     """
     Run all linting tasks: ruff and mypy
@@ -434,31 +434,32 @@ def lint():
     print("Linting Complete.")
 
 
-@app.command()
+@app.command(rich_help_panel="Coding")
 def ruff():
     run([RUFF, *RUFFOPTS])
     print("Ruff Finished.")
 
 
-@app.command()
+@app.command(rich_help_panel="Coding")
 def mypy():
     "Typecheck using mypy"
     run([MYPY, *MYPYOPTS])
     print("MyPy Finished.")
 
-@app.command()
+
+@app.command(rich_help_panel="Coding")
 def pyright():
     "Typecheck using pyright"
     run([PYRIGHT, *PYRIGHTOPTS])
     print("Pyright Finished.")
 
 
-@app.command()
+@app.command(rich_help_panel="Coding")
 def test_full():
     run([PYTEST, TESTDIR])
 
 
-@app.command()
+@app.command(rich_help_panel="Coding")
 def test():
     run([PYTEST, UNITTESTS])
 

--- a/make.py
+++ b/make.py
@@ -461,6 +461,7 @@ def test_full():
 
 @app.command(rich_help_panel="Coding")
 def test():
+    """Run unit tests (Run this before making a pull request)!"""
     run([PYTEST, UNITTESTS])
 
 

--- a/make.py
+++ b/make.py
@@ -179,7 +179,7 @@ def serve():
     run_doc([SPHINXAUTOBUILD, *SPHINXAUTOBUILDOPTS, '-b', 'html', *ALLSPHINXOPTS, f'{BUILDDIR}/html'])
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def dirhtml():
     """
     to make HTML files named index.html in directories
@@ -189,7 +189,7 @@ def dirhtml():
     print(f"Build finished. The HTML pages are in {FULL_BUILD_PREFIX}/dirhtml.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def singlehtml():
     """
     to make a single large HTML file
@@ -199,7 +199,7 @@ def singlehtml():
     print(f"Build finished. The HTML page is in {FULL_BUILD_PREFIX}/singlehtml.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def pickle():
     """
     to make pickle files
@@ -209,7 +209,7 @@ def pickle():
     print("Build finished; now you can process the pickle files.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def json():
     """
     to make JSON files
@@ -219,7 +219,7 @@ def json():
     print("Build finished; now you can process the JSON files.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def htmlhelp():
     """
     to make HTML files and a HTML help project
@@ -230,7 +230,7 @@ def htmlhelp():
           f".hhp project file in {FULL_BUILD_PREFIX}/htmlhelp.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def qthelp():
     """
     to make HTML files and a qthelp project
@@ -244,7 +244,7 @@ def qthelp():
     print(f"# assistant -collectionFile {FULL_BUILD_PREFIX}/qthelp/Arcade.qhc")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def applehelp():
     """
     to make an Apple Help Book
@@ -257,7 +257,7 @@ def applehelp():
           "bundle.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def devhelp():
     """
     to make HTML files and a Devhelp project
@@ -272,7 +272,7 @@ def devhelp():
     print("# devhelp")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def epub():
     """
     to make an epub
@@ -282,7 +282,7 @@ def epub():
     print(f"Build finished. The epub file is in {FULL_BUILD_PREFIX}/epub.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def latex():
     """
     to make LaTeX files, you can set PAPER_SIZE=a4 or PAPER_SIZE=letter
@@ -294,7 +294,7 @@ def latex():
           "(use \`make latexpdf' here to do that automatically).")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def latexpdf():
     """
     to make LaTeX files and run them through pdflatex
@@ -305,7 +305,7 @@ def latexpdf():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_PREFIX}/latex.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def latexpdfja():
     """
     to make LaTeX files and run them through platex/dvipdfmx
@@ -316,7 +316,7 @@ def latexpdfja():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_PREFIX}/latex.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def text():
     """
     to make text files
@@ -326,7 +326,7 @@ def text():
     print(f"Build finished. The text files are in {FULL_BUILD_PREFIX}/text.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def man():
     """
     to make manual pages
@@ -336,7 +336,7 @@ def man():
     print(f"Build finished. The manual pages are in {FULL_BUILD_PREFIX}/man.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def texinfo():
     """
     to make Texinfo files
@@ -348,7 +348,7 @@ def texinfo():
           "(use \`make info' here to do that automatically).")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def info():
     """
     to make Texinfo files and run them through makeinfo
@@ -359,7 +359,7 @@ def info():
     print(f"makeinfo finished; the Info files are in {FULL_BUILD_PREFIX}/texinfo.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def gettext():
     """
     to make PO message catalogs
@@ -369,7 +369,7 @@ def gettext():
     print(f"Build finished. The message catalogs are in {FULL_BUILD_PREFIX}/locale.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def changes():
     """
     to make an overview of all changed/added/deprecated items
@@ -379,7 +379,7 @@ def changes():
     print(f"The overview file is in {FULL_BUILD_PREFIX}/changes.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Code Quality")
 def linkcheck():
     """
     to check all external links for integrity
@@ -390,7 +390,7 @@ def linkcheck():
           f"or in {FULL_BUILD_PREFIX}/linkcheck/output.txt.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def doctest():
     """
     to run all doctests embedded in the documentation (if enabled)
@@ -400,7 +400,7 @@ def doctest():
           f"results in {FULL_BUILD_PREFIX}/doctest/output.txt.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def coverage():
     """
     to run coverage check of the documentation (if enabled)
@@ -410,58 +410,58 @@ def coverage():
           f"results in {FULL_BUILD_PREFIX}/coverage/python.txt.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def xml():
     run_doc([SPHINXBUILD, "-b", "xml", *ALLSPHINXOPTS, f"{BUILDDIR}/xml"])
     print()
     print(f"Build finished. The XML files are in {FULL_BUILD_PREFIX}/xml.")
 
 
-@app.command(rich_help_panel="Docs")
+@app.command(rich_help_panel="Additional Doc Formats")
 def pseudoxml():
     run_doc([SPHINXBUILD, "-b", "pseudoxml", *ALLSPHINXOPTS, f"{BUILDDIR}/pseudoxml"])
     print()
     print(f"Build finished. The pseudo-XML files are in {FULL_BUILD_PREFIX}/pseudoxml.")
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def lint():
     """
-    Run all linting tasks: ruff and mypy
+    Run all linting tasks: ruff and mypy (Run this before making a pull request!)
     """
     ruff()
     mypy()
     print("Linting Complete.")
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def ruff():
     run([RUFF, *RUFFOPTS])
     print("Ruff Finished.")
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def mypy():
     "Typecheck using mypy"
     run([MYPY, *MYPYOPTS])
     print("MyPy Finished.")
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def pyright():
     "Typecheck using pyright"
     run([PYRIGHT, *PYRIGHTOPTS])
     print("Pyright Finished.")
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def test_full():
     run([PYTEST, TESTDIR])
 
 
-@app.command(rich_help_panel="Coding")
+@app.command(rich_help_panel="Code Quality")
 def test():
-    """Run unit tests (Run this before making a pull request)!"""
+    """Run unit tests (Run this before making a pull request!)"""
     run([PYTEST, UNITTESTS])
 
 
@@ -474,7 +474,7 @@ SHELLS_WITH_AUTOCOMPLETE = (
 )
 
 
-@app.command()
+@app.command(rich_help_panel="Shell Completion")
 def whichshell():
     """to find out which shell your system seems to be running"""
 

--- a/make.py
+++ b/make.py
@@ -48,7 +48,8 @@ RUFF        = "ruff"
 RUFFOPTS    = ["arcade"]
 MYPY        = "mypy"
 MYPYOPTS    = ["arcade"]
-
+PYRIGHT     = "pyright"
+PYRIGHTOPTS = []
 
 # Testing
 PYTEST  = "pytest"
@@ -425,10 +426,11 @@ def pseudoxml():
 
 @app.command()
 def lint():
-    run([RUFF, *RUFFOPTS])
-    print("Ruff Finished.")
-    run([MYPY, *MYPYOPTS])
-    print("Mypy Finished.")
+    """
+    Run all linting tasks: ruff and mypy
+    """
+    ruff()
+    mypy()
     print("Linting Complete.")
 
 
@@ -440,8 +442,15 @@ def ruff():
 
 @app.command()
 def mypy():
+    "Typecheck using mypy"
     run([MYPY, *MYPYOPTS])
     print("MyPy Finished.")
+
+@app.command()
+def pyright():
+    "Typecheck using pyright"
+    run([PYRIGHT, *PYRIGHTOPTS])
+    print("Pyright Finished.")
 
 
 @app.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "sphinx-copybutton==0.5.1",
     # Intentionally kept at 2.3 until this bugfix is published: https://github.com/jdillard/sphinx-sitemap/pull/62
     "sphinx-sitemap==2.3.0",
-    "typer==0.7.0",
+    "typer[all]==0.7.0",
     "wheel",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pygments==2.14.0",
     "docutils==0.19",
     "furo",
+    "pyright",
     "pyyaml==6.0",
     "sphinx==6.1.3",
     "sphinx-autobuild==2021.3.14",
@@ -103,6 +104,9 @@ norecursedirs = ["doc", "holding", "arcade/examples", "build", ".venv", "env", "
 [tool.pyright]
 include = ["arcade"]
 exclude = ["venv", "arcade/examples", "arcade/experimental", "tests", "doc"]
+# Use type info from pytiled_parser and pyglet, which do not ship `py.typed` file
+useLibraryCodeForTypes = true
+reportMissingTypeStubs = "none"
 
 [tool.coverage.run]
 source = ["arcade"]


### PR DESCRIPTION
I would have submitted as 2x PRs, but unfortunately one depends on the other and stacked PRs don't really work if you're submitting from a fork.

These changes are extracted from #1738 plus some things we talked about on Discord.  Hopefully this changeset is purely non-controversial stuff.

- adds `./make.py pyright` but does _not_ add it to `./make.py lint`
- improve pyright config, telling it how to typecheck deps that don't bundle types
- add categorization to typer subcommands
- tweak contributing.md since `make.py` gets execute bit automatically, no need to `chmod` manually