### PR TITLE
Improve docstring test legibility for junior devs

### DIFF
--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -69,18 +69,25 @@ def check_submodules(parent_module_absolute_name: str) -> None:
 
 def test_docstrings():
     """
-    Check each example for a docstring with correct run instructions.
+    Ensure each user-facing example has a docstring with correct run instructions.
     """
 
-    # Get all the modules in the examples directory
+    # Check all immediate child python files in arcade.examples
     check_submodules(EXAMPLE_ROOT)
 
-    # Check subdirectories
-    for path in Path(arcade.examples.__path__[0]).iterdir():
-        if not path.is_dir():
+    # For each immediate child folder module in arcade.examples,
+    # check the immediate child python files for correct docstrings.
+    for folder_submodule_path in Path(arcade.examples.__path__[0]).iterdir():
+
+        # Skip file modules we already covered above outside the loop
+        if not folder_submodule_path.is_dir():
             continue
 
-        if any(pattern in path.name for pattern in ("__", "perf_test", "text_loc")):
+        folder_submodule_name = folder_submodule_path.name
+
+        # Skip anything which isn't a user-facing example
+        if any(pattern in folder_submodule_name for pattern in ("__", "perf_test", "text_loc")):
             continue
 
-        check_submodules(f"{EXAMPLE_ROOT}.{path.name}")
+        # Check the grandchildren inside the child folder module
+        check_submodules(f"{EXAMPLE_ROOT}.{folder_submodule_name}")

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -39,10 +39,9 @@ def check_code_docstring(path: Path, name: str):
     path: Path to the file
     name: Name of module
     """
-    with open(path) as f:
-        code = ast.parse(f.read())
-        docstring = ast.get_docstring(code)
-        run_line = f"python -m {name}"
-        # print(f"Checking if example {name} has a run instruction..")
-        assert docstring is not None, f"{run_line} not in {name} docstring."
-        assert run_line in docstring, f"{run_line} not in {name} docstring."
+    code = ast.parse(path.read_text())
+    docstring = ast.get_docstring(code)
+    run_line = f"python -m {name}"
+    # print(f"Checking if example {name} has a run instruction..")
+    assert docstring is not None, f"{run_line} not in {name} docstring."
+    assert run_line in docstring, f"{run_line} not in {name} docstring."

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -36,12 +36,33 @@ def check_submodules(module_path: str):
 
 def check_code_docstring(path: Path, name: str):
     """
-    path: Path to the file
-    name: Name of module
+    Read & check a single file for an appropriate docstring
+
+    A docstring should consist of the following:
+
+    1. A summary line explaining what it demonstrates per PEP-0257
+       (https://peps.python.org/pep-0257/#multi-line-docstrings)
+    2. If necessary, a further minimal explanation of how it will do so
+    3. A line specifying how this example can be as a module run, usually at
+       the end
+
+    Example::
+
+       \"\"\"
+       Show a timer on screen
+
+       If Python and Arcade are installed, this example can be run from the command line with:
+       python -m arcade.examples.sprite_rooms
+       \"\"\"
+
+    :param path: Path to the file
+    :param name: Name of module
     """
     code = ast.parse(path.read_text())
     docstring = ast.get_docstring(code)
     run_line = f"python -m {name}"
+
     # print(f"Checking if example {name} has a run instruction..")
     assert docstring is not None, f"{run_line} not in {name} docstring."
     assert run_line in docstring, f"{run_line} not in {name} docstring."
+

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -9,8 +9,7 @@ EXAMPLE_ROOT = "arcade.examples"
 
 def test_docstrings():
     """
-    Check each example for docstring.
-    Check each example for valid run instructions.
+    Check each example for a docstring with correct run instructions.
     """
     ignore_patterns = ["__", "perf_test", "text_loc"]
 

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -9,32 +9,6 @@ EXAMPLE_ROOT = "arcade.examples"
 SKIP_FILENAME_PATTERNS = ("__", "perf_test", "text_loc")
 
 
-def test_docstrings():
-    """
-    Check each example for a docstring with correct run instructions.
-    """
-
-    # Get all the modules in the examples directory
-    check_submodules(EXAMPLE_ROOT)
-
-    # Check subdirectories
-    for path in Path(arcade.examples.__path__[0]).iterdir():
-        if not path.is_dir():
-            continue
-
-        if any(pattern in path.name for pattern in SKIP_FILENAME_PATTERNS):
-            continue
-
-        check_submodules(f"{EXAMPLE_ROOT}.{path.name}")
-
-
-def check_submodules(module_path: str):
-    module = importlib.import_module(module_path)
-    for finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
-        path = Path(finder.path) / f"{name}.py"
-        check_single_example_docstring(path, f"{module_path}.{name}")
-
-
 def check_single_example_docstring(path: Path, name: str):
     """
     Read & check a single file for an appropriate docstring
@@ -68,3 +42,29 @@ def check_single_example_docstring(path: Path, name: str):
     run_line = f"python -m {name}"
     assert docstring is not None, f"{run_line} not in {name} docstring."
     assert run_line in docstring, f"{run_line} not in {name} docstring."
+
+
+def check_submodules(module_path: str):
+    module = importlib.import_module(module_path)
+    for finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
+        path = Path(finder.path) / f"{name}.py"
+        check_single_example_docstring(path, f"{module_path}.{name}")
+
+
+def test_docstrings():
+    """
+    Check each example for a docstring with correct run instructions.
+    """
+
+    # Get all the modules in the examples directory
+    check_submodules(EXAMPLE_ROOT)
+
+    # Check subdirectories
+    for path in Path(arcade.examples.__path__[0]).iterdir():
+        if not path.is_dir():
+            continue
+
+        if any(pattern in path.name for pattern in SKIP_FILENAME_PATTERNS):
+            continue
+
+        check_submodules(f"{EXAMPLE_ROOT}.{path.name}")

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -9,7 +9,7 @@ EXAMPLE_ROOT = "arcade.examples"
 SKIP_FILENAME_PATTERNS = ("__", "perf_test", "text_loc")
 
 
-def check_single_example_docstring(path: Path, name: str):
+def check_single_example_docstring(path: Path, name: str) -> None:
     """
     Read & check a single file for an appropriate docstring
 
@@ -44,7 +44,7 @@ def check_single_example_docstring(path: Path, name: str):
     assert run_line in docstring, f"{run_line} not in {name} docstring."
 
 
-def check_submodules(module_path: str):
+def check_submodules(module_path: str) -> None:
     module = importlib.import_module(module_path)
     for finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
         path = Path(finder.path) / f"{name}.py"

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -4,14 +4,15 @@ from pathlib import Path
 import pkgutil
 import arcade.examples
 
+
 EXAMPLE_ROOT = "arcade.examples"
+SKIP_FILENAME_PATTERNS = ("__", "perf_test", "text_loc")
 
 
 def test_docstrings():
     """
     Check each example for a docstring with correct run instructions.
     """
-    ignore_patterns = ["__", "perf_test", "text_loc"]
 
     # Get all the modules in the examples directory
     check_submodules(EXAMPLE_ROOT)
@@ -21,7 +22,7 @@ def test_docstrings():
         if not path.is_dir():
             continue
 
-        if any(pattern in path.name for pattern in ignore_patterns):
+        if any(pattern in path.name for pattern in SKIP_FILENAME_PATTERNS):
             continue
 
         check_submodules(f"{EXAMPLE_ROOT}.{path.name}")

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -67,4 +67,3 @@ def check_single_example_docstring(path: Path, name: str):
     run_line = f"python -m {name}"
     assert docstring is not None, f"{run_line} not in {name} docstring."
     assert run_line in docstring, f"{run_line} not in {name} docstring."
-

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -31,10 +31,10 @@ def check_submodules(module_path: str):
     module = importlib.import_module(module_path)
     for finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
         path = Path(finder.path) / f"{name}.py"
-        check_code_docstring(path, f"{module_path}.{name}")
+        check_single_example_docstring(path, f"{module_path}.{name}")
 
 
-def check_code_docstring(path: Path, name: str):
+def check_single_example_docstring(path: Path, name: str):
     """
     Read & check a single file for an appropriate docstring
 

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -58,11 +58,13 @@ def check_single_example_docstring(path: Path, name: str):
     :param path: Path to the file
     :param name: Name of module
     """
+
+    # Read the file & extract the docstring
     code = ast.parse(path.read_text())
     docstring = ast.get_docstring(code)
-    run_line = f"python -m {name}"
 
     # print(f"Checking if example {name} has a run instruction..")
+    run_line = f"python -m {name}"
     assert docstring is not None, f"{run_line} not in {name} docstring."
     assert run_line in docstring, f"{run_line} not in {name} docstring."
 

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -44,11 +44,28 @@ def check_single_example_docstring(path: Path, name: str) -> None:
     assert run_line in docstring, f"{run_line} not in {name} docstring."
 
 
-def check_submodules(module_path: str) -> None:
-    module = importlib.import_module(module_path)
-    for finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
-        path = Path(finder.path) / f"{name}.py"
-        check_single_example_docstring(path, f"{module_path}.{name}")
+def check_submodules(parent_module_absolute_name: str) -> None:
+    """
+    Check docstrings for all immediate child modules of the passed absolute name
+
+    It is important to understand that module names and file paths are different things:
+
+    * A module name is what Python sees the module's name as (``"arcade.color"``)
+    * A file path is the location on disk (``C:|Users\Reader\python_project\game.py``)
+
+    :param parent_module_absolute_name: The absolute import name of the module to check.
+    """
+    # Get the file system location of the named parent module
+    parent_module_info = importlib.import_module(parent_module_absolute_name)
+    parent_module_file_path = parent_module_info.__path__
+
+    # Check all modules nested immediately inside it on the file system
+    for finder, child_module_name, is_pkg in pkgutil.iter_modules(parent_module_file_path):
+
+        child_module_file_path = Path(finder.path) / f"{child_module_name}.py"
+        child_module_absolute_name = f"{parent_module_absolute_name}.{child_module_name}"
+
+        check_single_example_docstring(child_module_file_path, child_module_absolute_name)
 
 
 def test_docstrings():

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -6,7 +6,6 @@ import arcade.examples
 
 
 EXAMPLE_ROOT = "arcade.examples"
-SKIP_FILENAME_PATTERNS = ("__", "perf_test", "text_loc")
 
 
 def check_single_example_docstring(path: Path, name: str) -> None:
@@ -81,7 +80,7 @@ def test_docstrings():
         if not path.is_dir():
             continue
 
-        if any(pattern in path.name for pattern in SKIP_FILENAME_PATTERNS):
+        if any(pattern in path.name for pattern in ("__", "perf_test", "text_loc")):
             continue
 
         check_submodules(f"{EXAMPLE_ROOT}.{path.name}")


### PR DESCRIPTION
### Changes

tl;dr Improves the state of #1570 by outputting the example docstring spec on failure & generally improving test clarity

* Add a brief explanation of the expected example docstring format to test failures by expanding the relevant function docstring
* Use `Path.read_text` to immediately close source files after read
* Rearrange functions in dependency order
* Rename variables for clarity
* Add comments

### How to test

1. Delete `python -m` line from any example(s) in `arcade/examples` or one of its immediate child folders, except for `perf_test` and internationalization example files / folders.
2. `./make.py test`
3. Check for the full docstring of `check_code_docstring` in the output

### Follow-up work

While working on this PR, I discovered the following problems:

1. The GUI examples do not match our docstring standard
2. The GUI examples (`arcade.gui.examples.*`) are not covered by the test due to the test assuming all examples are in the same folder.
3. Recursion into deeper submodules (`arcade.examples.gl.ray_marching.*`) is broken

#### Generalized Docstring Check Functionality?

I do not know what @eruvanos is planning to do with the example structure. The second two problems may be best handled by refactoring the test  to:
1. fully recurse modules / folders
2. generalize docstring check functionality into something which takes a callable