### PR TITLE
UIDummy clarity improvements

### DIFF
--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -716,8 +716,14 @@ class UIInteractiveWidget(UIWidget):
 
 class UIDummy(UIInteractiveWidget):
     """
-    Solid color widget, used for testing.
-    Prints own rect on click.
+    Solid color widget used for testing & examples
+
+    It should not be subclassed for real-world usage.
+
+    When clicked, it does the following:
+
+    * Outputs its `rect` attribute to the console
+    * Changes its color to a new, random color
 
     :param float x: x coordinate of bottom left
     :param float y: y coordinate of bottom left

--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -33,7 +33,7 @@ from arcade.types import RGBA255, Color
 if TYPE_CHECKING:
     from arcade.gui.ui_manager import UIManager
 
-__all__ = ["Surface"]
+__all__ = ["Surface", "UIDummy"]
 
 
 class Rect(NamedTuple):

--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -28,7 +28,7 @@ from arcade.gui.events import (
 from arcade.gui.nine_patch import NinePatchTexture
 from arcade.gui.property import Property, bind, ListProperty
 from arcade.gui.surface import Surface
-from arcade.types import RGBA255
+from arcade.types import RGBA255, Color
 
 if TYPE_CHECKING:
     from arcade.gui.ui_manager import UIManager
@@ -765,7 +765,7 @@ class UIDummy(UIInteractiveWidget):
 
     def on_click(self, event: UIOnClickEvent):
         print("UIDummy.rect:", self.rect)
-        self.color = (randint(0, 255), randint(0, 255), randint(0, 255))
+        self.color = Color.random(a=255)
 
     def on_update(self, dt):
         self.border_width = 2 if self.hovered else 0

--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -723,7 +723,7 @@ class UIDummy(UIInteractiveWidget):
     When clicked, it does the following:
 
     * Outputs its `rect` attribute to the console
-    * Changes its color to a new, random color
+    * Changes its color to a random fully opaque color
 
     :param float x: x coordinate of bottom left
     :param float y: y coordinate of bottom left


### PR DESCRIPTION
### Changes

tl;dr minor clarity improvements discovered during work on a follow-up to #1750

1. Clean up UIDummy top-level docstring
2. Fix a PyCharm linter highlight by adding UIDummy to an `__all__` list
3. Use `Color.random(a=255)` instead of inlined RGB tuple generation

### How to test

1. `python -m arcade.gui.examples.box_layout`
2. Make sure UIDummy instances still change colors when clicked
3. Make sure UIDummy instances still print their rect values to the terminal when clicked

### Follow-ups

I'll be submitting another PR containing docstring fixes for the GUI examples later.