### PR TITLE
Increase min pyglet version to fix group issues with caret

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.6,<2.1",
+    "pyglet>=2.0.7,<2.1",
     "pillow~=9.4.0",
     "pymunk~=6.4.0",
     "pytiled-parser~=2.2.0"


### PR DESCRIPTION
### Changes

* Increase min pyglet version to 2.0.7 to include [a fix for incorrect group handling](https://github.com/pyglet/pyglet/commit/c0b7e7797b545f2790138c28773da0015241b7e0)
