### PR TITLE
Fix Surface.draw_texture (#1705)

### DIFF
--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -98,9 +98,6 @@ class Surface:
         alpha: int = 255,
     ):
         if isinstance(tex, NinePatchTexture):
-            if x != 0 or y != 0:
-                raise NotImplementedError("Ninepatch does not support a position != (0,0) yet")
-
             if angle != 0.0:
                 raise NotImplementedError("Ninepatch does not support a angle != 0 yet")
 

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -99,10 +99,10 @@ class Surface:
     ):
         if isinstance(tex, NinePatchTexture):
             if angle != 0.0:
-                raise NotImplementedError("Ninepatch does not support a angle != 0 yet")
+                raise NotImplementedError(f"Ninepatch does not support an angle != 0 yet, but got {angle}")
 
             if alpha != 255:
-                raise NotImplementedError("Ninepatch does not support a alpha != 255 yet")
+                raise NotImplementedError(f"Ninepatch does not support an alpha != 255 yet, but got {alpha}")
 
             tex.draw_sized(size=(width, height))
         else:

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -94,18 +94,18 @@ class Surface:
         width: float,
         height: float,
         tex: Union[Texture, NinePatchTexture],
-        angle=0,
+        angle: float = 0.0,
         alpha: int = 255,
     ):
         if isinstance(tex, NinePatchTexture):
             if x != 0 or y != 0:
-                raise ValueError("Ninepatch does not support a position != (0,0) yet")
+                raise NotImplementedError("Ninepatch does not support a position != (0,0) yet")
 
-            if x != 0 or y != 0:
-                raise ValueError("Ninepatch does not support a angle != 0 yet")
+            if angle != 0.0:
+                raise NotImplementedError("Ninepatch does not support a angle != 0 yet")
 
-            if x != 0 or y != 0:
-                raise ValueError("Ninepatch does not support a alpha != 255 yet")
+            if alpha != 0:
+                raise NotImplementedError("Ninepatch does not support a alpha != 255 yet")
 
             tex.draw_sized(size=(width, height))
         else:

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -101,7 +101,7 @@ class Surface:
             if angle != 0.0:
                 raise NotImplementedError("Ninepatch does not support a angle != 0 yet")
 
-            if alpha != 0:
+            if alpha != 255:
                 raise NotImplementedError("Ninepatch does not support a alpha != 255 yet")
 
             tex.draw_sized(size=(width, height))

--- a/tests/unit/gui/test_surface.py
+++ b/tests/unit/gui/test_surface.py
@@ -1,0 +1,33 @@
+import pytest
+
+from arcade import load_texture
+from arcade.gui import Surface, NinePatchTexture
+
+
+def test_surface_draw_texture_raises_not_implemented_error_on_unsupported_values(window):
+    ninepatch_tx = NinePatchTexture(
+        left=5,
+        right=5,
+        top=5,
+        bottom=5,
+        texture=load_texture(
+            ":resources:gui_basic_assets/window/dark_blue_gray_panel.png"
+    ))
+    surface = Surface(size=(100, 100))
+
+    def keywords_only(**kwargs):
+        surface.draw_texture(0, 0, 20, 20, ninepatch_tx, **kwargs)
+
+    with pytest.raises(NotImplementedError):
+        keywords_only(alpha=128)
+
+    with pytest.raises(NotImplementedError):
+        keywords_only(angle=30.0)
+
+    with pytest.raises(NotImplementedError):
+        keywords_only(alpha=10, angle=30.0)
+
+
+
+
+


### PR DESCRIPTION
Closes #1705 

### Changes

* `arcade.gui.Surface.draw_texture` now raises `NotImplementedError` when alpha != 255 or angle != 0.
* Added test

### How to test

Run test suite as normal

### Retained for context 

~~I have the logic corrected, but there are two questions I need answered:~~

1. ~~Is support for position implemented? [One comment says it is](https://github.com/pythonarcade/arcade/pull/1682#discussion_r1158379744), while [another gives me the impression it isn't](https://github.com/pythonarcade/arcade/issues/1705#issuecomment-1514367795).~~  Updated per comments
2. ~~Is using the `window` fixture acceptable in `tests/unit`? If not, should I build out a new `mock_window` fixture to fully or partially mock the gl context + window?~~ Implemented. I'd prefer to decouple this better, but it won't get us closer to 3.0.
