### PR TITLE
Add performance warning to Sprite.draw docstring

### DIFF
--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -327,7 +327,14 @@ class Sprite(BasicSprite, PymunkMixin):
 
     def draw(self, *, filter=None, pixelated=None, blend_function=None) -> None:
         """
-        Draw the sprite.
+        A debug method which draws the sprite into the current OpenGL context.
+
+        .. warning:: You are probably looking for :py:meth:`SpriteList.draw() <arcade.SpriteList.draw>`!
+
+                     Drawing individual sprites is slow compared to using :py:class:`~arcade.SpriteList`.
+                     See :ref:`pg_spritelists_why` for more information.
+
+        This method should not be relied on. It may be removed one day.
 
         :param filter: Optional parameter to set OpenGL filter, such as
                        `gl.GL_NEAREST` to avoid smoothing.


### PR DESCRIPTION
### Changes

Add a warning to the Sprite.draw docstring

This is split off from the WIP changes in #1620.

### How to test

`./make.py html` and/or `./make.py serve`
