### PR TITLE
Add basic type annotations & docstrings to arcade.hitbox.base

### DIFF
--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -37,7 +37,8 @@ class HitBoxAlgorithm:
         """
         A string representation of the parameters used to create this algorithm.
 
-        This is used when caching :py:class:`~arcade.Texture` instances.
+        Subclasses should override this method to return a meaningful value since this
+        method is called when caching :py:class:`~arcade.Texture` instances.
         """
         return ""
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import cos, radians, sin
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 
 from PIL.Image import Image
 
@@ -9,6 +9,12 @@ from arcade.types import Point, PointList
 
 
 __all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
+
+
+# Speed / typing workaround:
+# 1. Makes sure we don't reallocate new empty tuples
+# 2. Allows HitBox & subclass typing annotation to work cleanly
+_EMPTY_TUPLE = tuple()
 
 
 class HitBoxAlgorithm:
@@ -63,6 +69,19 @@ class HitBoxAlgorithm:
 
 
 class HitBox:
+    """
+    A basic hit box class supporting scaling.
+
+    It includes support for rescaling as well as shorthand properties
+    for boundary values along the X and Y axes. For rotation support,
+    use :py:meth:`.create_rotatable` to create an instance of
+    :py:class:`RotatableHitBox`.
+
+    :param points: The unmodified points bounding the hit box
+    :param position: The center around which the points will be offset
+    :param scale: The X and Y scaling factors to use when offsetting the
+        points
+    """
     def __init__(
         self,
         points: PointList,
@@ -78,15 +97,27 @@ class HitBox:
         self._bottom = None
         self._top = None
 
-        self._adjusted_points = None
+        # This empty tuple will be replaced the first time
+        # get_adjusted_points is called
+        self._adjusted_points: PointList = _EMPTY_TUPLE
         self._adjusted_cache_dirty = True
 
     @property
-    def points(self):
+    def points(self) -> PointList:
+        """
+        The raw, unadjusted points of this hit box.
+
+        These are the points as originally passed before offsetting, scaling,
+        and any operations subclasses may perform, such as rotation.
+        """
         return self._points
 
     @property
-    def position(self):
+    def position(self) -> Point:
+        """
+        The center point used to offset the final adjusted positions.
+        :return:
+        """
         return self._position
 
     @position.setter
@@ -95,31 +126,48 @@ class HitBox:
         self._adjusted_cache_dirty = True
 
     @property
-    def left(self):
+    def left(self) -> float:
+        """
+        Calculates the leftmost adjusted x position of this hit box
+        """
         points = self.get_adjusted_points()
         x_points = [point[0] for point in points]
         return min(x_points)
 
     @property
-    def right(self):
+    def right(self) -> float:
+        """
+        Calculates the rightmost adjusted x position of this hit box
+        """
         points = self.get_adjusted_points()
         x_points = [point[0] for point in points]
         return max(x_points)
 
     @property
-    def top(self):
+    def top(self) -> float:
+        """
+        Calculates the topmost adjusted y position of this hit box
+        """
         points = self.get_adjusted_points()
         y_points = [point[1] for point in points]
         return max(y_points)
 
     @property
-    def bottom(self):
+    def bottom(self) -> float:
+        """
+        Calculates the bottommost adjusted y position of this hit box
+        """
         points = self.get_adjusted_points()
         y_points = [point[1] for point in points]
         return min(y_points)
 
     @property
-    def scale(self):
+    def scale(self) -> Tuple[float, float]:
+        """
+        The X & Y scaling factors for the points in this hit box.
+
+        These are used to calculate the final adjusted positions of points.
+        """
         return self._scale
 
     @scale.setter
@@ -131,11 +179,27 @@ class HitBox:
         self,
         angle: float = 0.0,
     ) -> RotatableHitBox:
+        """
+        Create a rotatable instance of this hit box.
+
+        The internal point list is transferred directly instead of
+        deepcopied, so care should be taken if using a mutable internal
+        representation.
+
+        :param angle: The angle to rotate points by (0 by default)
+        :return:
+        """
         return RotatableHitBox(
             self._points, position=self._position, scale=self._scale, angle=angle
         )
 
-    def get_adjusted_points(self):
+    def get_adjusted_points(self) -> PointList:
+        """
+        Return the positions of points, scaled and offset from the center.
+
+        Unlike the boundary helper properties (left, etc), this method will
+        only recalculate the values if something was changed.
+        """
         if not self._adjusted_cache_dirty:
             return self._adjusted_points
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -217,6 +217,12 @@ class HitBox:
 
 
 class RotatableHitBox(HitBox):
+    """
+    A hit box with support for rotation.
+
+    Rotation is separated from the basic hitbox because it is much
+    slower than offsetting and scaling.
+    """
     def __init__(
         self,
         points: PointList,
@@ -226,10 +232,13 @@ class RotatableHitBox(HitBox):
         scale: Tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(points, position=position, scale=scale)
-        self._angle = angle
+        self._angle: float = angle
 
     @property
-    def angle(self):
+    def angle(self) -> float:
+        """
+        The angle to rotate the raw points by in degrees
+        """
         return self._angle
 
     @angle.setter
@@ -237,7 +246,14 @@ class RotatableHitBox(HitBox):
         self._angle = angle
         self._adjusted_cache_dirty = True
 
-    def get_adjusted_points(self):
+    def get_adjusted_points(self) -> PointList:
+        """
+        Return the offset, scaled, & rotated points of this hitbox.
+
+        As with :py:meth:`.HitBox.get_adjusted_points`, this method only
+        recalculates the adjusted values when necessary.
+        :return:
+        """
         if not self._adjusted_cache_dirty:
             return self._adjusted_points
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import cos, radians, sin
-from typing import Any, Tuple, Optional
+from typing import Any, Tuple
 
 from PIL.Image import Image
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -185,7 +185,7 @@ class HitBox:
         """
         Create a rotatable instance of this hit box.
 
-        The internal point list is transferred directly instead of
+        The internal ``PointList`` is transferred directly instead of
         deepcopied, so care should be taken if using a mutable internal
         representation.
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -37,8 +37,11 @@ class HitBoxAlgorithm:
         """
         A string representation of the parameters used to create this algorithm.
 
-        Subclasses should override this method to return a meaningful value since this
-        method is called when caching :py:class:`~arcade.Texture` instances.
+        It will be incorporated at the end of the string returned by
+        :py:meth:`Texture.create_cache_name <arcade.Texture.create_cache_name>`.
+        Subclasses should override this method to return a value which allows
+        distinguishing different configurations of a particular hit box
+        algorithm.
         """
         return ""
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -93,6 +93,10 @@ class HitBox:
         self._position = position
         self._scale = scale
 
+        # Per Clepto's testing as of around May 2023, these are better
+        # left uncached because caching them is somehow slower than what
+        # we currently do. Any readers should feel free to retest /
+        # investigate further.
         self._left = None
         self._right = None
         self._bottom = None

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -12,9 +12,9 @@ __all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
 
 
 # Speed / typing workaround:
-# 1. Makes sure we don't reallocate new empty tuples
+# 1. Eliminate extra allocations
 # 2. Allows HitBox & subclass typing annotation to work cleanly
-_EMPTY_TUPLE = tuple()
+_EMPTY_POINT_LIST: PointList = tuple()
 
 
 class HitBoxAlgorithm:
@@ -99,7 +99,7 @@ class HitBox:
 
         # This empty tuple will be replaced the first time
         # get_adjusted_points is called
-        self._adjusted_points: PointList = _EMPTY_TUPLE
+        self._adjusted_points: PointList = _EMPTY_POINT_LIST
         self._adjusted_cache_dirty = True
 
     @property

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -96,15 +96,6 @@ class HitBox:
         self._position = position
         self._scale = scale
 
-        # Per Clepto's testing as of around May 2023, these are better
-        # left uncached because caching them is somehow slower than what
-        # we currently do. Any readers should feel free to retest /
-        # investigate further.
-        self._left = None
-        self._right = None
-        self._bottom = None
-        self._top = None
-
         # This empty tuple will be replaced the first time
         # get_adjusted_points is called
         self._adjusted_points: PointList = _EMPTY_POINT_LIST
@@ -133,6 +124,10 @@ class HitBox:
         self._position = position
         self._adjusted_cache_dirty = True
 
+    # Per Clepto's testing as of around May 2023, these are better
+    # left uncached because caching them is somehow slower than what
+    # we currently do. Any readers should feel free to retest /
+    # investigate further.
     @property
     def left(self) -> float:
         """

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -198,7 +198,10 @@ class HitBox:
         Return the positions of points, scaled and offset from the center.
 
         Unlike the boundary helper properties (left, etc), this method will
-        only recalculate the values if something was changed.
+        only recalculate the values when necessary:
+
+        * The first time this method is called
+        * After properties affecting adjusted position were changed
         """
         if not self._adjusted_cache_dirty:
             return self._adjusted_points

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -13,28 +13,52 @@ __all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
 
 class HitBoxAlgorithm:
     """
-    Base class for hit box algorithms. Hit box algorithms are used to calculate the
-    points that make up a hit box for a sprite.
+    The base class for hit box algorithms.
+
+    Hit box algorithms are intended to calculate the points which make up
+    a hit box for a given :py:class:`~PIL.Image.Image`. However, advanced
+    users can also repurpose them for other tasks.
     """
 
     #: The name of the algorithm
     name = "base"
-    #: Should points for this algorithm be cached?
+
+    #: Whether points for this algorithm should be cached
     cache = True
 
     @property
     def param_str(self) -> str:
         """
-        Return a string representation of the parameters used to create this algorithm.
+        A string representation of the parameters used to create this algorithm.
 
-        This is used in caching.
+        This is used when caching :py:class:`~arcade.Texture` instances.
         """
         return ""
 
     def calculate(self, image: Image, **kwargs) -> PointList:
+        """
+        Calculate hit box points for a given image.
+
+        .. warning:: This method should not be made into a class method!
+
+                     Although this base class does not take arguments
+                     when initialized, subclasses use them to alter how
+                     a specific instance handles image data by default.
+
+        :param image: The image to calculate hitbox points for
+        :param kwargs: keyword arguments
+        :return: A list of hit box points.
+        """
         raise NotImplementedError
 
     def __call__(self, *args: Any, **kwds: Any) -> "HitBoxAlgorithm":
+        """
+        Shorthand allowing any instance to be used identically to the base type.
+
+        :param args: The same positional arguments as `__init__`
+        :param kwds: The same keyword arguments as `__init__`
+        :return: A new HitBoxAlgorithm instance
+        """
         return self.__class__(*args, **kwds)
 
 


### PR DESCRIPTION
### Changes

* Add missing annotations to `arcade.hitbox.base` members
* Add basic docstrings to `arcade.hitbox.base` members
* Add protected top-level workaround constant
* Add notes on why we don't cache axis extrema properties

### Why

* IDE tooltips & hints
* Help anyone who reads the source

### How to test

1. Run linting & unit tests as normal
2. Check IDE type annotation / docstring rendering for HitBox classes

### Questions for reviewers

* Is our rotation  direction consistent enough that I can add it here / to the programming guide?
* Should I update `update_quick_index.py` to generate this doc now?
