### PR TITLE
Fix merge accident in doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -110,7 +110,6 @@ The Python Arcade Library
    :maxdepth: 1
    :caption: Source Code & Contributing
 
-   contributing_guide/index
    GitHub <https://github.com/pythonarcade/arcade>
    programming_guide/release_notes
    License <https://github.com/pythonarcade/arcade/blob/development/license.rst>


### PR DESCRIPTION
This fixes the cause of [this build error](https://github.com/pythonarcade/arcade/actions/runs/5009137050/jobs/8977743132): a doubled entry for contributing_guide/index on the homepage 