### PR TITLE
Fix exception types in Texture's init

### DIFF
--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -163,7 +163,7 @@ class Texture:
         elif isinstance(image, ImageData):
             self._image_data = image
         else:
-            raise ValueError(
+            raise TypeError(
                 "image must be an instance of PIL.Image.Image or ImageData, "
                 f"not {type(image)}"
             )
@@ -180,7 +180,7 @@ class Texture:
 
         self._hit_box_algorithm = hit_box_algorithm or hitbox.algo_default
         if not isinstance(self._hit_box_algorithm, HitBoxAlgorithm):
-            raise ValueError(
+            raise TypeError(
                 f"hit_box_algorithm must be an instance of HitBoxAlgorithm, not {type(self._hit_box_algorithm)}"
             )
 

--- a/tests/unit/texture/test_texture.py
+++ b/tests/unit/texture/test_texture.py
@@ -13,6 +13,9 @@ def test_create():
     assert texture.image_data.hash == "7a12e561363385e9dfeeab326368731c030ed4b374e7f5897ac819159d2884c5"
     assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.name}|"
 
+    with pytest.raises(TypeError):
+        _ = arcade.Texture("not valid image data")
+
 
 def test_create_override_name():
     texture = arcade.Texture(Image.new("RGBA", (10, 10)), hash="test")

--- a/tests/unit/texture/test_textures.py
+++ b/tests/unit/texture/test_textures.py
@@ -51,7 +51,7 @@ def test_texture_constructor_hit_box_algo():
     Texture(name="allows_none_hitbox", image=image, hit_box_algorithm=hitbox.algo_bounding_box)
     Texture(name="old_behavior_preserved", image=image)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Texture(name="random", image=image, hit_box_algorithm="definitely invalid")
 
 


### PR DESCRIPTION
### Changes

* Use `TypeError` on wrong types instead of `ValueError`
* Correct unit tests to account for this

### How to test

`./make.py test` or `pytest tests/unit` as usual
