### PR TITLE
Unprotect _EMPTY_POINT_LIST & move it to arcade.types

### DIFF
--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -5,16 +5,9 @@ from typing import Any, Sequence, Tuple
 
 from PIL.Image import Image
 
-from arcade.types import Point, PointList
-
+from arcade.types import Point, PointList, EMPTY_POINT_LIST
 
 __all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
-
-
-# Speed / typing workaround:
-# 1. Eliminate extra allocations
-# 2. Allows HitBox & subclass typing annotation to work cleanly
-_EMPTY_POINT_LIST: PointList = tuple()
 
 
 class HitBoxAlgorithm:
@@ -98,7 +91,7 @@ class HitBox:
 
         # This empty tuple will be replaced the first time
         # get_adjusted_points is called
-        self._adjusted_points: PointList = _EMPTY_POINT_LIST
+        self._adjusted_points: PointList = EMPTY_POINT_LIST
         self._adjusted_cache_dirty = True
 
     @property

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -1,6 +1,8 @@
 """
 Module specifying data custom types used for type hinting.
 """
+from __future__ import annotations
+
 from array import array
 import ctypes
 import random
@@ -56,6 +58,7 @@ __all__ = [
     "PathOrTexture",
     "Point",
     "PointList",
+    "EMPTY_POINT_LIST",
     "NamedPoint",
     "Rect",
     "RectList",
@@ -421,7 +424,14 @@ IPoint = Tuple[int, int]
 Vector = Point
 NamedPoint = namedtuple("NamedPoint", ["x", "y"])
 
+
 PointList = Sequence[Point]
+# Speed / typing workaround:
+# 1. Eliminate extra allocations
+# 2. Allows type annotation to be cleaner, primarily for HitBox & subclasses
+EMPTY_POINT_LIST: PointList = tuple()
+
+
 Rect = Union[Tuple[int, int, int, int], List[int]]  # x, y, width, height
 RectList = Union[Tuple[Rect, ...], List[Rect]]
 


### PR DESCRIPTION
### Changes

1. Unprotect `_EMPTY_POINT_LIST` by renaming it to `EMPTY_POINT_LIST`
2. Move it next to the `PointList` declaration.

### Why

This utility constant isn't specific to hitboxes, so it makes more sense to keep it next to the original type alias declaration.