### PR TITLE
Refactor hitbox algo cache names into an instance property

### DIFF
--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -24,20 +24,10 @@ class HitBoxAlgorithm:
     cache = True
 
     def __init__(self):
-        self._texture_cache_base = self.__class__.__name__
-        self._texture_cache_name: str = ""  # Temporary value
-        self._build_texture_cache_name()
-
-    def _build_texture_cache_name(self) -> None:
-        """
-        Set the texture cache name to its final value.
-
-        Subclasses should override this to build clear cache names.
-        """
-        self._texture_cache_name = self._texture_cache_base
+        self._cache_name = self.__class__.__name__
 
     @property
-    def texture_cache_name(self) -> str:
+    def cache_name(self) -> str:
         """
         A string representation of the parameters used to create this algorithm.
 
@@ -47,7 +37,7 @@ class HitBoxAlgorithm:
         distinguishing different configurations of a particular hit box
         algorithm.
         """
-        return self._texture_cache_name
+        return self._cache_name
 
     def calculate(self, image: Image, **kwargs) -> PointList:
         """

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -27,7 +27,7 @@ class HitBoxAlgorithm:
     cache = True
 
     @property
-    def param_str(self) -> str:
+    def texture_cache_name(self) -> str:
         """
         A string representation of the parameters used to create this algorithm.
 

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -20,11 +20,21 @@ class HitBoxAlgorithm:
     users can also repurpose them for other tasks.
     """
 
-    #: The name of the algorithm
-    name = "base"
-
     #: Whether points for this algorithm should be cached
     cache = True
+
+    def __init__(self):
+        self._texture_cache_base = self.__class__.__name__
+        self._texture_cache_name: str = ""  # Temporary value
+        self._build_texture_cache_name()
+
+    def _build_texture_cache_name(self) -> None:
+        """
+        Set the texture cache name to its final value.
+
+        Subclasses should override this to build clear cache names.
+        """
+        self._texture_cache_name = self._texture_cache_base
 
     @property
     def texture_cache_name(self) -> str:
@@ -37,7 +47,7 @@ class HitBoxAlgorithm:
         distinguishing different configurations of a particular hit box
         algorithm.
         """
-        return ""
+        return self._texture_cache_name
 
     def calculate(self, image: Image, **kwargs) -> PointList:
         """

--- a/arcade/hitbox/bounding_box.py
+++ b/arcade/hitbox/bounding_box.py
@@ -7,7 +7,6 @@ class BoundingHitBoxAlgorithm(HitBoxAlgorithm):
     """
     A simple hit box algorithm that returns a hit box around the entire image.
     """
-    name = "bounding_box"
     cache = False
 
     def calculate(self, image: Image, **kwargs) -> PointList:

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -26,7 +26,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
         self.detail = detail or self.default_detail
 
     @property
-    def texture_cache_name(self) -> str:
+    def cache_name(self) -> str:
         """
         Return a string representation of the parameters used to create this algorithm.
 

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -23,16 +23,9 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
     default_detail = 4.5
 
     def __init__(self, *, detail: Optional[float] = None):
+        super().__init__()
         self.detail = detail or self.default_detail
-
-    @property
-    def cache_name(self) -> str:
-        """
-        Return a string representation of the parameters used to create this algorithm.
-
-        This is used in caching.
-        """
-        return f"detail={self.detail}"
+        self._cache_name += f"|detail={self.detail}"
 
     def __call__(self, *, detail: Optional[float] = None) -> "PymunkHitBoxAlgorithm":
         """Create a new instance with new default values"""

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -26,7 +26,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
         self.detail = detail or self.default_detail
 
     @property
-    def param_str(self) -> str:
+    def texture_cache_name(self) -> str:
         """
         Return a string representation of the parameters used to create this algorithm.
 

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -18,7 +18,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
     This is a more accurate algorithm generating more points. The
     point count can be controlled with the ``detail`` parameter.
     """
-    name = "pymunk"
+
     #: The default detail when creating a new instance.
     default_detail = 4.5
 

--- a/arcade/hitbox/simple.py
+++ b/arcade/hitbox/simple.py
@@ -9,7 +9,6 @@ class SimpleHitBoxAlgorithm(HitBoxAlgorithm):
     Simple hit box algorithm. This algorithm attempts to trim out transparent pixels
     from an image to create a hit box.
     """
-    name = "simple"
 
     def calculate(self, image: Image, **kwargs) -> PointList:
         """

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -241,7 +241,7 @@ class Texture:
         if not isinstance(hit_box_algorithm, HitBoxAlgorithm):
             raise TypeError(f"Expected HitBoxAlgorithm, got {type(hit_box_algorithm)}")
 
-        return f"{hash}|{vertex_order}|{hit_box_algorithm.name}|{hit_box_algorithm.texture_cache_name}"
+        return f"{hash}|{vertex_order}|{hit_box_algorithm.texture_cache_name}|"
 
     @classmethod
     def create_atlas_name(

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -241,7 +241,7 @@ class Texture:
         if not isinstance(hit_box_algorithm, HitBoxAlgorithm):
             raise TypeError(f"Expected HitBoxAlgorithm, got {type(hit_box_algorithm)}")
 
-        return f"{hash}|{vertex_order}|{hit_box_algorithm.texture_cache_name}|"
+        return f"{hash}|{vertex_order}|{hit_box_algorithm.cache_name}|"
 
     @classmethod
     def create_atlas_name(

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -241,7 +241,7 @@ class Texture:
         if not isinstance(hit_box_algorithm, HitBoxAlgorithm):
             raise TypeError(f"Expected HitBoxAlgorithm, got {type(hit_box_algorithm)}")
 
-        return f"{hash}|{vertex_order}|{hit_box_algorithm.name}|{hit_box_algorithm.param_str}"
+        return f"{hash}|{vertex_order}|{hit_box_algorithm.name}|{hit_box_algorithm.texture_cache_name}"
 
     @classmethod
     def create_atlas_name(

--- a/tests/unit/htibox/test_hitbox.py
+++ b/tests/unit/htibox/test_hitbox.py
@@ -39,8 +39,8 @@ def test_calculate_hit_box_points_detailed():
 
 def test_texture_cache_name():
     # These algos don't have any parameters
-    assert hitbox.algo_simple.texture_cache_name == ""
-    assert hitbox.algo_bounding_box.texture_cache_name == ""
+    assert hitbox.algo_simple.texture_cache_name == "SimpleHitBoxAlgorithm"
+    assert hitbox.algo_bounding_box.texture_cache_name == "BoundingHitBoxAlgorithm"
 
     # Detailed has a detail parameter for the number of points
     # Test default value and specifying a value

--- a/tests/unit/htibox/test_hitbox.py
+++ b/tests/unit/htibox/test_hitbox.py
@@ -37,15 +37,15 @@ def test_calculate_hit_box_points_detailed():
         hitbox.calculate_hit_box_points_detailed(image)
 
 
-def test_param_str():
+def test_texture_cache_name():
     # These algos don't have any parameters
-    assert hitbox.algo_simple.param_str == ""
-    assert hitbox.algo_bounding_box.param_str == ""
+    assert hitbox.algo_simple.texture_cache_name == ""
+    assert hitbox.algo_bounding_box.texture_cache_name == ""
 
     # Detailed has a detail parameter for the number of points
     # Test default value and specifying a value
-    assert hitbox.algo_detailed.param_str == "detail=4.5"
-    assert hitbox.algo_detailed(detail=10.0).param_str == "detail=10.0"
+    assert hitbox.algo_detailed.texture_cache_name == "detail=4.5"
+    assert hitbox.algo_detailed(detail=10.0).texture_cache_name == "detail=10.0"
 
 
 def test_call_override():

--- a/tests/unit/htibox/test_hitbox.py
+++ b/tests/unit/htibox/test_hitbox.py
@@ -39,13 +39,13 @@ def test_calculate_hit_box_points_detailed():
 
 def test_texture_cache_name():
     # These algos don't have any parameters
-    assert hitbox.algo_simple.texture_cache_name == "SimpleHitBoxAlgorithm"
-    assert hitbox.algo_bounding_box.texture_cache_name == "BoundingHitBoxAlgorithm"
+    assert hitbox.algo_simple.cache_name == "SimpleHitBoxAlgorithm"
+    assert hitbox.algo_bounding_box.cache_name == "BoundingHitBoxAlgorithm"
 
     # Detailed has a detail parameter for the number of points
     # Test default value and specifying a value
-    assert hitbox.algo_detailed.texture_cache_name == "detail=4.5"
-    assert hitbox.algo_detailed(detail=10.0).texture_cache_name == "detail=10.0"
+    assert hitbox.algo_detailed.cache_name == "detail=4.5"
+    assert hitbox.algo_detailed(detail=10.0).cache_name == "detail=10.0"
 
 
 def test_call_override():

--- a/tests/unit/htibox/test_hitbox.py
+++ b/tests/unit/htibox/test_hitbox.py
@@ -44,8 +44,8 @@ def test_texture_cache_name():
 
     # Detailed has a detail parameter for the number of points
     # Test default value and specifying a value
-    assert hitbox.algo_detailed.cache_name == "detail=4.5"
-    assert hitbox.algo_detailed(detail=10.0).cache_name == "detail=10.0"
+    assert hitbox.algo_detailed.cache_name == "PymunkHitBoxAlgorithm|detail=4.5"
+    assert hitbox.algo_detailed(detail=10.0).cache_name == "PymunkHitBoxAlgorithm|detail=10.0"
 
 
 def test_call_override():

--- a/tests/unit/texture/test_texture.py
+++ b/tests/unit/texture/test_texture.py
@@ -10,7 +10,7 @@ def test_create():
     assert texture.height == 10
     assert texture.file_path is None
     assert texture.crop_values is None
-    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.texture_cache_name}|"
+    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.cache_name}|"
     assert texture.image_data.hash == "7a12e561363385e9dfeeab326368731c030ed4b374e7f5897ac819159d2884c5"
 
     with pytest.raises(TypeError):
@@ -19,7 +19,7 @@ def test_create():
 
 def test_create_override_name():
     texture = arcade.Texture(Image.new("RGBA", (10, 10)), hash="test")
-    assert texture.cache_name == f"test|{texture._vertex_order}|{texture.hit_box_algorithm.texture_cache_name}|"
+    assert texture.cache_name == f"test|{texture._vertex_order}|{texture.hit_box_algorithm.cache_name}|"
 
 
 def test_hitbox_algo_selection():

--- a/tests/unit/texture/test_texture.py
+++ b/tests/unit/texture/test_texture.py
@@ -10,8 +10,8 @@ def test_create():
     assert texture.height == 10
     assert texture.file_path is None
     assert texture.crop_values is None
+    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.texture_cache_name}|"
     assert texture.image_data.hash == "7a12e561363385e9dfeeab326368731c030ed4b374e7f5897ac819159d2884c5"
-    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.name}|"
 
     with pytest.raises(TypeError):
         _ = arcade.Texture("not valid image data")
@@ -19,7 +19,7 @@ def test_create():
 
 def test_create_override_name():
     texture = arcade.Texture(Image.new("RGBA", (10, 10)), hash="test")
-    assert texture.cache_name == f"test|{texture._vertex_order}|{texture.hit_box_algorithm.name}|"
+    assert texture.cache_name == f"test|{texture._vertex_order}|{texture.hit_box_algorithm.texture_cache_name}|"
 
 
 def test_hitbox_algo_selection():

--- a/tests/unit/texture/test_texture.py
+++ b/tests/unit/texture/test_texture.py
@@ -10,8 +10,8 @@ def test_create():
     assert texture.height == 10
     assert texture.file_path is None
     assert texture.crop_values is None
-    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.cache_name}|"
     assert texture.image_data.hash == "7a12e561363385e9dfeeab326368731c030ed4b374e7f5897ac819159d2884c5"
+    assert texture.cache_name == f"{texture.image_data.hash}|{texture._vertex_order}|{texture.hit_box_algorithm.cache_name}|"
 
     with pytest.raises(TypeError):
         _ = arcade.Texture("not valid image data")


### PR DESCRIPTION
~~Stacks onto #1792~~ Rebased onto `development`, no longer depends on that PR.

### Changes

1. Remove `name` class attribute from hit box algorithm classes
2. Add `cache_name` per-instance property
3. Update tests

### Why

Per [discord discussion with einarf](https://discord.com/channels/458662222697070613/1108023300589879386/1108497287979737169), the current cache names are from the old caching system:

> I think we can drop the name and just use self.__class__.__name__, right?
> No need to make it complicated

### How to test

`./make.py test` or `pytest tests/unit` as usual

### Follow-up work

Refactor `cache` class attribute into a `cache_points` instance property.

