### PR TITLE
Improve scene object annotations & docstrings

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -181,6 +181,7 @@ from .sprite_list import get_sprites_in_rect
 from .sprite_list import SpatialHash
 
 from .scene import Scene
+from .scene import SceneKeyError
 
 from .physics_engines import PhysicsEnginePlatformer
 from .physics_engines import PhysicsEngineSimple
@@ -260,6 +261,7 @@ __all__ = [
     'Section',
     'SectionManager',
     'Scene',
+    'SceneKeyError',
     'Sound',
     'BasicSprite',
     'Sprite',

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -25,11 +25,12 @@ class Scene:
     with single calls. It also provides convenience methods, but some of them
     trade execution speed for convenience.
 
-    * Support for python keywords such as ``in``, ``del``, as well as :py:func:`len`
-    * Fine-grained but slow convenience methods for adding, deleting, and reordering
-      sprites and sprite lists
+    * Fine-grained convenience methods for adding, deleting, and reordering
+      sprite lists
     * :py:meth:`.from_tilemap`, which creates a new scene from a
       :py:class:`~arcade.tilemap.TileMap` already loaded from tiled data
+    * Flexible but slow convenience methods & support for python keywords such
+      as ``in``, ``del``
 
     For an example of how to use this class, see :ref:`platformer_part_three`.
     """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -19,10 +19,19 @@ __all__ = ["Scene"]
 
 class Scene:
     """
-    Class that represents a `scene` object. Most games will use Scenes to render their Sprites.
-    For examples on how to use this class, see:
-    https://api.arcade.academy/en/latest/tutorials/views/index.html
+    Uses :py:class:`~arcade.SpriteList` instances as layers, allowing bulk updates & drawing.
 
+    The primary use of this class is to update or draw multiple sprite lists
+    with single calls. It also provides convenience methods, but some of them
+    trade execution speed for convenience.
+
+    * Support for python keywords such as ``in``, ``del``, as well as :py:func:`len`
+    * Fine-grained but slow convenience methods for adding, deleting, and reordering
+      sprites and sprite lists
+    * :py:meth:`.from_tilemap`, which creates a new scene from a
+      :py:class:`~arcade.tilemap.TileMap` already loaded from tiled data
+
+    For an example of how to use this class, see :ref:`platformer_part_three`.
     """
 
     def __init__(self) -> None:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -204,17 +204,20 @@ class Scene:
         sprite_list: Optional[SpriteList] = None,
     ) -> None:
         """
-        Add a SpriteList to the scene with the specified name before a specific SpriteList.
+        Add a sprite list to the scene with the specified name before another SpriteList.
 
-        This will add a new SpriteList to the scene before the specified SpriteList in the draw order.
+        If no sprite list is supplied via the ``sprite_list`` parameter then a new one
+        will be created. Aside using the value of ``use_spatial_hash`` passed to this
+        method, it will use the default arguments for a new :py:class:`SpriteList`.
 
-        If no SpriteList is supplied via the `sprite_list` parameter then a new one will be
-        created, and the `use_spatial_hash` parameter will be respected for that creation.
+        The added sprite list will be drawn under the sprite list named in ``before``.
 
-        :param str name: The name to give the SpriteList.
+        :param str name: The name to give the sprite list.
         :param str before: The name of the SpriteList to place this one before.
-        :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
-        :param SpriteList sprite_list: The SpriteList to add, optional.
+        :param bool use_spatial_hash: If creating a new sprite list, selects whether to
+            enable spatial hashing.
+        :param SpriteList sprite_list: If a sprite list passed via this argument, it will
+            be used instead of creating a new one.
         """
         if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -133,12 +133,12 @@ class Scene:
 
     def __getitem__(self, key: str) -> SpriteList:
         """
-        Retrieve a `SpriteList` by name.
+        Retrieve a sprite list by name.
 
         This is here for ease of use to make sub-scripting the scene object directly
         to retrieve a SpriteList possible.
 
-        :param str key: The name of the 'SpriteList' to retreive.
+        :param str key: The name of the sprite list to retrieve
         """
         if key in self._name_mapping:
             return self._name_mapping[key]

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -46,11 +46,21 @@ class Scene:
 
     def __delitem__(self, sprite_list: Union[int, str, SpriteList]) -> None:
         """
-        Remove the SpriteList from `_sprite_lists` and `_name_mapping`.
+        Remove a sprite list from this scene by its index, name, or instance value.
 
-        :param Union[int, str, SpriteList] sprite_list: which SpriteList to delete - can
-        be the index of the SpriteList in `_sprite_lists`, the name of the SpriteList or
-        the SpriteList object.
+        .. tip:: Use a more specific method when speed is important!
+
+                 This method uses :py:func:`isinstance`, which can be slow.
+
+        Consider the following alternatives:
+
+        * :py:meth:`.remove_sprite_list_by_index`
+        * :py:meth:`.remove_sprite_list_by_name`
+        * :py:meth:`.remove_sprite_list_by_object`
+
+        :param Union[int, str, SpriteList] sprite_list:
+            The index, name, or :py:class:`~arcade.SpriteList` instance to remove from
+            this scene.
         """
         if isinstance(sprite_list, int):
             self.remove_sprite_list_by_index(sprite_list)

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -271,19 +271,20 @@ class Scene:
         after: str,
     ) -> None:
         """
-        Move the named SpriteList in the scene to be after another SpriteList.
+        Move a named SpriteList in the scene to be after another SpriteList in the scene.
 
-        This will adjust the render order so that the SpriteList
-        specified by ``name`` is placed after the one specified by
-        ``after``.
+        A :py:class:`.SceneKeyError` will be raised if either ``name`` or ``after`` contain
+        a name not currently in the scene. This exception can be handled as a
+        :py:class:`KeyError`.
 
         :param str name: The name of the SpriteList to move.
         :param str after: The name of the SpriteList to place it after.
         """
         if name not in self._name_mapping:
-            raise ValueError(
-                f"Tried to move unknown SpriteList with the name {name} in Scene"
-            )
+            raise SceneKeyError(name)
+
+        if after not in self._name_mapping:
+            raise SceneKeyError(after)
 
         name_list = self._name_mapping[name]
         after_list = self._name_mapping[after]

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -160,8 +160,8 @@ class Scene:
         * :py:meth:`.add_sprite_list`
         * :py:meth:`.add_sprite_list_after`
 
-        :param str name: The name of the `SpriteList` to add to or create.
-        :param Sprite sprite: The `Sprite` to add.
+        :param str name: The name of the sprite list to add to or create.
+        :param Sprite sprite: The sprite to add.
         """
         if name in self._name_mapping:
             self._name_mapping[name].append(sprite)

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -104,12 +104,13 @@ class Scene:
     @classmethod
     def from_tilemap(cls, tilemap: TileMap) -> "Scene":
         """
-        Create a new Scene from a `TileMap` object.
+        Create a new Scene from a :py:class:`~arcade.tilemap.TileMap` object.
 
         The SpriteLists will use the layer names and ordering as defined in the
         Tiled file.
 
-        :param TileMap tilemap: The `TileMap` object to create the scene from.
+        :param TileMap tilemap: The :py:class:`~arcade.tilemap.TileMap`
+            object to create the scene from.
         """
         scene = cls()
         for name, sprite_list in tilemap.sprite_lists.items():

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -75,10 +75,8 @@ class Scene:
         """
         Create a new Scene from a `TileMap` object.
 
-        This will look at all the SpriteLists in a TileMap object and create
-        a Scene with them. This will automatically keep SpriteLists in the same
-        order as they are defined in the TileMap class, which is the order that
-        they are defined within Tiled.
+        The SpriteLists will use the layer names and ordering as defined in the
+        Tiled file.
 
         :param TileMap tilemap: The `TileMap` object to create the scene from.
         """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -18,7 +18,7 @@ from arcade.tilemap import TileMap
 
 from warnings import warn
 
-__all__ = ["Scene"]
+__all__ = ["Scene", "SceneKeyError"]
 
 
 class SceneKeyError(KeyError):
@@ -34,13 +34,13 @@ class SceneKeyError(KeyError):
 
 class Scene:
     """
-    Stores :py:class:`~arcade.SpriteList`s as named layers, allowing bulk updates & drawing.
+    Stores :py:class:`~arcade.SpriteList` instances as named layers, allowing bulk updates & drawing.
 
     In addition to allowing you to update or draw multiple sprite lists
     with one call, this class also provides convenience methods:
 
     * :py:meth:`.add_sprite` to allow adding sprites to layers dynamically
-    * :py:meth:`.from_tilemap`, which creates a new scene from a
+    * :py:meth:`.Scene.from_tilemap`, which creates a new scene from a
       :py:class:`~arcade.tilemap.TileMap` already loaded from tiled data
     * Fine-grained convenience methods for adding, deleting, and reordering
       sprite lists
@@ -217,9 +217,9 @@ class Scene:
         """
         Move a named SpriteList in the scene to be before another SpriteList in the scene.
 
-        A :py:class:`.SceneKeyError` will be raised if either ``name`` or ``before`` contain
-        a name not currently in the scene. This exception can be handled as a
-        :py:class:`KeyError`.
+        A :py:class:`~arcade.scene.SceneKeyError` will be raised if either ``name``
+        or ``before`` contain a name not currently in the scene. This exception can
+        be handled as a :py:class:`KeyError`.
 
         :param str name: The name of the SpriteList to move.
         :param str before: The name of the SpriteList to place it before.
@@ -273,9 +273,9 @@ class Scene:
         """
         Move a named SpriteList in the scene to be after another SpriteList in the scene.
 
-        A :py:class:`.SceneKeyError` will be raised if either ``name`` or ``after`` contain
-        a name not currently in the scene. This exception can be handled as a
-        :py:class:`KeyError`.
+        A :py:class:`~arcade.scene.SceneKeyError` will be raised if either ``name``
+        or ``after`` contain a name not currently in the scene. This exception can
+        be handled as a :py:class:`KeyError`.
 
         :param str name: The name of the SpriteList to move.
         :param str after: The name of the SpriteList to place it after.

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -143,7 +143,7 @@ class Scene:
         if key in self._name_mapping:
             return self._name_mapping[key]
 
-        raise KeyError(f"Scene does not contain a layer named: {key}")
+        raise SceneKeyError(key)
 
     def add_sprite(self, name: str, sprite: Sprite) -> None:
         """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -21,6 +21,17 @@ from warnings import warn
 __all__ = ["Scene"]
 
 
+class SceneKeyError(KeyError):
+    """
+    Helper subclass of :py:class:`KeyError` which performs templating.
+
+    :param name: the name of the missing :py:class:`~arcade.SpriteList`
+    """
+
+    def __init__(self, name: str):
+        super().__init__(f"This scene does not contain a SpriteList named {name!r}.")
+
+
 class Scene:
     """
     Stores :py:class:`~arcade.SpriteList`s as named layers, allowing bulk updates & drawing.
@@ -206,21 +217,18 @@ class Scene:
         """
         Move a named SpriteList in the scene to be before another SpriteList in the scene.
 
-        A :py:class:`KeyError` will be raised if either ``name`` or ``before`` contain
-        a name not currently in the scene.
+        A :py:class:`.SceneKeyError` will be raised if either ``name`` or ``before`` contain
+        a name not currently in the scene. This exception can be handled as a
+        :py:class:`KeyError`.
 
         :param str name: The name of the SpriteList to move.
         :param str before: The name of the SpriteList to place it before.
         """
         if name not in self._name_mapping:
-            raise KeyError(
-                f"Tried to move unknown SpriteList with the name {name!r} in Scene"
-            )
+            raise SceneKeyError(name)
 
         if before not in self._name_mapping:
-            raise KeyError(
-                f"Tried to move unknown SpriteList with the name {before!r} in Scene"
-            )
+            raise SceneKeyError(before)
 
         name_list = self._name_mapping[name]
         before_list = self._name_mapping[before]

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -370,8 +370,7 @@ class Scene:
         lists will be drawn in the order of the passed iterable. If a
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
-        :param names:
-            An iterable of sprite list names to update, such as a list.
+        :param names: Which layers & what order to update them in.
         """
         if names:
             for name in names:
@@ -394,8 +393,7 @@ class Scene:
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
         :param delta_time: The time step to update by in seconds.
-        :param names:
-            An iterable of sprite list names to update, such as a list.
+        :param names: Which layers & what order to update them in.
         """
         if names:
             for name in names:
@@ -420,8 +418,7 @@ class Scene:
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
         :param delta_time: The time step to update by in seconds.
-        :param names:
-            An iterable of sprite list names to update, such as a list.
+        :param names: Which layers & what order to update them in.
         """
         if names:
             for name in names:
@@ -455,8 +452,7 @@ class Scene:
         ``**kwargs`` option is for advanced users who have
         subclassed :py:class:`~arcade.SpriteList`.
 
-        :param names: An iterable of sprite list
-            names to draw from the lowest index to highest.
+        :param names: Which layers to draw & what order to draw them in.
         :param filter: Optional parameter to set OpenGL filter, such as
            ``gl.GL_NEAREST`` to avoid smoothing.
         :param pixelated: ``True`` for pixel art and ``False`` for
@@ -502,7 +498,7 @@ class Scene:
 
         :param color: The RGBA color to use to draw the hit boxes with.
         :param line_thickness: How many pixels thick the hit box outlines should be
-        :param names: Which layers & what order to draw the hit boxes for them in
+        :param names: Which layers & what order to draw their hit boxes in.
         """
 
         if names:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -23,18 +23,18 @@ __all__ = ["Scene"]
 
 class Scene:
     """
-    Uses :py:class:`~arcade.SpriteList` instances as layers, allowing bulk updates & drawing.
+    Stores :py:class:`~arcade.SpriteList`s as named layers, allowing bulk updates & drawing.
 
-    The primary use of this class is to update or draw multiple sprite lists
-    with single calls. It also provides convenience methods, but some of them
-    trade execution speed for convenience.
+    In addition to allowing you to update or draw multiple sprite lists
+    with one call, this class also provides convenience methods:
 
-    * Fine-grained convenience methods for adding, deleting, and reordering
-      sprite lists
+    * :py:meth:`.add_sprite` to allow adding sprites to layers dynamically
     * :py:meth:`.from_tilemap`, which creates a new scene from a
       :py:class:`~arcade.tilemap.TileMap` already loaded from tiled data
-    * Flexible but slow convenience methods & support for python keywords such
-      as ``in``, ``del``
+    * Fine-grained convenience methods for adding, deleting, and reordering
+      sprite lists
+    * Flexible but slow convenience methods & support for the ``in`` & ``del``
+      Python keywords.
 
     For an example of how to use this class, see :ref:`platformer_part_three`.
     """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -40,7 +40,7 @@ class Scene:
 
     def __len__(self) -> int:
         """
-        Get length of `_sprite_lists`.
+        Return the number of sprite lists in this scene.
         """
         return len(self._sprite_lists)
 

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -6,7 +6,7 @@ a name, as well as control the draw order. In addition it provides a
 helper function to create a Scene directly from a TileMap object.
 """
 
-from typing import Dict, List, Optional, Union, Iterable
+from typing import Dict, List, Optional, Union, Iterable, Tuple
 
 from arcade import Sprite, SpriteList
 from arcade.types import Color, RGBA255
@@ -387,31 +387,59 @@ class Scene:
         for sprite_list in self._sprite_lists:
             sprite_list.update_animation(delta_time)
 
-    def draw(self, names: Optional[List[str]] = None, **kwargs) -> None:
+    def draw(
+        self,
+        names: Optional[Iterable[str]] = None,
+        filter: Optional[int] = None,
+        pixelated: bool = False,
+        blend_function: Optional[Union[Tuple[int, int], Tuple[int, int, int, int]]] = None,
+        **kwargs
+    ) -> None:
         """
-        Draw the Scene.
+        Call :py:meth:`~arcade.SpriteList.draw` on the scene's sprite lists.
 
-        If `names` parameter is provided then only the specified SpriteLists
-        will be drawn. They will be drawn in the order that the names in the
-        list were arranged. If `names` is not provided, then every SpriteList
-        in the scene will be drawn according the order of the main _sprite_lists
-        attribute of the Scene.
+        By default, this method calls :py:meth:`~arcade.SpriteList.draw`
+        on each sprite list in the scene in the default draw order.
 
-        :param Optional[List[str]] names: A list of names of SpriteLists to draw.
-        :param filter: Optional parameter to set OpenGL filter, such as
-                       `gl.GL_NEAREST` to avoid smoothing.
-        :param blend_function: Optional parameter to set the OpenGL blend function
-            used for drawing the sprite list, such as `arcade.Window.ctx.BLEND_ADDITIVE`
-            or `arcade.Window.ctx.BLEND_DEFAULT`
+        You can limit and reorder the draw calls with the ``names``
+        argument by passing a list of names in the scene. The sprite
+        lists will be drawn in the order of the passed iterable. If a
+        name is not in the scene, a :py:class:`KeyError` will be raised.
+
+        The other named keyword arguments are the same as those of
+        :py:meth:`SpriteList.draw() <arcade.SpriteList.draw>`. The
+        ``**kwargs`` option is for advanced users who have
+        subclassed :py:class:`~arcade.SpriteList`.
+
+        :param Optional[Iterable[str]] names: An iterable of sprite list
+            names to draw from lowest index to highest.
+        :param Optional[int] filter: Optional parameter to set OpenGL filter, such as
+           ``gl.GL_NEAREST`` to avoid smoothing.
+        :param bool pixelated: ``True`` for pixel art and ``False`` for
+            smooth scaling.
+        :param Optional[Union[Tuple[int, int], Tuple[int, int, int, int]]] blend_function:
+            Use the specified OpenGL blend function while drawing the
+            sprite list, such as ``arcade.Window.ctx.BLEND_ADDITIVE``
+            or ``arcade.Window.ctx.BLEND_DEFAULT``.
         """
 
         if names:
             for name in names:
-                self._name_mapping[name].draw(**kwargs)
+                self._name_mapping[name].draw(
+                    filter=filter,
+                    pixelated=pixelated,
+                    blend_function=blend_function,
+                    **kwargs
+                )
             return
 
         for sprite_list in self._sprite_lists:
-            sprite_list.draw(**kwargs)
+            sprite_list.draw(
+                filter=filter,
+                pixelated=pixelated,
+                blend_function=blend_function,
+                **kwargs
+            )
 
     def draw_hit_boxes(
         self,

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -23,13 +23,28 @@ __all__ = ["Scene", "SceneKeyError"]
 
 class SceneKeyError(KeyError):
     """
-    Helper subclass of :py:class:`KeyError` which performs templating.
+    Raised when a py:class:`.Scene` cannot find a layer for a specified name.
+
+    It is a subclass of :py:class:`KeyError`, and you can handle it as
+    one if you wish::
+
+        try:
+            # this will raise a SceneKeyError
+            scene_instance.add_sprite("missing_layer_name", arcade.SpriteSolidColor(10,10))
+
+        # We can handle it as a KeyError because it is a subclass of it
+        except KeyError as e:
+            print("Your error handling should go here")
+
+    The main purpose of this class is to help arcade's developers keep
+    error messages consistent.
 
     :param name: the name of the missing :py:class:`~arcade.SpriteList`
     """
 
     def __init__(self, name: str):
         super().__init__(f"This scene does not contain a SpriteList named {name!r}.")
+        self.layer_name = name
 
 
 class Scene:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -90,7 +90,7 @@ class Scene:
         * :py:meth:`.remove_sprite_list_by_name`
         * :py:meth:`.remove_sprite_list_by_object`
 
-        :param Union[int, str, SpriteList] sprite_list:
+        :param sprite_list:
             The index, name, or :py:class:`~arcade.SpriteList` instance to remove from
             this scene.
         """
@@ -109,7 +109,7 @@ class Scene:
         The SpriteLists will use the layer names and ordering as defined in the
         Tiled file.
 
-        :param TileMap tilemap: The :py:class:`~arcade.tilemap.TileMap`
+        :param tilemap: The :py:class:`~arcade.tilemap.TileMap`
             object to create the scene from.
         """
         scene = cls()
@@ -127,7 +127,7 @@ class Scene:
         * directly accessing ``scene_instance._name_mapping``, although this may
           get flagged by linters as bad style.
 
-        :param str name: The name of the sprite list to retrieve.
+        :param name: The name of the sprite list to retrieve.
         """
         return self._name_mapping[name]
 
@@ -138,7 +138,7 @@ class Scene:
         This is here for ease of use to make sub-scripting the scene object directly
         to retrieve a SpriteList possible.
 
-        :param str key: The name of the sprite list to retrieve
+        :param key: The name of the sprite list to retrieve
         """
         if key in self._name_mapping:
             return self._name_mapping[key]
@@ -160,8 +160,8 @@ class Scene:
         * :py:meth:`.add_sprite_list`
         * :py:meth:`.add_sprite_list_after`
 
-        :param str name: The name of the sprite list to add to or create.
-        :param Sprite sprite: The sprite to add.
+        :param name: The name of the sprite list to add to or create.
+        :param sprite: The sprite to add.
         """
         if name in self._name_mapping:
             self._name_mapping[name].append(sprite)
@@ -184,9 +184,9 @@ class Scene:
         If no SpriteList is supplied via the `sprite_list` parameter then a new one will be
         created, and the `use_spatial_hash` parameter will be respected for that creation.
 
-        :param str name: The name to give the SpriteList.
-        :param bool use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
-        :param SpriteList sprite_list: The SpriteList to add, optional.
+        :param name: The name to give the SpriteList.
+        :param use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
+        :param sprite_list: The SpriteList to add, optional.
         """
         if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)
@@ -212,12 +212,12 @@ class Scene:
 
         The added sprite list will be drawn under the sprite list named in ``before``.
 
-        :param str name: The name to give the new layer.
-        :param str before: The name of the layer to place the new
+        :param name: The name to give the new layer.
+        :param before: The name of the layer to place the new
             one before.
-        :param bool use_spatial_hash: If creating a new sprite list, selects
+        :param use_spatial_hash: If creating a new sprite list, selects
             whether to enable spatial hashing.
-        :param SpriteList sprite_list: If a sprite list is passed via
+        :param sprite_list: If a sprite list is passed via
             this argument, it will be used instead of creating a new one.
         """
         if sprite_list is None:
@@ -242,8 +242,8 @@ class Scene:
         or ``before`` contain a name not currently in the scene. This exception can
         be handled as a :py:class:`KeyError`.
 
-        :param str name: The name of the SpriteList to move.
-        :param str before: The name of the SpriteList to place it before.
+        :param name: The name of the SpriteList to move.
+        :param before: The name of the SpriteList to place it before.
         """
         if name not in self._name_mapping:
             raise SceneKeyError(name)
@@ -273,11 +273,11 @@ class Scene:
 
         The added sprite list will be drawn above the sprite list named in ``after``.
 
-        :param str name: The name to give the layer.
-        :param str after: The name of the layer to place the new one after.
-        :param bool use_spatial_hash: If creating a new sprite list, selects
+        :param name: The name to give the layer.
+        :param after: The name of the layer to place the new one after.
+        :param use_spatial_hash: If creating a new sprite list, selects
             whether to enable spatial hashing.
-        :param SpriteList sprite_list: If a sprite list is passed via
+        :param sprite_list: If a sprite list is passed via
             this argument, it will be used instead of creating a new one.
         """
         if sprite_list is None:
@@ -302,8 +302,8 @@ class Scene:
         or ``after`` contain a name not currently in the scene. This exception can
         be handled as a :py:class:`KeyError`.
 
-        :param str name: The name of the SpriteList to move.
-        :param str after: The name of the SpriteList to place it after.
+        :param name: The name of the SpriteList to move.
+        :param after: The name of the SpriteList to place it after.
         """
         if name not in self._name_mapping:
             raise SceneKeyError(name)
@@ -322,9 +322,9 @@ class Scene:
         index: int
     ) -> None:
         """
-        Remove a SpriteList from the scene by its index in the draw order.
+        Remove a layer from the scene by its index in the draw order.
 
-        :param int index: The index of the SpriteList to remove.
+        :param index: The index of the sprite list to remove.
         """
         self.remove_sprite_list_by_object(self._sprite_lists[index])
 
@@ -333,12 +333,12 @@ class Scene:
         name: str,
     ) -> None:
         """
-        Remove a SpriteList from the scene by its name.
+        Remove a layer from the scene by its name.
 
         A :py:class:`KeyError` will be raised if the SpriteList is not
         in the scene.
 
-        :param str name: The name of the SpriteList to remove.
+        :param name: The name of the sprite list to remove.
         """
         sprite_list = self._name_mapping[name]
         self._sprite_lists.remove(sprite_list)
@@ -351,7 +351,7 @@ class Scene:
         A :py:class:`ValueError` will be raised if the passed sprite
         list is not in the scene.
 
-        :param SpriteList sprite_list: The SpriteList to remove.
+        :param sprite_list: The sprite list to remove.
         """
         self._sprite_lists.remove(sprite_list)
         self._name_mapping = {
@@ -370,7 +370,7 @@ class Scene:
         lists will be drawn in the order of the passed iterable. If a
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
-        :param Optional[Iterable[str]] names:
+        :param names:
             An iterable of sprite list names to update, such as a list.
         """
         if names:
@@ -393,8 +393,8 @@ class Scene:
         lists will be drawn in the order of the passed iterable. If a
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
-        :param float delta_time: The time step to update by in seconds.
-        :param Optional[Iterable[str]] names:
+        :param delta_time: The time step to update by in seconds.
+        :param names:
             An iterable of sprite list names to update, such as a list.
         """
         if names:
@@ -419,8 +419,8 @@ class Scene:
         lists will be drawn in the order of the passed iterable. If a
         name is not in the scene, a :py:class:`KeyError` will be raised.
 
-        :param float delta_time: The time step to update by in seconds.
-        :param Optional[Iterable[str]] names:
+        :param delta_time: The time step to update by in seconds.
+        :param names:
             An iterable of sprite list names to update, such as a list.
         """
         if names:
@@ -455,13 +455,13 @@ class Scene:
         ``**kwargs`` option is for advanced users who have
         subclassed :py:class:`~arcade.SpriteList`.
 
-        :param Optional[Iterable[str]] names: An iterable of sprite list
-            names to draw from lowest index to highest.
-        :param Optional[int] filter: Optional parameter to set OpenGL filter, such as
+        :param names: An iterable of sprite list
+            names to draw from the lowest index to highest.
+        :param filter: Optional parameter to set OpenGL filter, such as
            ``gl.GL_NEAREST`` to avoid smoothing.
-        :param bool pixelated: ``True`` for pixel art and ``False`` for
+        :param pixelated: ``True`` for pixel art and ``False`` for
             smooth scaling.
-        :param Optional[Union[Tuple[int, int], Tuple[int, int, int, int]]] blend_function:
+        :param blend_function:
             Use the specified OpenGL blend function while drawing the
             sprite list, such as ``arcade.Window.ctx.BLEND_ADDITIVE``
             or ``arcade.Window.ctx.BLEND_DEFAULT``.

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -6,7 +6,7 @@ a name, as well as control the draw order. In addition it provides a
 helper function to create a Scene directly from a TileMap object.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Iterable
 
 from arcade import Sprite, SpriteList
 from arcade.types import Color, RGBA255
@@ -314,15 +314,20 @@ class Scene:
             key: val for key, val in self._name_mapping.items() if val != sprite_list
         }
 
-    def update(self, names: Optional[List[str]] = None) -> None:
+    def update(self, names: Optional[Iterable[str]] = None) -> None:
         """
-        Used to update SpriteLists contained in the scene.
+        Call :py:meth:`~arcade.SpriteList.update` on the scene's sprite lists.
 
-        If `names` parameter is provided then only the specified spritelists
-        will be updated. If `names` is not provided, then every SpriteList
-        in the scene will be updated.
+        By default, this method calls :py:meth:`~arcade.SpriteList.update`
+        on the scene's sprite lists in the default draw order.
 
-        :param Optional[List[str]] names: A list of names of SpriteLists to update.
+        You can limit and reorder the updates with the ``names``
+        argument by passing a list of names in the scene. The sprite
+        lists will be drawn in the order of the passed iterable. If a
+        name is not in the scene, a :py:class:`KeyError` will be raised.
+
+        :param Optional[Iterable[str]] names:
+            An iterable of sprite list names to update, such as a list.
         """
         if names:
             for name in names:
@@ -332,17 +337,21 @@ class Scene:
         for sprite_list in self._sprite_lists:
             sprite_list.update()
 
-    def on_update(self, delta_time: float = 1 / 60, names: Optional[List[str]] = None) -> None:
+    def on_update(self, delta_time: float = 1 / 60, names: Optional[Iterable[str]] = None) -> None:
         """
-        Used to call on_update of SpriteLists contained in the scene.
+        Call :py:meth:`~arcade.SpriteList.on_update` on the scene's sprite lists.
 
-        Similar to update() but allows passing a delta_time variable.
-        If `names` parameter is provided then only the specified spritelists
-        will be updated. If `names` is not provided, then every SpriteList
-        in the scene will have on_update called.
+        By default, this method calls :py:meth:`~arcade.SpriteList.on_update`
+        on the scene's sprite lists in the default draw order.
 
-        :param float delta_time: Time since last update.
-        :param Optional[List[str]] names: A list of names of SpriteLists to update.
+        You can limit and reorder the updates with the ``names``
+        argument by passing a list of names in the scene. The sprite
+        lists will be drawn in the order of the passed iterable. If a
+        name is not in the scene, a :py:class:`KeyError` will be raised.
+
+        :param float delta_time: The time step to update by in seconds.
+        :param Optional[Iterable[str]] names:
+            An iterable of sprite list names to update, such as a list.
         """
         if names:
             for name in names:
@@ -353,17 +362,22 @@ class Scene:
             sprite_list.on_update(delta_time)
 
     def update_animation(
-        self, delta_time: float, names: Optional[List[str]] = None
+        self, delta_time: float, names: Optional[Iterable[str]] = None
     ) -> None:
         """
-        Used to update the animation of SpriteLists contained in the scene.
+        Call :py:meth:`~arcade.SpriteList.update_animation` on the scene's sprite lists.
 
-        If `names` parameter is provided then only the specified spritelists
-        will be updated. If `names` is not provided, then every SpriteList
-        in the scene will be updated.
+        By default, this method calls :py:meth:`~arcade.SpriteList.update_animation`
+        on each sprite list in the scene in the default draw order.
 
-        :param float delta_time: The delta time for the update.
-        :param Optional[List[str]] names: A list of names of SpriteLists to update.
+        You can limit and reorder the updates with the ``names``
+        argument by passing a list of names in the scene. The sprite
+        lists will be drawn in the order of the passed iterable. If a
+        name is not in the scene, a :py:class:`KeyError` will be raised.
+
+        :param float delta_time: The time step to update by in seconds.
+        :param Optional[Iterable[str]] names:
+            An iterable of sprite list names to update, such as a list.
         """
         if names:
             for name in names:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -179,7 +179,7 @@ class Scene:
         """
         Add a SpriteList to the scene with the specified name.
 
-        This will add a new SpriteList to the scene at the end of the draw order.
+        This will add a new SpriteList as a layer above the others in the scene.
 
         If no SpriteList is supplied via the `sprite_list` parameter then a new one will be
         created, and the `use_spatial_hash` parameter will be respected for that creation.
@@ -206,18 +206,19 @@ class Scene:
         """
         Add a sprite list to the scene with the specified name before another SpriteList.
 
-        If no sprite list is supplied via the ``sprite_list`` parameter then a new one
-        will be created. Aside using the value of ``use_spatial_hash`` passed to this
+        If no sprite list is supplied via the ``sprite_list`` parameter, then a new one
+        will be created. Aside from the value of ``use_spatial_hash`` passed to this
         method, it will use the default arguments for a new :py:class:`SpriteList`.
 
         The added sprite list will be drawn under the sprite list named in ``before``.
 
-        :param str name: The name to give the sprite list.
-        :param str before: The name of the SpriteList to place this one before.
-        :param bool use_spatial_hash: If creating a new sprite list, selects whether to
-            enable spatial hashing.
-        :param SpriteList sprite_list: If a sprite list passed via this argument, it will
-            be used instead of creating a new one.
+        :param str name: The name to give the new layer.
+        :param str before: The name of the layer to place the new
+            one before.
+        :param bool use_spatial_hash: If creating a new sprite list, selects
+            whether to enable spatial hashing.
+        :param SpriteList sprite_list: If a sprite list is passed via
+            this argument, it will be used instead of creating a new one.
         """
         if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)
@@ -266,14 +267,18 @@ class Scene:
         """
         Add a SpriteList to the scene with the specified name after a specific SpriteList.
 
-        This will add a new SpriteList to the scene after the specified SpriteList in the draw order.
-        If no SpriteList is supplied via the `sprite_list` parameter then a new one will be
-        created, and the `use_spatial_hash` parameter will be respected for that creation.
+        If no sprite list is supplied via the ``sprite_list`` parameter, then a new one
+        will be created. Aside from the value of ``use_spatial_hash`` passed to this
+        method, it will use the default arguments for a new :py:class:`SpriteList`.
 
-        :param str name: The name to give the SpriteList.
-        :param str after: The name of the SpriteList to place this one after.
-        :param bool use_spatial_hash: Whether or not to use spatial hash if creating a new SpriteList.
-        :param SpriteList sprite_list: The SpriteList to add, optional.
+        The added sprite list will be drawn above the sprite list named in ``after``.
+
+        :param str name: The name to give the layer.
+        :param str after: The name of the layer to place the new one after.
+        :param bool use_spatial_hash: If creating a new sprite list, selects
+            whether to enable spatial hashing.
+        :param SpriteList sprite_list: If a sprite list is passed via
+            this argument, it will be used instead of creating a new one.
         """
         if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -213,8 +213,8 @@ class Scene:
         :param str before: The name of the SpriteList to place it before.
         """
         if name not in self._name_mapping:
-            raise ValueError(
-                f"Tried to move unknown SpriteList with the name {name} in Scene"
+            raise KeyError(
+                f"Tried to move unknown SpriteList with the name {name!r} in Scene"
             )
 
         name_list = self._name_mapping[name]

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -1,9 +1,13 @@
 """
-This module provides a Scene Manager class.
+This module provides a Scene class which acts as a sprite list manager.
 
-This class let's you add Sprites/SpriteLists to a scene and give them
-a name, as well as control the draw order. In addition it provides a
-helper function to create a Scene directly from a TileMap object.
+It allows you to do the following:
+
+* Group sprite lists into a larger object, using them like layers
+* Draw & update the contained sprite lists
+* Add sprites by name
+* Load from tiled map objects
+* Control sprite list draw order within the group
 """
 
 from typing import Dict, List, Optional, Union, Iterable, Tuple

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -87,9 +87,13 @@ class Scene:
 
     def get_sprite_list(self, name: str) -> SpriteList:
         """
-        Helper function to retrieve a `SpriteList` by name.
+        Retrieve a sprite list by name.
 
-        The name mapping can be accessed directly, this is just here for ease of use.
+        It is also possible to access sprite lists the following ways:
+
+        * ``scene_instance[name]``
+        * directly accessing ``scene_instance._name_mapping``, although this may
+          get flagged by linters as bad style.
 
         :param str name: The name of the `SpriteList` to retrieve.
         """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -115,14 +115,18 @@ class Scene:
 
     def add_sprite(self, name: str, sprite: Sprite) -> None:
         """
-        Add a Sprite to a SpriteList in the Scene with the specified name.
+        Add a Sprite to the SpriteList with the specified name.
 
-        If the desired SpriteList does not exist, it will automatically be created
-        and added to the Scene. This will default the SpriteList to be added to the end
-        of the draw order, and created with no extra options like using spatial hashing.
+        If there is no SpriteList for the given ``name``, one will be
+        created with :py:class:`SpriteList`'s default arguments and
+        added to the end (top) of the scene's current draw order.
 
-        If you need more control over where the SpriteList goes or need it to use Spatial Hash,
-        then the SpriteList should be added separately and then have the Sprites added.
+        To fully customize the SpriteList's options, you should create
+        it directly and add it to the scene with one of the following:
+
+        * :py:meth:`.add_sprite_list_before`
+        * :py:meth:`.add_sprite_list`
+        * :py:meth:`.add_sprite_list_after`
 
         :param str name: The name of the `SpriteList` to add to or create.
         :param Sprite sprite: The `Sprite` to add.

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -124,7 +124,7 @@ class Scene:
         It is also possible to access sprite lists the following ways:
 
         * ``scene_instance[name]``
-        * directly accessing ``scene_instance._name_mapping``, although this may
+        * directly accessing ``scene_instance._name_mapping``, although this will
           get flagged by linters as bad style.
 
         :param name: The name of the sprite list to retrieve.
@@ -181,12 +181,13 @@ class Scene:
 
         This will add a new SpriteList as a layer above the others in the scene.
 
-        If no SpriteList is supplied via the `sprite_list` parameter then a new one will be
-        created, and the `use_spatial_hash` parameter will be respected for that creation.
+        If no SpriteList is supplied via the ``sprite_list`` parameter then a new one will be
+        created, and the ``use_spatial_hash`` parameter will be respected for that creation.
 
-        :param name: The name to give the SpriteList.
-        :param use_spatial_hash: Wether or not to use spatial hash if creating a new SpriteList.
-        :param sprite_list: The SpriteList to add, optional.
+        :param name: The name to give the new layer.
+        :param use_spatial_hash: If creating a new sprite list, whether
+            to enable spatial hashing on it.
+        :param sprite_list: Use a specific sprite list rather than creating a new one.
         """
         if sprite_list is None:
             sprite_list = SpriteList(use_spatial_hash=use_spatial_hash)

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -51,18 +51,18 @@ class Scene:
     """
     Stores :py:class:`~arcade.SpriteList` instances as named layers, allowing bulk updates & drawing.
 
-    In addition to allowing you to update or draw multiple sprite lists
-    with one call, this class also provides convenience methods:
+    In addition to helping you update or draw multiple sprite lists at
+    once, this class also provides the following convenience methods:
 
-    * :py:meth:`.add_sprite` to allow adding sprites to layers dynamically
-    * :py:meth:`.Scene.from_tilemap`, which creates a new scene from a
+    * :py:meth:`.add_sprite`, which adds sprites to layers by name
+    * :py:meth:`.Scene.from_tilemap`, which creates a scene from a
       :py:class:`~arcade.tilemap.TileMap` already loaded from tiled data
     * Fine-grained convenience methods for adding, deleting, and reordering
       sprite lists
-    * Flexible but slow convenience methods & support for the ``in`` & ``del``
-      Python keywords.
+    * Flexible but slow general convenience methods
+    * Flexible but slow support for the ``in`` & ``del`` Python keywords.
 
-    For an example of how to use this class, see :ref:`platformer_part_three`.
+    For another example of how to use this class, see :ref:`platformer_part_three`.
     """
 
     def __init__(self) -> None:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -204,10 +204,10 @@ class Scene:
         before: str,
     ) -> None:
         """
-        Move a given SpriteList in the scene to before another given SpriteList.
+        Move a named SpriteList in the scene to be before another SpriteList in the scene.
 
-        This will adjust the render order so that the SpriteList specified by `name`
-        is placed before the one specified by `before`.
+        A :py:class:`KeyError` will be raised if either ``name`` or ``before`` contain
+        a name not currently in the scene.
 
         :param str name: The name of the SpriteList to move.
         :param str before: The name of the SpriteList to place it before.
@@ -215,6 +215,11 @@ class Scene:
         if name not in self._name_mapping:
             raise KeyError(
                 f"Tried to move unknown SpriteList with the name {name!r} in Scene"
+            )
+
+        if before not in self._name_mapping:
+            raise KeyError(
+                f"Tried to move unknown SpriteList with the name {before!r} in Scene"
             )
 
         name_list = self._name_mapping[name]
@@ -258,10 +263,11 @@ class Scene:
         after: str,
     ) -> None:
         """
-        Move a given SpriteList in the scene to be after another given SpriteList.
+        Move the named SpriteList in the scene to be after another SpriteList.
 
-        This will adjust the render order so that the SpriteList specified by `name`
-        is placed after the one specified by `after`.
+        This will adjust the render order so that the SpriteList
+        specified by ``name`` is placed after the one specified by
+        ``after``.
 
         :param str name: The name of the SpriteList to move.
         :param str after: The name of the SpriteList to place it after.

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -81,7 +81,8 @@ class Scene:
 
         .. tip:: Use a more specific method when speed is important!
 
-                 This method uses :py:func:`isinstance`, which can be slow.
+                 This method uses :py:func:`isinstance`, which will
+                 slow down your program if used frequently!
 
         Consider the following alternatives:
 

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -254,7 +254,7 @@ class Scene:
         after: str,
     ) -> None:
         """
-        Move a given SpriteList in the scene to after another given SpriteList.
+        Move a given SpriteList in the scene to be after another given SpriteList.
 
         This will adjust the render order so that the SpriteList specified by `name`
         is placed after the one specified by `after`.
@@ -278,9 +278,7 @@ class Scene:
         index: int
     ) -> None:
         """
-        Remove a SpriteList by its index.
-
-        This function serves to completely remove the SpriteList from the Scene.
+        Remove a SpriteList from the scene by its index in the draw order.
 
         :param int index: The index of the SpriteList to remove.
         """
@@ -291,9 +289,10 @@ class Scene:
         name: str,
     ) -> None:
         """
-        Remove a SpriteList by its name.
+        Remove a SpriteList from the scene by its name.
 
-        This function serves to completely remove the SpriteList from the Scene.
+        A :py:class:`KeyError` will be raised if the SpriteList is not
+        in the scene.
 
         :param str name: The name of the SpriteList to remove.
         """
@@ -303,9 +302,10 @@ class Scene:
 
     def remove_sprite_list_by_object(self, sprite_list: SpriteList) -> None:
         """
-        Remove a SpriteList from the Scene.
+        Remove the passed SpriteList instance from the Scene.
 
-        This function serves to completely remove the SpriteList from the Scene.
+        A :py:class:`ValueError` will be raised if the passed sprite
+        list is not in the scene.
 
         :param SpriteList sprite_list: The SpriteList to remove.
         """

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -127,7 +127,7 @@ class Scene:
         * directly accessing ``scene_instance._name_mapping``, although this may
           get flagged by linters as bad style.
 
-        :param str name: The name of the `SpriteList` to retrieve.
+        :param str name: The name of the sprite list to retrieve.
         """
         return self._name_mapping[name]
 

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -488,17 +488,21 @@ class Scene:
     def draw_hit_boxes(
         self,
         color: RGBA255 = Color(0, 0, 0, 255),
-        line_thickness: float = 1,
-        names: Optional[List[str]] = None,
+        line_thickness: float = 1.0,
+        names: Optional[Iterable[str]] = None,
     ) -> None:
         """
-        Draw hitboxes for all sprites in the scene.
+        Draw debug hit box outlines for sprites in the scene's layers.
 
-        If `names` parameter is provided then only the specified SpriteLists
-        will be drawn. They will be drawn in the order that the names in the
-        list were arranged. If `names` is not provided, then every SpriteList
-        in the scene will be drawn according to the order of the main _sprite_lists
-        attribute of the Scene.
+        If ``names`` is a valid iterable of layer names in the scene, then hit boxes
+        will be drawn for the specified layers in the order of the passed iterable.
+
+        If `names` is not provided, then every layer's hit boxes will be drawn in the
+        order specified.
+
+        :param color: The RGBA color to use to draw the hit boxes with.
+        :param line_thickness: How many pixels thick the hit box outlines should be
+        :param names: Which layers & what order to draw the hit boxes for them in
         """
 
         if names:


### PR DESCRIPTION
### Changes

* Rewrite multiple docstrings for clarity & precision
* Add links to other relevant sections of arcade & python doc
* Add missing keyword arguments & type annotations to `Scene.draw`

### How to test

1. Build & serve doc locally with `./make.py serve`
2. Open http://localhost:8000/api_docs/api/sprite_scenes.html#arcade.Scene in your browser
3. Check for anything wrong

### Progress
- [x] Top-level docstring
- [x] Sprite list addition docstrings
- [x] Dunder docstrings
- [x] Drawing docstrings
- [x] `get_*` docstrings
- [x] Take care of `move_*` function docstrings
- [x] Find & fix any remaining docstrings & annotation in need of attention
- [x] Double check backtick formatting for variables displaying as italics