### PR TITLE
Add CI report of typehint completeness

### DIFF
--- a/.github/workflows/verify_types.yml
+++ b/.github/workflows/verify_types.yml
@@ -1,0 +1,31 @@
+name: Type completeness report
+
+on:
+  push:
+    branches: [development, maintenance]
+  pull_request:
+    branches: [development, maintenance]
+  workflow_dispatch:
+
+jobs:
+
+  verifytypes:
+    name: verifytypes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          architecture: x64
+
+      - name: Install
+        id: install
+        run: |
+          python -m pip install .[dev]
+      - name: "code-inspection: pyright --verifytypes"
+        # Suppress exit code because we do not expect to reach 100% type completeness any time soon
+        run: |
+          python -m pyright --verifytypes arcade || true


### PR DESCRIPTION
Pyright has a flag to check how much of a library's API is properly typehinted.  This PR generates that report on CI.

Output looks like this:
https://github.com/pythonarcade/arcade/actions/runs/5137377588/jobs/9245379193?pr=1807

It generates a summary at the bottom:

```
Symbols exported by "arcade": 9419
  With known type: 3363
  With ambiguous type: 442
  With unknown type: 5614
  Functions without docstring: 768
  Functions without default param: 38
  Classes without docstring: 150

Other symbols referenced but not exported by "arcade": 1151
  With known type: 877
  With ambiguous type: 54
  With unknown type: 220

Type completeness score: 35.7%
```

It would be great to see how much @gran4's PRs improve this score.