### PR TITLE
Fix pyright issues in pathing

### DIFF
--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -2,6 +2,7 @@
 Classic A-star algorithm for path finding.
 """
 from typing import (
+    cast,
     List,
     Optional,
     Set,
@@ -319,7 +320,7 @@ def astar_calculate_path(start_point: Point,
     # Currently 'result' is in grid locations. We need to convert them to pixel
     # locations.
     revised_result = [_expand(p, grid_size) for p in result]
-    return revised_result
+    return cast(List[Point], revised_result)
 
 
 def has_line_of_sight(observer: Point,

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -169,7 +169,7 @@ def _AStarSearch(start: Point, end: Point, graph: _AStarGraph) -> Optional[List[
         current = None
         current_fscore = None
         for pos in sorted(open_vertices):
-            if current is None or F[pos] < current_fscore:
+            if current is None or F[pos] < current_fscore:  # type: ignore
                 current_fscore = F[pos]
                 current = pos
 


### PR DESCRIPTION
Follow-up to #1762 

### Changes

* Cast a return type to silence a pyright error
* Use `#type: ignore` on a short-circuit evaluation pyright fails to understand

### Follow-up work

The UI stack needs similar fixes, but I do not yet understand the intended design well enough to be confident fixing it.