### PR TITLE
Fix typo in message of ValueError Color.from_normalized can raise

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -306,7 +306,7 @@ class Color(RGBA255):
 
         if _a:
             if len(_a) > 1:
-                raise ValueError("color_normalized must unpack to 3 or 3 values")
+                raise ValueError("color_normalized must unpack to 3 or 4 values")
             a = _a[0]
 
             if not 0.0 <= a <= 1.0:


### PR DESCRIPTION
### Changes

* s/3 or 3/3 or 4/

Discovered while working on #1772