### PR TITLE
doc_stack/fix_readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - docs
+        - dev
 
 # Build PDF & ePub
 formats:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "furo",
     "pyright",
     "pyyaml==6.0",
-    "sphinx==7.0.1",
+    "sphinx==7.1.2",
     "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.2",
     # Intentionally kept at 2.3 until this bugfix is published: https://github.com/jdillard/sphinx-sitemap/pull/62

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.2",
     # Intentionally kept at 2.3 until this bugfix is published: https://github.com/jdillard/sphinx-sitemap/pull/62
-    "sphinx-sitemap==2.5.0",
+    "sphinx-sitemap==2.3.0",
     "typer[all]==0.7.0",
     "wheel",
 ]


### PR DESCRIPTION
Part of the PR stack described by #1797

Reverts a change from #1826, see comment in pyproject.toml about why we use old version.