### PR TITLE
Fix exception type when Window.show_view is passed a non-View

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -721,8 +721,9 @@ class Window(pyglet.window.Window):
         :param View new_view: View to show
         """
         if not isinstance(new_view, View):
-            raise TypeError("Must pass an arcade.View object to "
-                             f"Window.show_view() {type(new_view)}")
+            raise TypeError(
+                f"Window.show_view() takes an arcade.View,"
+                f"but it got a {type(new_view)}: {new_view}")
 
         # Store the Window that is showing the "new_view" View.
         if new_view.window is None:

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -721,7 +721,7 @@ class Window(pyglet.window.Window):
         :param View new_view: View to show
         """
         if not isinstance(new_view, View):
-            raise ValueError("Must pass an arcade.View object to "
+            raise TypeError("Must pass an arcade.View object to "
                              f"Window.show_view() {type(new_view)}")
 
         # Store the Window that is showing the "new_view" View.

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -723,7 +723,7 @@ class Window(pyglet.window.Window):
         if not isinstance(new_view, View):
             raise TypeError(
                 f"Window.show_view() takes an arcade.View,"
-                f"but it got a {type(new_view)}: {new_view}")
+                f"but it got a {type(new_view)}.")
 
         # Store the Window that is showing the "new_view" View.
         if new_view.window is None:

--- a/tests/unit/window/test_window.py
+++ b/tests/unit/window/test_window.py
@@ -1,3 +1,5 @@
+import pytest
+
 import arcade
 import pyglet
 
@@ -13,6 +15,10 @@ def test_window(window: arcade.Window):
     arcade.set_background_color(arcade.color.AMAZON)
     w = arcade.get_window()
     assert w is not None
+
+    for not_a_view in ("string", 1, ("not", "a", "view")):
+        with pytest.raises(TypeError):
+            w.show_view(not_a_view)
 
     # NOTE: Window managers can enforce difference sizes
     # Make sure the arguments get passed to the window


### PR DESCRIPTION
The errors reported for this PR are fixed by #1854

### Changes

1. Raise a `TypeError` instead of a `ValueError` when `Window.show_view` is passed something other than a view
2. Include the passed object's string representation in the `TypeError`'s string
3. Test the exception type in Window's unit tests

### How to test

Run unit tests as usual.