### PR TITLE
Lock pyright version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pygments==2.15.1",
     "docutils==0.19",
     "furo",
-    "pyright",
+    "pyright==1.1.322",
     "pyyaml==6.0",
     "sphinx==7.1.2",
     "sphinx-autobuild==2021.3.14",


### PR DESCRIPTION
To avoid CI breakages due to pyright releasing a new version, not caused by any of our code