### PR TITLE
Fix readthedocs by requiring 3.9 for local dev and doc build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,12 +71,19 @@ jobs:
           path: pull_request_payload.json
 
   builddoc:
+
     name: Documentation build test
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # python-version in must be kept in sync with .readthedocs.yaml
+        #
+        # Why 3.9?
+        #  1. It's the lowest version compatible w/ Sphinx 7.2.2, a doc build dependency
+        #  2. Better doc build accessibility for contributors who may have trouble
+        #     setting up newer Python versions (Debian, etc).
         python-version: ['3.9']
         architecture: ['x64']
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.9']
         architecture: ['x64']
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.8
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,11 @@ sphinx:
 python:
   # If you change this, you also need to update .github/workflows/test.yml
   # to make sure doc test builds run on the same version.
+  #
+  # Why 3.9?
+  #  1. It's the lowest version compatible w/ Sphinx 7.2.2, a doc build dependency
+  #  2. Better doc build accessibility for contributors who may have trouble
+  #     setting up newer Python versions (Debian, etc).
   version: 3.9
   install:
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ sphinx:
   configuration: doc/conf.py
 
 python:
+  # If you change this, you also need to update .github/workflows/test.yml
+  # to make sure doc test builds run on the same version.
   version: 3.9
   install:
     - method: pip

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,9 +42,12 @@ The rest of the guide will help you get to this point & explain how to test in m
 Requirements
 ------------
 
-This guide assumes you've already done the following:
+Although using arcade only requires Python 3.8 or higher, development
+currently requires 3.9 or higher.
 
-1. `Installed python with pip <https://wiki.python.org/moin/BeginnersGuide/Download>`_
+The rest of this guide assumes you've already done the following:
+
+1. `Installed Python 3.9+ with pip <https://wiki.python.org/moin/BeginnersGuide/Download>`_
 2. `Installed git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
 3. `Forked the repo on GitHub <https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository>`_
 4. `Cloned your fork locally <https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository>`_

--- a/doc/contributing_guide/how_to_contribute.rst
+++ b/doc/contributing_guide/how_to_contribute.rst
@@ -23,6 +23,15 @@ First, take some time to understand the project layout:
 * :ref:`how-to-compile`
 * :ref:`how-to-submit-changes`
 
+
+Then, perform the following steps:
+
+#. Make sure you have Python 3.9+ installed rather than 3.8+ to meet
+   dev tool requirements.
+#. Make a virtual environment.
+#. Run `pip install -e .[dev]` to perform a dev install.
+
+
 Then you can improve these parts of the project:
 
 * **Document** - Edit the reStructuredText_ and docstrings_ to make the Arcade

--- a/doc/contributing_guide/how_to_contribute.rst
+++ b/doc/contributing_guide/how_to_contribute.rst
@@ -32,7 +32,7 @@ Then, perform the following steps:
 #. Run `pip install -e .[dev]` to perform a dev install.
 
 
-Then you can improve these parts of the project:
+Afterwards, you can improve these parts of the project:
 
 * **Document** - Edit the reStructuredText_ and docstrings_ to make the Arcade
   documentation better.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Source = "https://github.com/pythonarcade/arcade"
 Book = "https://learn.arcade.academy"
 
 [project.optional-dependencies]
+# Note: this actually requires Python 3.9 due to sphinx==7.2.2
 # Used for dev work
 dev = [
     "pytest",


### PR DESCRIPTION
tl;dr 
1. Use 3.9 for doc build instead of 3.8
2. Add notes explaining that 3.9+ is needed for development in `CONTRIBUTING.md` and `how_to_contribute.rst`