### PR TITLE
Fix #1891: monkeypatch autodoc to avoid directive name conflict

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,9 +269,11 @@ def post_process(_app, _exception):
 #         traceback.print_exc()
 #         raise
 
+
 def on_autodoc_process_bases(app, name, obj, options, bases):
     # Strip `object` from bases, it's just noise
     bases[:] = [base for base in bases if base is not object]
+
 
 class ClassDocumenter(sphinx.ext.autodoc.ClassDocumenter):
     """A replacement for the default autodocumenter.
@@ -304,10 +306,12 @@ class ClassDocumenter(sphinx.ext.autodoc.ClassDocumenter):
             strings.pop()
         return r
 
+
 class Transform(sphinx.transforms.SphinxTransform):
     default_priority = 800
     def apply(self):
         self.document.walk(Visitor(self.document))
+
 class Visitor(docutils.nodes.SparseNodeVisitor):
     def visit_desc_annotation(self, node):
         # Remove `property` prefix from properties so they look the same as


### PR DESCRIPTION
### Changes

Fixes #1891 , unblocks #1890 

1. Monkeypatch instead of attempting to add a `ClassDocumenter` which conflicts with the `autoclass` directive
2. Add doc explaining why / how this is necessary
3. Add some whitespace

### Follow up work

We should really consider making those "Is awesome Sphinx!" mugs.

### How to test

#### Option 1: Locally

1. `./make.py clean`
2. `./make.py html`
3. If the following warning no longer shows up, it's good:
    ```
    WARNING: while setting up extension conf.py: directive 'autoclass' is already registered, it will be overridden
    ```

#### Option 2: CI

1. Rebase something which failed off this branch
2. Push it to GitHub to trigger CI

