### PR TITLE
Fix MOD_ACCEL to match doc & pyglet behavior

### DIFF
--- a/arcade/key/__init__.py
+++ b/arcade/key/__init__.py
@@ -4,6 +4,7 @@ Constants used to signify what keys on the keyboard were pressed.
 """
 
 from __future__ import annotations
+from sys import platform
 
 # Key modifiers
 # Done in powers of two, so you can do a bit-wise 'and' to detect
@@ -17,7 +18,11 @@ MOD_WINDOWS = 32
 MOD_COMMAND = 64
 MOD_OPTION = 128
 MOD_SCROLLLOCK = 256
-MOD_ACCEL = 2
+
+# Platform-specific base hotkey modifier
+MOD_ACCEL = MOD_CTRL
+if platform == 'darwin':
+    MOD_ACCEL = MOD_COMMAND
 
 # Keys
 BACKSPACE = 65288


### PR DESCRIPTION
### Changes

* Update `MOD_ACCEL` to work on mac as described by our doc & pyglet's behavior
 
There are currently no tests for this in the entire codebase, but some could be added.

This PR will fail CI for the moment due to the ongoing effects from #1888, but I'll have a more durable fix + improvements to `test_key.py` soon. It will add more meaningful tests and rudimentary typo detection.

