### PR TITLE
Temp fix unit tests failing on color

### DIFF
--- a/tests/unit/color/test_module_color.py
+++ b/tests/unit/color/test_module_color.py
@@ -2,5 +2,5 @@
 def test_colors():
     from arcade import color
     names = color.__dict__.keys()
-    # number of colors + 1 import
-    assert 1013 + 1 == len(names)
+    # number of colors + 1 real import + 1 annotations
+    assert 1013 + 1 + 1 == len(names)

--- a/tests/unit/color/test_module_csscolor.py
+++ b/tests/unit/color/test_module_csscolor.py
@@ -2,5 +2,5 @@
 def test_csscolors():
     from arcade import csscolor
     names = csscolor.__dict__.keys()
-    # number of colors + 1 import
-    assert 156 + 1 == len(names)
+    # number of colors + 1 import + 1 annotations
+    assert 156 + 1 + 1 == len(names)

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -2,4 +2,7 @@
 def test_key():
     from arcade import key
     names = key.__dict__.keys()
-    assert 214 == len(names)
+    # temp fix which will be replaced with fuller, more meaningful
+    # tests in the coming days. The values are as follows:
+    # 214 key constants + from __future__ import annotations
+    assert 215 == len(names)


### PR DESCRIPTION
tl;dr  temp fix the arcade.color and arcade.csscolor tess by accounting for the annotations import.