### PR TITLE
Gl attrib type fix

### DIFF
--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -214,10 +214,10 @@ class BufferDescription:
         "f4": (gl.GL_FLOAT, 4),
         "f8": (gl.GL_DOUBLE, 8),
         # Unsigned integers
-        "u": (gl.GL_FLOAT, 4),
-        "u1": (gl.GL_FLOAT, 1),
-        "u2": (gl.GL_FLOAT, 2),
-        "u4": (gl.GL_FLOAT, 4),
+        "u": (gl.GL_UNSIGNED_INT, 4),
+        "u1": (gl.GL_UNSIGNED_BYTE, 1),
+        "u2": (gl.GL_UNSIGNED_SHORT, 2),
+        "u4": (gl.GL_UNSIGNED_INT, 4),
         # Signed integers
         "i": (gl.GL_INT, 4),
         "i1": (gl.GL_BYTE, 1),

--- a/arcade/gl/vertex_array.py
+++ b/arcade/gl/vertex_array.py
@@ -13,7 +13,14 @@ from .program import Program
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context
 
-index_types = [None, gl.GL_UNSIGNED_BYTE, gl.GL_UNSIGNED_SHORT, None, gl.GL_UNSIGNED_INT]
+# Index buffer types based on index element size
+index_types = [
+    None,  # 0 (not supported)
+    gl.GL_UNSIGNED_BYTE,  # 1 ubyte8
+    gl.GL_UNSIGNED_SHORT,  # 2 ubyte16
+    None,  # 3 (not supported)
+    gl.GL_UNSIGNED_INT  # 4 ubyte32
+]
 
 
 class VertexArray:

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -440,7 +440,7 @@ class TextureAtlas:
             region = self.get_texture_region_info(texture.atlas_name)
             return slot, region
 
-        LOG.info("Attempting to add texture: %s | %s", texture.atlas_name)
+        LOG.info("Attempting to add texture: %s", texture.atlas_name)
 
         # Add the image if we don't already have it.
         # If the atlas is full we will try to resize it.


### PR DESCRIPTION
Unsigned integers are not possible to use in vertex data due to incorrect data type mapping.

+ fix broken log message in atlas