### PR TITLE
Bug: Shader defines cannot be set to 0

### DIFF
--- a/arcade/gl/glsl.py
+++ b/arcade/gl/glsl.py
@@ -137,8 +137,8 @@ class ShaderSource:
             if line.startswith("#define"):
                 try:
                     name = line.split()[1]
-                    value = defines.get(name)
-                    if not value:
+                    value = defines.get(name, None)
+                    if value is None:
                         continue
 
                     lines[nr] = "#define {} {}".format(name, str(value))


### PR DESCRIPTION
If we have the following define in a shader ..
```glsl
#define LIGHTING_ENABLED 1
```

passsing `defines={"LIGHTING_ENABLED": 0}` duing program creation will not overrwrite the define value above because the "truthiness" of `0` is `False`.
