### PR TITLE
Shader include bugs and issues

### DIFF
--- a/arcade/context.py
+++ b/arcade/context.py
@@ -385,6 +385,8 @@ class ArcadeContext(Context):
         from arcade.resources import resolve
 
         vertex_shader_src = resolve(vertex_shader).read_text()
+        vertex_shader_src = self.shader_inc(vertex_shader_src)
+
         fragment_shader_src = None
         geometry_shader_src = None
         tess_control_src = None


### PR DESCRIPTION
Some issue related to shader includes.
* [x] Includes are not handled for vertex shader in `ArcadeContext.load_program`

Possibly we should add some unit tests.

We should probably use shader includes a lot more in the internal shaders, but this also means we should cache the loaded / resolved shader strings with support for flushing this cache.