### PR TITLE
Flip texture also for animation

### DIFF
--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -102,6 +102,16 @@ def _get_image_source(
     return None
 
 
+def _may_be_flip(tile, texture):
+        if tile.flipped_diagonally:
+            texture = texture.flip_diagonally()
+        if tile.flipped_horizontally:
+            texture = texture.flip_horizontally()
+        if tile.flipped_vertically:
+            texture = texture.flip_vertically()
+        return texture
+
+
 class TileMap:
     """
     Class that represents a fully parsed and loaded map from Tiled.
@@ -466,12 +476,7 @@ class TileMap:
                 height=height,
                 hit_box_algorithm=hit_box_algorithm,
             )
-            if tile.flipped_diagonally:
-                texture = texture.flip_diagonally()
-            if tile.flipped_horizontally:
-                texture = texture.flip_horizontally()
-            if tile.flipped_vertically:
-                texture = texture.flip_vertically()
+            texture = _may_be_flip(tile, texture)
 
             args = {
                 "path_or_texture": texture,  # type: ignore
@@ -624,6 +629,8 @@ class TileMap:
                             f"Warning: failed to load image for animation frame for "
                             f"tile '{frame_tile.id}', '{image_file}'."
                         )
+
+                    texture = _may_be_flip(tile, texture)
 
                     key_frame = AnimationKeyframe(  # type: ignore
                         frame.tile_id, frame.duration, texture

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -31,7 +31,7 @@ from arcade.hitbox import HitBoxAlgorithm, RotatableHitBox
 from arcade.texture.loading import _load_tilemap_texture
 
 if TYPE_CHECKING:
-    from arcade import TextureAtlas
+    from arcade import TextureAtlas, Texture
 
 from pyglet.math import Vec2
 
@@ -102,7 +102,7 @@ def _get_image_source(
     return None
 
 
-def _may_be_flip(tile, texture):
+def _may_be_flip(tile: pytiled_parser.Tile, texture: Texture) -> Texture:
         if tile.flipped_diagonally:
             texture = texture.flip_diagonally()
         if tile.flipped_horizontally:


### PR DESCRIPTION
Move the code that flip texture for fixed sprite to a function. Apply this function on animated texture.

Fix #1916