### PR TITLE
Move _view_examples link target to cover all view examples

### DIFF
--- a/doc/example_code/how_to_examples/index.rst
+++ b/doc/example_code/how_to_examples/index.rst
@@ -433,10 +433,11 @@ Cameras
 
    :ref:`camera_platform`
 
-View Management
----------------
 
 .. _view_examples:
+
+View Management
+---------------
 
 Instruction and Game Over Screens
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
tl;dr jump to the actual view examples heading instead of the just the instruction and game over screens

This is a minor quality of life fix discovered while drafting audio documentation.