### PR TITLE
Lingering glreadbuffer

### DIFF
--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -777,9 +777,17 @@ class Context:
 
     # Various utility methods
 
-    def copy_framebuffer(self, src: Framebuffer, dst: Framebuffer):
+    def copy_framebuffer(
+        self,
+        src: Framebuffer,
+        dst: Framebuffer,
+        src_layer_id: int = 0,
+        depth: bool = True,
+    ):
         """
         Copies/blits a framebuffer to another one.
+        We can select one color attachment to copy plus
+        an optional depth attachment.
 
         This operation has many restrictions to ensure it works across
         different platforms and drivers:
@@ -791,15 +799,20 @@ class Context:
 
         :param src: The framebuffer to copy from
         :param dst: The framebuffer we copy to
+        :param glBlitNamedFramebuffer: The color attachment layer to copy from
+        :param depth: Also copy depth attachment if present
         """
+        # TODO: Make make this more configurable (target)
+        gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + src_layer_id)
         gl.glBindFramebuffer(gl.GL_READ_FRAMEBUFFER, src._glo)
         gl.glBindFramebuffer(gl.GL_DRAW_FRAMEBUFFER, dst._glo)
         gl.glBlitFramebuffer(
             0, 0, src.width, src.height,  # Make source and dest size the same
             0, 0, src.width, src.height,
-            gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT,
+            gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT if depth else 0,
             gl.GL_NEAREST,
         )
+        gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)  # Reset read buffer
         self.active_framebuffer.use(force=True)
 
     # --- Resource methods ---

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -781,7 +781,7 @@ class Context:
         self,
         src: Framebuffer,
         dst: Framebuffer,
-        src_layer_id: int = 0,
+        src_attachment_index: int = 0,
         depth: bool = True,
     ):
         """
@@ -799,12 +799,12 @@ class Context:
 
         :param src: The framebuffer to copy from
         :param dst: The framebuffer we copy to
-        :param glBlitNamedFramebuffer: The color attachment layer to copy from
+        :param src_attachment_index: The color attachment to copy from
         :param depth: Also copy depth attachment if present
         """
         # TODO: Make make this more configurable (target)
-        gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + src_layer_id)
         gl.glBindFramebuffer(gl.GL_READ_FRAMEBUFFER, src._glo)
+        gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + src_attachment_index)
         gl.glBindFramebuffer(gl.GL_DRAW_FRAMEBUFFER, dst._glo)
         gl.glBlitFramebuffer(
             0, 0, src.width, src.height,  # Make source and dest size the same

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -433,6 +433,7 @@ class Framebuffer:
                 x, y, width, height = 0, 0, self._width, self._height
             data = (gl.GLubyte * (components * component_size * width * height))(0)
             gl.glReadPixels(x, y, width, height, base_format, pixel_type, data)
+            gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)  # Reset to default
 
         return string_at(data, len(data))
 


### PR DESCRIPTION
We're not properly setting what read framebuffer should be active. This leads to quite a bit of trouble when dealing with multi-attachment framebuffers.

I noticed this when debugging my deferred renderer. It messued up absolutely everything and screen was turning black.
