### PR TITLE
Add Sound page to the Programming Guide

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -98,6 +98,7 @@ The Python Arcade Library
 
    programming_guide/sprites/index
    programming_guide/keyboard
+   programming_guide/sound
    programming_guide/textures
    programming_guide/sections
    programming_guide/gui/index

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -328,9 +328,13 @@ Advanced Playback Control
 .. _pyglet_controlling_playback: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#controlling-playback
 .. _inconsistency_loop_issue: https://github.com/pythonarcade/arcade/issues/1915
 
-You can alter the playback of a :py:class:`arcade.Sound`'s data by:
+Arcade's functions for :ref:`sound-basics-stopping` are convenience
+wrappers around the passed pyglet :py:class:`~pyglet.media.player.Player`.
 
-* Using properties and methods of a :py:class:`~pyglet.media.player.Player`
+You can alter a playback of :py:class:`~arcade.Sound` data with more precision
+by:
+
+* Using the properties and methods of its :py:class:`~pyglet.media.player.Player`
   any time before playback has finished
 * Passing keyword arguments with the same (or similar) names as the
   Player's properties when :ref:`playing the sound <sound-basics-playing>`.
@@ -338,24 +342,36 @@ You can alter the playback of a :py:class:`arcade.Sound`'s data by:
 Stopping via the Player Object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Arcade's functions for :ref:`sound-basics-stopping` call methods on the
-passed pyglet :py:class:`~pyglet.media.player.Player`. You can use the
-same methods for finer control, such as pausing and resuming playback.
+The simplest form of advanced control is pausing and resuming playback.
 
 Pausing
 """""""
-There is no stop method. Instead, the stopping helpers call the
-:py:meth:`Player.pause() <pyglet.media.player.Player.pause>` method.
+There is no stop method. Instead, call the :py:meth:`Player.pause()
+<pyglet.media.player.Player.pause>` method::
+
+ # Assume this is inside an Enemy class subclassing arcade.Sprite
+ self.current_player.pause()
 
 Stopping Permanently
 """"""""""""""""""""
-The helper functions are for stopping a playback without resuming. If
-you are sure you want don't want to resume, do the following after
-pausing the player:
+After you've paused a player, you can stop playback permanently:
 
-#. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method
-#. Make sure all references to the player are replaced with ``None`` to
-   allow `garbage collection`_.
+#. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method::
+
+    # Permanently deletes the operating system half of this playback.
+    self.current_player.delete()
+
+   `This specific playback is now permanently over, but you can start
+   new ones.`
+
+#. Make sure all references to the player are replaced with ``None``::
+
+    # Python will delete the pyglet Player once there are 0 references to it
+    self.current_player = None
+
+For a more in-depth explanation of references and auto-deletion, skim
+the start of Python's page on `garbage collection`_. Reading the Abstract
+section of this page should be enough to get started.
 
 Changing Aspects of Playback
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -150,8 +150,8 @@ perform some other action.
 
 Although this may seem unimportant, it is crucial if for games which
 hide parts of the world from view. An enemy with no way to know it's
-there is the most common version of an "unknown danger" as described in
-:ref:`sound-why-important`.
+there is the most common version of the unknown danger example listed
+in :ref:`sound-why-important`.
 
 See the following to learn more:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -92,7 +92,7 @@ The easiest way to use :py:func:`arcade.load_sound`:
     # You can pass strings containing a built-in resource handle,
     hurt_sound = arcade.load_sound(":resources:sounds/hurt1.wav")
     # a pathlib.Path,
-    pathlib_sound = arcade.load_sound(Path("imaginary\windows\path\file.wav"))
+    pathlib_sound = arcade.load_sound(Path("imaginary\windows\path\\file.wav"))
     # or an ordinary string describing a path.
     string_path_sound = arcade.load_sound("imaginary/mac/style/path.wav")
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -108,7 +108,7 @@ See the following to learn more:
 #. :ref:`Platformer Part 7 - Loading Sounds <platformer_part_seven_loading_sounds>`
 #. :ref:`resources`
 #. :py:mod:`pathlib`
-#. :ref:`sound-static-vs-streaming`
+#. :ref:`sound-loading-modes`
 
 .. _sound-basics-playing:
 
@@ -194,10 +194,10 @@ See the following to learn more:
 * :ref:`sound-advanced-playback`
 * `Python's contributor guide article on garbage collection <garbage collection_>`_
 
-.. _sound-static-vs-streaming:
+.. _sound-loading-modes:
 
-Streaming vs Static Audio
--------------------------
+Streaming or Static Loading?
+----------------------------
 
 .. _keyword argument: https://docs.python.org/3/glossary.html#term-argument
 
@@ -243,10 +243,10 @@ The following subheadings will explain each option in detail.
 .. [#staticsourcefoot]
    See the :py:class:`pyglet.media.StaticSource` class used by arcade.
 
-.. _sound-effects:
+.. _sound-loading-modes-static:
 
-Sound Effects are Fast
-^^^^^^^^^^^^^^^^^^^^^^
+Static Sounds Can Be Fastest
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As long as you have enough memory, preloading entire sounds prevents
 in-game slowdowns.
@@ -263,7 +263,7 @@ Any of the following suggest a sound should be loaded a a static effect:
 * You need to automatically loop playback.
 * The file is a short clip.
 
-.. _sound-streaming:
+.. _sound-loading-modes-streaming:
 
 Streaming Can Save Memory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -426,8 +426,8 @@ The Most Reliable Formats & Features
 
 For most users, the best formats are the following ones:
 
-* Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <sound-effects>`
-* Use MP3 files for :ref:`long background audio like music <sound-streaming>`
+* Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <sound-loading-modes-static>`
+* Use MP3 files for :ref:`long background audio like music <sound-loading-modes-streaming>`
 
 As long as a user has working audio hardware and drivers, the following
 basic features should work:

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -23,7 +23,7 @@ In addition each section's concepts, there may also be links to example
 code and documentation.
 
 #. :ref:`pgsound-why-important`
-#. :ref:`pgsound-tech-overview`:
+#. :ref:`pgsound-tech-overview`
 
    * :ref:`pgsound-loading`
    * :ref:`pgsound-playing`

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -83,7 +83,9 @@ Before you can play a sound, you need to load its data into memory.
 Arcade provides two ways to do this. Both accept the same arguments and
 return an :py:class:`arcade.Sound` instance.
 
-The easiest way is :py:func:`arcade.load_sound`::
+The easiest way to use :py:func:`arcade.load_sound`:
+
+.. code-block:: python
 
     import arcade
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -1,0 +1,594 @@
+.. _Wave: https://en.wikipedia.org/wiki/WAV
+.. _MP3: https://en.wikipedia.org/wiki/MP3
+
+.. _Audacity: https://www.audacityteam.org/
+.. _FFmpeg: https://ffmpeg.org/
+
+.. _PyGame CE: https://pyga.me/
+.. _SDL2: https://www.libsdl.org/
+
+.. _pyglet media guide: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html
+.. _positional audio: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#positional-audio
+.. _pyglet's supported media types: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#supported-media-types
+.. _pyglet_audio_drivers: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#choosing-the-audio-driver
+
+.. _pgsound:
+
+Sound
+=====
+
+This page will help you get started by covering the essentials of sound.
+
+In addition each section's concepts, there may also be links to example
+code and documentation.
+
+#. :ref:`pgsound-why-important`
+#. :ref:`pgsound-tech-overview`:
+
+   * :ref:`pgsound-loading`
+   * :ref:`pgsound-playing`
+   * :ref:`pgsound-stopping`
+
+#. :ref:`pgsound-compat`
+#. :ref:`pgsound-other-audio-libs` (for advanced users)
+
+.. rubric:: I'm Impatient!
+
+Users who want to skip to example code should consult the following:
+
+#. :ref:`sound_demo`
+#. :ref:`sound_speed_demo`
+#. :ref:`music_control_demo`
+#. :ref:`Platformer Tutorial - Step 7 - Add Coins And Sound <platformer_part_seven>`
+
+   #. :ref:`platformer_part_seven_loading_sounds`
+   #. :ref:`platformer_part_seven_playing_sounds`
+
+.. _pgsound-why-important:
+
+Why Is Sound Important?
+-----------------------
+
+Sound helps players make sense of what they see.
+
+This is about far more than the game being immersive or cool. For
+example, have you ever run into one of these common problems?
+
+* Danger you never knew was there
+* A character whose reaction seemed unexpected or out of place
+* Items or abilities which appeared similar, but were very different
+* An unclear warning or confirmation dialog
+
+How much progress did it cost you? A few minutes? The whole playthrough?
+More importantly, how did you feel? You probably didn't want to keep
+playing.
+
+You can use sound to prevent moments like these. In each example above,
+the right audio can provide the information players need for the game
+to feel fair.
+
+.. _pgsound-tech-overview:
+
+Sound Basics
+------------
+
+.. _pgsound-loading:
+
+Loading Sounds
+^^^^^^^^^^^^^^
+
+Before you can play a sound, you need to load its data into memory.
+
+Arcade provides two ways to do this. Both accept the same arguments and
+return an :py:class:`arcade.Sound` instance.
+
+The easiest way is :py:func:`arcade.load_sound`::
+
+    import arcade
+
+    # You can pass strings containing a built-in resource handle,
+    hurt_sound = arcade.load_sound(":resources:sounds/hurt1.wav")
+    # a pathlib.Path,
+    pathlib_sound = arcade.load_sound(Path("imaginary\windows\path\file.wav"))
+    # or an ordinary string describing a path.
+    string_path_sound = arcade.load_sound("imaginary/mac/style/path.wav")
+
+If you prefer a more object-oriented style, you can create
+:py:class:`~arcade.Sound` instances directly::
+
+    from arcade import Sound  # You can also use arcade.Sound directly
+
+    # Although Sound accepts the same arguments as load_sound,
+    # only the built-in resource handle is shown here.
+    hurt_sound = Sound(":resources:sounds/hurt1.wav")
+
+See the following to learn more:
+
+#. :ref:`Platformer Part 7 - Loading Sounds <platformer_part_seven_loading_sounds>`
+#. :ref:`resources`
+#. :py:mod:`pathlib`
+#. :ref:`pgsound-static-vs-streaming`
+
+.. _pgsound-playing:
+
+Playing Sounds
+^^^^^^^^^^^^^^
+
+There are two easy ways to play a :py:class:`~arcade.Sound` object.
+
+One is to call :py:meth:`Sound.play <arcade.Sound.play>` directly::
+
+    hurt_player = hurt_sound.play()
+
+The other is to pass a :py:class:`~arcade.Sound` instance as the first
+argument of :py:func:`arcade.play_sound`::
+
+    # Important: this *must* be a Sound instance, not a path or string!
+    self.hurt_player = arcade.play_sound(hurt_sound)
+
+See the following to learn more:
+
+#. :ref:`Platformer Tutorial - Part 7 - Collision Detection <platformer_part_seven_playing_sounds>`
+#. :ref:`sound_demo`
+
+.. _pgsound-stopping:
+
+Stopping Sounds
+^^^^^^^^^^^^^^^
+
+.. _garbage collection: https://devguide.python.org/internals/garbage-collector/
+
+Arcade's helper functions are the easiest way to stop playback:
+
+* The :py:func:`arcade.stop_sound` function
+* The :py:meth:`Sound.stop <arcade.Sound.stop>` method of the
+  sound data being played
+
+To use them, do the following:
+
+#. Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to one of the helpers::
+
+    # These are equivalent, but remember:
+    # 1. You only need to use one of them
+    # 2. You must pass the Player object, not the Sound object
+    arcade.stop_sound(self.current_playback)
+    Sound.stop(self.current_playback)
+
+#. Clear any references to the player to allow its memory to be freed::
+
+    # For each object, Python tracks how many other objects use it. If
+    # nothing else uses an object, it will be marked as garbage which
+    # Python can delete automatically to free memory.
+    self.current_playback = None
+
+See the following to learn more:
+
+* :ref:`pgsound-reliability`
+* :ref:`pgsound-playback-details`
+* `Python's contributor guide article on garbage collection <garbage collection_>`_
+
+.. _pgsound-static-vs-streaming:
+
+Streaming vs Static Audio
+-------------------------
+
+.. _keyword argument: https://docs.python.org/3/glossary.html#term-argument
+
+.. list-table::
+   :header-rows: 1
+
+   * - Streaming
+     - Best [#meaningbestformatheader]_ Format
+     - Decompressed
+     - Best Uses
+
+   * - ``False`` (Default)
+     - ``.wav``
+     - Whole file
+     - 2+ overlapping playbacks, short, repeated, unpredictable
+
+   * - ``True``
+     - ``.mp3``
+     - Predicted data
+     - 1 copy & file at a time, long, uninterrupted
+
+By default, arcade decompresses the entirety of each sound into memory.
+
+This is the best option for most game sound effects. It's called
+"static" [#staticsourcefoot]_ audio because the data never changes.
+
+The alternative is streaming. Enable it by passing ``True`` through the
+``streaming`` `keyword argument`_  when you :ref:`load a sound
+<pgsound-loading>`::
+
+    # Both loading approaches accept the streaming keyword.
+    classical_music_track = arcade.load_sound(":resources:music/1918.mp3", streaming=True)
+    funky_music_track = arcade.Sound(":resources:music/funkyrobot.mp3", streaming=True)
+
+
+For an interactive example, see the :ref:`music_control_demo`.
+
+The following subheadings will explain each option in detail.
+
+.. [#meaningbestformatheader]
+   See :ref:`pgsound-reliability` to learn more.
+
+.. [#staticsourcefoot]
+   See the :py:class:`pyglet.media.StaticSource` class used by arcade.
+
+.. _pgsound-effects:
+
+Sound Effects are Fast
+^^^^^^^^^^^^^^^^^^^^^^
+
+As long as you have enough memory, preloading entire sounds prevents
+in-game slowdowns.
+
+This is because disk access is one of the slowest things a computer can
+do. Avoiding it during gameplay is important if your gameplay needs to
+be fast and smooth.
+
+Any of the following suggest a sound should be loaded a a static effect:
+
+* You need to start playback quickly in response to gameplay.
+* 2 or more "copies" of the sound can be playing at the same time.
+* You will unpredictably restart or skip playback through the file.
+* You need to automatically loop playback.
+* The file is a short clip.
+
+.. _pgsound-streaming:
+
+Streaming Can Save Memory
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Streaming audio from files is very similar to streaming video online.
+
+Both save memory by keeping only part of a file into memory at any given
+time. Even on the slowest recent hardware, this usually works if:
+
+* You only stream one media source at a time.
+* You don't try to closely synchronize it with anything else.
+
+Use Streaming Sparingly
+"""""""""""""""""""""""
+The best way to use streaming is to only use it when you need it.
+
+Advanced users may be able to handle streaming multiple tracks at a
+time. However, issues with synchronization & interruptions will grow
+with the number and audio quality of the tracks involved.
+
+If you're unsure, avoid streaming unless you can say yes to all of the
+following:
+
+#. The :py:class:`~arcade.Sound` will have at most one playback at a time.
+   [#streamingsource]_
+
+#. The file is long enough to make it worth it.
+
+#. Seeking (skipping to different parts) will be infrequent.
+
+   * Ideally, you will never seek or restart playback suddenly
+   * If you do skip, the jumps will ideally be close enough to
+     land in the same or next chunk.
+
+.. [#streamingsource]
+   This is a requirement of the underlying :py:class:`pyglet.media.StreamingSource`.
+
+Streaming Can Cause Freezes
+"""""""""""""""""""""""""""
+Failing to meet the requirements can cause buffering issues.
+
+Good compression can help, but it can't fully overcome it. Each skip outside
+the currently loaded data requires reading and decompressing a replacement.
+
+In the worst-case scenario, frequent skipping will mean constantly
+buffering instead of playing. Although video streaming sites can
+downgrade quality, your game will be at risk of stuttering or freezing.
+
+The best way to handle this is to only use streaming when necessary.
+
+.. _pgsound-playback-details:
+
+Advanced Playback Control
+-------------------------
+
+.. _pyglet_controlling_playback: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#controlling-playback
+.. _inconsistency_loop_issue: https://github.com/pythonarcade/arcade/issues/1915
+
+You can alter the playback of a :py:class:`arcade.Sound`'s data by:
+
+* Using properties and methods of a :py:class:`~pyglet.media.player.Player`
+  any time before playback has finished
+* Passing keyword arguments with the same (or similar) names as the
+  Player's properties when :ref:`playing the sound <pgsound-playing>`.
+
+Stopping via the Player Object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can stop playback through its pyglet :py:meth:`pyglet.media.player.Player`
+instead of the :ref:`stopping helpers <pgsound-stopping>` as follows:
+
+#. Call the player's :py:meth:`~pyglet.media.player.Player.pause`
+   method.
+#. Call the player's :py:meth:`~pyglet.media.player.Player.delete`
+   method.
+#. Make sure all references to the player are discarded to allow
+   `garbage collection`_.
+
+Changing Playback Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ongoing Playback
+""""""""""""""""
+The properties and methods of an ongoing playback's
+:py:class:`pyglet.media.player.Player` allow changing aspects of it.
+
+The table below summarizes the most commonly used ones. Superscripts
+link explanations of inconsistencies, such as differences between names
+of properties and their equivalent keyword arguments in arcade functions.
+
+.. list-table::
+   :header-rows: 1
+
+   * - :py:class:`~pyglet.media.player.Player` Property
+     - Type
+     - Default
+     - Purpose
+
+   * - :py:attr:`~pyglet.media.player.Player.volume`
+     - :py:class:`float`
+     - ``1.0``
+     - The scaling factor for the original sound data's volume. Must be
+       between ``0.0`` (silent) and ``1.0`` (full volume).
+
+   * - :py:attr:`~pyglet.media.player.Player.loop`
+       [#inconsistencyloop]_
+     - :py:class:`bool`
+     - ``False``
+     - Whether to restart playback automatically after finishing. [#streamingnoloop]_
+
+   * - :py:attr:`~pyglet.media.player.Player.pitch` [#inconsistencyspeed]_
+     - :py:class:`float`
+     - ``1.0``
+     - How fast to play back the sound; also affects pitch.
+
+.. [#inconsistencyloop]
+   :py:func:`arcade.play_sound` uses ``looping`` as a keyword instead of
+   ``loop``; see `the related GitHub issue <inconsistency_loop_issue_>`_.
+
+.. [#streamingnoloop]
+   Looping is unavailable when ``streaming=True``; see `pyglet's guide to
+   controlling playback <pyglet_controlling_playback_>`_.
+
+.. [#inconsistencyspeed]
+   Arcade's equivalent keyword for :ref:`pgsound-playing` is ``speed``
+
+These are only a few of :py:class:`~pyglet.media.player.Player`'s many
+features. Consult its documentation and the `relevant section of the pyglet
+media guide <pyglet_controlling_playback_>`_ to learn more.
+
+Changing Parameters from the Start
+""""""""""""""""""""""""""""""""""
+You can alter playback when :ref:`pgsound-playing` through `keyword
+arguments <keyword argument>`_ with the same or similar names as the
+properties mentioned above. See the following to learn more:
+
+* :ref:`sound_speed_demo`
+* :py:func:`arcade.play_sound`
+* :py:meth:`Sound.play <arcade.Sound.play>`
+
+.. _pgsound-compat:
+
+Cross-Platform Compatibility
+----------------------------
+
+The sections below cover the easiest approach to compatibility.
+
+You can try other options it if you need to. Be aware that doing so
+requires grappling with the factors affecting audio compatibility:
+
+#. The formats which can be loaded
+#. The features supported by playback
+#. The hardware, software, and settings limitations on the first two
+#. The interactions of project requirements with all of the above
+
+.. _pgsound-reliability:
+
+The Most Reliable Formats & Features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For most users, the best formats are the following ones:
+
+* Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <pgsound-effects>`
+* Use MP3 files for :ref:`long background audio like music <pgsound-streaming>`
+
+As long as a user has working audio hardware and drivers, the following
+basic features should work:
+
+#. :ref:`pgsound-loading` sound effects from Wave files
+#. :ref:`pgsound-playing` and :ref:`pgsound-stopping`
+#. :ref:`Adjusting playback volume and speed of playback <pgsound-playback-details>`
+
+Advanced functionality or subsets of it may not, especially
+`positional audio`_. To learn more, see the rest of this page and the
+links below:
+
+* :ref:`pgsound-compat-playback`
+* :ref:`pgsound-converting`
+* `pyglet's supported media types`_
+
+.. _pgsound-reliability-best-effects:
+
+Why 16-bit PCM Wave for Effects?
+""""""""""""""""""""""""""""""""
+Loading 16-bit PCM ``.wav`` ensures all users can load sound effects because:
+
+#. pyglet :ref:`has built-in in support for this format <pgsound-compat-loading>`
+#. :ref:`Some platforms can only play 16-bit audio <pgsound-compat-playback>`
+
+There is another requirement if you want to use  `positional audio`_:
+the files must be mono (single-channel) instead of stereo.
+
+Accepting these limitations is usually worth the compatibility benefits,
+especially as a beginner.
+
+.. _pgsound-reliability-best-stream:
+
+Why MP3 For Music and Ambiance?
+"""""""""""""""""""""""""""""""
+#. Nearly every system which can run arcade has a supported MP3 decoder.
+#. MP3 files are much smaller than Wave equivalents per minute of audio,
+   which has multiple benefits.
+
+See the following to learn more:
+
+* :ref:`pgsound-compat-loading`
+* `Pyglet's Supported Media Types <pyglet's supported media types_>`_
+
+.. _pgsound-converting:
+
+Converting Audio Formats
+""""""""""""""""""""""""
+Don't worry if you have a great sound in a different format.
+
+There are multiple free, reliable, open-source tools you can use to
+convert existing audio. Two of the most famous are summarized below.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name & Link for Tool
+     - Difficulty
+     - Summary
+
+   * - `Audacity`_
+     - Beginner [#linuxlame]_
+     - A free GUI application for editing sound
+
+   * - `FFmpeg`_'s command line tool
+     - Advanced
+     - Powerful media conversion tool included with the library
+
+These should be able to handle converting from stereo to mono
+for users who want to use `positional audio`_ . Consult their
+documentation to learn how.
+
+.. [#linuxlame]
+   Linux users may need to `install the LAME MP3 encoder separately
+   to export MP3 files <https://manual.audacityteam.org/man/faq_installing_the_lame_mp3_encoder.html>`_.
+
+.. _pgsound-compat-loading:
+
+Loading In-Depth
+^^^^^^^^^^^^^^^^
+
+There are 3 ways arcade can read audio data through pyglet:
+
+#. The built-in pyglet ``.wav`` loading features
+#. Platform-specific components or nearly-universal libraries
+#. Supported cross-platform media libraries, such as PyOgg or `FFmpeg`_
+
+Everyday Usage
+""""""""""""""
+In practice, Wave is universally supported and MP3 nearly so. [#mp3linux]_
+
+Limiting yourself to these formats is usually worth the increased
+compatibility doing so provides. Benefits include:
+
+#. Smaller download & install sizes due to having fewer dependencies
+#. Avoiding binary dependency issues common with PyInstaller and Nuitka
+#. Faster install and loading, especially when using MP3s on slow drives
+
+These benefits become even more important during game jams.
+
+.. [#mp3linux]
+   The only time MP3 will be absent is on unusual Linux configurations.
+   See `pyglet's supported media types`_ to learn more.
+
+.. _pgsound-compat-playback:
+
+Backends Determine Playback Features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _pyglet_openal: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#openal
+
+As with formats, you can maximize compatibility by only using the lowest
+common denominators among features. The most restrictive backends are:
+
+* Mac's only backend, an OpenAL version limited to 16-bit audio
+* PulseAudio on Linux, which lacks support for `positional audio
+  <positional audio_>`_ [#openallinux]_
+
+Other differences between backends are less drastic. Usually, they will
+be things like the specific positional features supported and the maximum
+number of simultaneous sounds.
+
+.. [#openallinux]
+   On Linux, OpenAL is often `installed or available <pyglet_openal_>`_
+   without Mac's limitations.
+
+See the following to learn more:
+
+* `pyglet's audio driver overview <pyglet_audio_drivers_>`_
+* :ref:`pgsound-other-audio-libs`
+
+Choosing the Audio Backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _python_env_vars: https://www.twilio.com/blog/environment-variables-python
+
+By default, arcade will try pyglet audio back-ends in the following
+order until it finds one which loads:
+
+#. ``"openal"``
+#. ``"xaudio2"``
+#. ``"directsound"``
+#. ``"pulse"``
+#. ``"silent"``
+
+You can override through the ``ARCADE_SOUND_BACKENDS`` `environment
+variable <python_env_vars>`_. The following rules apply to its value:
+
+#. It must be a comma-separated string
+#. Each name must be an audio back-ends supported by pyglet
+#. Spaces do not matter and will be ignored
+
+For example, you could need to test OpenAL on a specific system. This
+example first tries OpenAL, then gives up instead using fallbacks.
+
+.. code-block:: shell
+
+   ARCADE_SOUND_BACKENDS="openal,silent" python mygame.py
+
+Please see the following to learn more:
+
+* `pyglet's audio driver documentation <pyglet_audio_drivers_>`_
+* `Working with Environment Variables in Python <python_env_vars_>`_
+
+.. _pgsound-other-audio-libs:
+
+Other Sound Libraries
+---------------------
+
+Advanced users may have reasons to use other libraries to handle sound.
+
+The most obvious choice is pyglet itself:
+
+* It's guaranteed to work wherever arcade's sound support does
+* You are already familiar with from using
+  :py:class:`pyglet.media.player.Player` to control playback
+* It offers more control over media loading and playback than arcade
+
+If you are interested in porting to using pyglet directly, note that the
+:py:attr:`arcade.Sound.source` attribute is exposed. This means you can
+cleanly interface with pyglet code if you are porting code or want to use
+arcade's built-in resource path resolution.
+
+To learn more, consult the `pyglet media guide`_.
+
+External Libraries
+^^^^^^^^^^^^^^^^^^
+
+Some users have reported success with using `PyGame CE`_ or `SDL2`_ to
+handle sound. Both these and other libraries may work for you as well.
+You will need to experiment since this isn't officially supported.

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -173,11 +173,9 @@ See the following to learn more:
 Stopping Sounds
 ^^^^^^^^^^^^^^^
 
+Arcade's helper functions are the easiest way to stop playback. To use them:
 
-Arcade's helper functions are the easiest way to stop playback. To use them, do
-the following:
-
-#. Choose one of the following:
+#. Do one of the following:
 
    * Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to
      :py:func:`arcade.stop_sound`:

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -148,20 +148,20 @@ This is a very important distinction:
 * Arcade uses pyglet's :py:class:`~pyglet.media.player.Player` to
   represent a specific playback of audio data
 
-Imagine you have two characters in a game which both play the same
-:py:class:`~arcade.Sound` when moving. Since they are separate
+Imagine you have two non-player characters in a game which both play the
+same :py:class:`~arcade.Sound` when moving. Since they are separate
 characters in the world, they have separate playbacks of that sound.
-This means each stores its own :py:class:`~pyglet.media.player.Player`.
 
-The separate pyglet players allow controlling their playbacks of the
-movement sound separately. For example, one character may get close
-enough to the user's character to talk, attack, or perform some other
-action. You would use that character's specific pyglet
+This means each stores its own :py:class:`~pyglet.media.player.Player`
+object to allow controlling its specific playback of the movement sound.
+For example, one character may get close enough to the user's character
+to talk, attack, or perform some other action. When a character stops
+moving, you would use that character's specific pyglet
 :py:class:`~pyglet.media.player.Player` to stop the corresponding
 playback of the movement sound.
 
 This is crucial for games which hide parts of the world from view.
-An enemy with no way for the user to know it's there is the most
+Enemies without a way for users to detect their presence is the most
 common version of the unknown danger mentioned in :ref:`sound-why-important`.
 
 See the following to learn more:

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -148,10 +148,10 @@ This allows controlling their movement sound playbacks separately. For
 example, one character may get close enough to the player to attack or
 perform some other action.
 
-Although this may seem unimportant, it is crucial if for games which
-hide parts of the world from view. An enemy with no way to know it's
-there is the most common version of the unknown danger example listed
-in :ref:`sound-why-important`.
+Although this may seem unimportant, it is crucial for games which hide
+parts of the world from view. An enemy with no way to know it's there
+is the most common version of the unknown danger example listed in
+:ref:`sound-why-important`.
 
 See the following to learn more:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -180,22 +180,27 @@ the following:
 #. Choose one of the following:
 
    * Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to
-     :py:func:`arcade.stop_sound`::
+     :py:func:`arcade.stop_sound`:
 
-      arcade.stop_sound(self.current_playback)
+     .. code-block:: python
+
+        arcade.stop_sound(self.current_playback)
 
    * Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to the
-     sound's :py:meth:`~arcade.Sound.stop` method::
+     sound's :py:meth:`~arcade.Sound.stop` method:
 
-      self.hurt_sound.stop(self.current_playback)
+     .. code-block:: python
 
+        self.hurt_sound.stop(self.current_playback)
 
-#. Clear any references to the player to allow its memory to be freed::
+#. Clear any references to the player to allow its memory to be freed:
 
-    # For each object, Python tracks how many other objects use it. If
-    # nothing else uses an object, it will be marked as garbage which
-    # Python can delete automatically to free memory.
-    self.current_playback = None
+   .. code-block:: python
+
+      # For each object, Python tracks how many other objects use it. If
+      # nothing else uses an object, it will be marked as garbage which
+      # Python can delete automatically to free memory.
+      self.current_playback = None
 
 See the following to learn more:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -255,7 +255,7 @@ This is because disk access is one of the slowest things a computer can
 do. Avoiding it during gameplay is important if your gameplay needs to
 be fast and smooth.
 
-Any of the following suggest a sound should be loaded a a static effect:
+Any of the following suggest a sound should be loaded as a static effect:
 
 * You need to start playback quickly in response to gameplay.
 * 2 or more "copies" of the sound can be playing at the same time.

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -545,7 +545,7 @@ Most versions of these tools should handle the following common tasks:
   <sound-other-libraries-pyglet-positional>`.
 
 To integrate FFmpeg with Arcade as a decoder, you must use FFmpeg
-version 4 or 5. See :ref:`sound-compat-loading` to learn more.
+version 4.X, 5.X, or 6.X. See :ref:`sound-compat-loading` to learn more.
 
 .. [#linuxlame]
    Linux users may need to `install the LAME MP3 encoder separately
@@ -564,9 +564,9 @@ There are 3 ways arcade can read audio data through pyglet:
 #. Platform-specific components or nearly-universal libraries
 #. Supported cross-platform media libraries, such as PyOgg or `FFmpeg`_
 
-.. warning:: To load through FFmpeg, you must install FFmpeg 4.X, 5.X, or 6.X!
-
-             See `pyglet's notes on installing FFmpeg <pyglet_ffmpeg_install_>`_.
+To load through FFmpeg, you must install FFmpeg 4.X, 5.X, or 6.X. This
+is a requirement imposed by pyglet. See `pyglet's notes on installing
+FFmpeg <pyglet_ffmpeg_install_>`_ to learn more.
 
 Everyday Usage
 """"""""""""""

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -339,8 +339,8 @@ Stopping via the Player Object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Arcade's functions for :ref:`sound-basics-stopping` call methods on the
-passed pyglet :py:class:`~pyglet.media.player.Player`. This section
-covers how as an introduction to using the player object directly.
+passed pyglet :py:class:`~pyglet.media.player.Player`. You can use the
+same methods for finer control, such as pausing and resuming playback.
 
 Pausing
 """""""

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -12,7 +12,7 @@
 .. _pyglet's supported media types: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#supported-media-types
 .. _pyglet_audio_drivers: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#choosing-the-audio-driver
 
-.. _pgsound:
+.. _sound:
 
 Sound
 =====
@@ -108,7 +108,7 @@ See the following to learn more:
 #. :ref:`Platformer Part 7 - Loading Sounds <platformer_part_seven_loading_sounds>`
 #. :ref:`resources`
 #. :py:mod:`pathlib`
-#. :ref:`pgsound-static-vs-streaming`
+#. :ref:`sound-static-vs-streaming`
 
 .. _sound-basics-playing:
 
@@ -194,7 +194,7 @@ See the following to learn more:
 * :ref:`sound-advanced-playback`
 * `Python's contributor guide article on garbage collection <garbage collection_>`_
 
-.. _pgsound-static-vs-streaming:
+.. _sound-static-vs-streaming:
 
 Streaming vs Static Audio
 -------------------------
@@ -243,7 +243,7 @@ The following subheadings will explain each option in detail.
 .. [#staticsourcefoot]
    See the :py:class:`pyglet.media.StaticSource` class used by arcade.
 
-.. _pgsound-effects:
+.. _sound-effects:
 
 Sound Effects are Fast
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ Any of the following suggest a sound should be loaded a a static effect:
 * You need to automatically loop playback.
 * The file is a short clip.
 
-.. _pgsound-streaming:
+.. _sound-streaming:
 
 Streaming Can Save Memory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -426,8 +426,8 @@ The Most Reliable Formats & Features
 
 For most users, the best formats are the following ones:
 
-* Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <pgsound-effects>`
-* Use MP3 files for :ref:`long background audio like music <pgsound-streaming>`
+* Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <sound-effects>`
+* Use MP3 files for :ref:`long background audio like music <sound-streaming>`
 
 As long as a user has working audio hardware and drivers, the following
 basic features should work:

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -119,7 +119,7 @@ There are two easy ways to play a :py:class:`~arcade.Sound` object.
 
 One is to call :py:meth:`Sound.play <arcade.Sound.play>` directly::
 
-    hurt_player = hurt_sound.play()
+    self.hurt_player = hurt_sound.play()
 
 The other is to pass a :py:class:`~arcade.Sound` instance as the first
 argument of :py:func:`arcade.play_sound`::
@@ -165,23 +165,22 @@ See the following to learn more:
 Stopping Sounds
 ^^^^^^^^^^^^^^^
 
-.. _garbage collection: https://devguide.python.org/internals/garbage-collector/
 
-Arcade's helper functions are the easiest way to stop playback:
+Arcade's helper functions are the easiest way to stop playback. To use them, do
+the following:
 
-* The :py:func:`arcade.stop_sound` function
-* The :py:meth:`Sound.stop <arcade.Sound.stop>` method of the
-  sound data being played
+#. Choose one of the following:
 
-To use them, do the following:
+   * Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to
+     :py:func:`arcade.stop_sound`::
 
-#. Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to one of the helpers::
+      arcade.stop_sound(self.current_playback)
 
-    # These are equivalent, but remember:
-    # 1. You only need to use one of them
-    # 2. You must pass the Player object, not the Sound object
-    arcade.stop_sound(self.current_playback)
-    Sound.stop(self.current_playback)
+   * Pass the stored pyglet :py:class:`~pyglet.media.player.Player` to the
+     sound's :py:meth:`~arcade.Sound.stop` method::
+
+      self.hurt_sound.stop(self.current_playback)
+
 
 #. Clear any references to the player to allow its memory to be freed::
 
@@ -194,7 +193,6 @@ See the following to learn more:
 
 * :ref:`sound-compat-easy`
 * :ref:`sound-advanced-playback`
-* `Python's contributor guide article on garbage collection <garbage collection_>`_
 
 .. _sound-loading-modes:
 
@@ -354,6 +352,9 @@ There is no stop method. Instead, call the :py:meth:`Player.pause()
 
 Stopping Permanently
 """"""""""""""""""""
+
+.. _garbage collection: https://devguide.python.org/internals/garbage-collector/
+
 After you've paused a player, you can stop playback permanently:
 
 #. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method::

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -293,7 +293,7 @@ Both save memory by keeping only part of a file into memory at any given
 time. Even on the slowest recent hardware, this usually works if:
 
 * You only stream one media source at a time.
-* You don't try to closely synchronize it with anything else.
+* You don't need synchronize it closely with anything else.
 
 Use Streaming Sparingly
 """""""""""""""""""""""

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -519,17 +519,17 @@ common denominators among features. The most restrictive backends are:
 * Mac's only backend, an OpenAL version limited to 16-bit audio
 * PulseAudio on Linux, which has multiple limitations:
 
-  * It lacks support for `positional audio <positional audio_>`_. [#openallinux]_
+  * It lacks support for `positional audio <positional audio_>`_.
   * It can `crash under certain circumstances <pyglet_pulseaudiobug_>`_
-    where OpenAL will not.
+    where other backends will not.
+
+On Linux, the best way to deal with the PulseAudio bug is to `install
+OpenAL <pyglet_openal_>`_. It will often already be installed as a
+dependency of other packages.
 
 Other differences between backends are less drastic. Usually, they will
 be things like the specific positional features supported and the maximum
 number of simultaneous sounds.
-
-.. [#openallinux]
-   On Linux, OpenAL is often `installed or available <pyglet_openal_>`_
-   without Mac's limitations.
 
 See the following to learn more:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -511,13 +511,17 @@ Backends Determine Playback Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _pyglet_openal: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#openal
+.. _pyglet_pulseaudiobug: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#the-bug
 
 As with formats, you can maximize compatibility by only using the lowest
 common denominators among features. The most restrictive backends are:
 
 * Mac's only backend, an OpenAL version limited to 16-bit audio
-* PulseAudio on Linux, which lacks support for `positional audio
-  <positional audio_>`_ [#openallinux]_
+* PulseAudio on Linux, which has multiple limitations:
+
+  * It lacks support for `positional audio <positional audio_>`_. [#openallinux]_
+  * It can `crash under certain circumstances <pyglet_pulseaudiobug_>`_
+    where OpenAL will not.
 
 Other differences between backends are less drastic. Usually, they will
 be things like the specific positional features supported and the maximum

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -145,9 +145,11 @@ Imagine you have two characters in a game which both play the same
 characters in the world with separate playbacks of the sound,
 each stores its own :py:class:`~pyglet.media.player.Player`.
 
-This allows controlling their movement sound playbacks separately. For
-example, one character may get close enough to the player to attack or
-perform some other action.
+This allows controlling their playbacks of the movement sound
+separately. For example, one character may get close enough to the
+user's character to talk, attack, attack perform some other action.
+You would use that character's pyglet player to stop the movement
+sound's playback.
 
 Although this may seem unimportant, it is crucial for games which hide
 parts of the world from view. An enemy with no way to know it's there

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -538,10 +538,14 @@ convert existing audio. Two of the most famous are summarized below.
      - Advanced
      - Powerful media conversion tool included with the library
 
-They should be able to handle converting from stereo to mono
-for any users who want to use :ref:`positional audio
-<sound-other-libraries-pyglet-positional>`. Consult the documentation
-for the utilities above to learn how.
+Most versions of these tools should handle the following common tasks:
+
+* Converting audio files from one encoding format to another
+* Converting from stereo to mono for use with :ref:`positional audio
+  <sound-other-libraries-pyglet-positional>`.
+
+To integrate FFmpeg with Arcade as a decoder, you must use FFmpeg
+version 4 or 5. See :ref:`sound-compat-loading` to learn more.
 
 .. [#linuxlame]
    Linux users may need to `install the LAME MP3 encoder separately
@@ -552,11 +556,18 @@ for the utilities above to learn how.
 Loading In-Depth
 ^^^^^^^^^^^^^^^^
 
+.. _pyglet_ffmpeg_install: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#ffmpeg-installation
+
 There are 3 ways arcade can read audio data through pyglet:
 
 #. The built-in pyglet ``.wav`` loading features
 #. Platform-specific components or nearly-universal libraries
 #. Supported cross-platform media libraries, such as PyOgg or `FFmpeg`_
+
+.. warning:: To load through FFmpeg, you must use version 4 or 5!
+
+             This is a requirement imposed by pyglet. See `pyglet's
+             notes on installing FFmpeg <pyglet_ffmpeg_install_>`_.
 
 Everyday Usage
 """"""""""""""

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -291,18 +291,22 @@ If you're unsure, avoid streaming unless you can say yes to all of the
 following:
 
 #. The :py:class:`~arcade.Sound` will have at most one playback at a time.
-   [#streamingsource]_
 
 #. The file is long enough to make it worth it.
 
 #. Seeking (skipping to different parts) will be infrequent.
 
-   * Ideally, you will never seek or restart playback suddenly
-   * If you do skip, the jumps will ideally be close enough to
+   * Ideally, you will never seek or restart playback suddenly.
+   * If you do seek, the jumps will ideally be close enough to
      land in the same or next chunk.
 
-.. [#streamingsource]
-   This is a requirement of the underlying :py:class:`pyglet.media.StreamingSource`.
+See the following to learn more:
+
+* :ref:`sound-advanced-playback-change-aspects-ongoing`
+* The :py:class:`pyglet.media.StreamingSource` class used to implement
+  streaming
+
+.. _sound-loading-modes-streaming-freezes:
 
 Streaming Can Cause Freezes
 """""""""""""""""""""""""""
@@ -345,46 +349,70 @@ instead of the :ref:`stopping helpers <sound-basics-stopping>` as follows:
 #. Make sure all references to the player are discarded to allow
    `garbage collection`_.
 
-Changing Playback Parameters
+Changing Aspects of Playback
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Ongoing Playback
-""""""""""""""""
-The properties and methods of an ongoing playback's
-:py:class:`pyglet.media.player.Player` allow changing aspects of it.
+There are more ways to alter playback than stopping. Some are more
+qualitative. Many of them can be applied to both ongoing and new sound
+sound data playbacks, but the way to do so differs.
+
+.. _sound-advanced-playback-change-aspects-ongoing:
+
+Change an Ongoing Playback via its Player Object
+""""""""""""""""""""""""""""""""""""""""""""""""
+In addition to the pyglet :py:class:`~pyglet.media.player.Player`'s
+:py:meth:`~pyglet.media.player.Player.pause` method, it also has properties
+and methods for changing aspects of the ongoing playback it represents.
 
 The table below summarizes the most commonly used ones. Superscripts
-link explanations of inconsistencies, such as differences between names
-of properties and their equivalent keyword arguments in arcade functions.
+link footnotes about potential issues, such as the differences between
+the names of properties and their equivalent keyword arguments in arcade
+functions.
 
 .. list-table::
    :header-rows: 1
 
-   * - :py:class:`~pyglet.media.player.Player` Property
+   * - :py:class:`~pyglet.media.player.Player` Member
      - Type
      - Default
      - Purpose
 
+   * - :py:meth:`~pyglet.media.player.Player.play`
+     - method
+     - N/A
+     - Resume playback.
+
+   * - :py:meth:`~pyglet.media.player.Player.seek`
+     - method
+     - N/A
+     - .. warning:: :ref:`Using this option with streaming can cause freezes!
+        <sound-loading-modes-streaming-freezes>`
+
+       Skip to the passed :py:class:`float` timestamp measured as seconds
+       from the audio's start.
+
    * - :py:attr:`~pyglet.media.player.Player.volume`
-     - :py:class:`float`
+     - :py:class:`float` property
      - ``1.0``
-     - The scaling factor for the original sound data's volume. Must be
-       between ``0.0`` (silent) and ``1.0`` (full volume).
+     - The scaling factor to apply to the original audio's volume. Must
+       be between ``0.0`` (silent) and ``1.0`` (full volume).
 
    * - :py:attr:`~pyglet.media.player.Player.loop`
        [#inconsistencyloop]_
-     - :py:class:`bool`
+     - :py:class:`bool` property
      - ``False``
      - Whether to restart playback automatically after finishing. [#streamingnoloop]_
 
    * - :py:attr:`~pyglet.media.player.Player.pitch` [#inconsistencyspeed]_
-     - :py:class:`float`
+     - :py:class:`float` property
      - ``1.0``
-     - How fast to play back the sound; also affects pitch.
+     - How fast to play the sound data; also affects pitch.
 
 .. [#inconsistencyloop]
-   :py:func:`arcade.play_sound` uses ``looping`` as a keyword instead of
-   ``loop``; see `the related GitHub issue <inconsistency_loop_issue_>`_.
+   :py:func:`arcade.play_sound` uses ``looping`` instead. See:
+
+   *  :ref:`sound-advanced-playback-change-aspects-new`
+   * `The related GitHub issue <inconsistency_loop_issue_>`_.
 
 .. [#streamingnoloop]
    Looping is unavailable when ``streaming=True``; see `pyglet's guide to
@@ -393,20 +421,23 @@ of properties and their equivalent keyword arguments in arcade functions.
 .. [#inconsistencyspeed]
    Arcade's equivalent keyword for :ref:`sound-basics-playing` is ``speed``
 
-These are only a few of :py:class:`~pyglet.media.player.Player`'s many
-features. To learn more, consult its documentation and the
+These are only a few of the :py:class:`~pyglet.media.player.Player`'s
+many features. To learn more, consult its documentation and the
 `Controlling playback <pyglet_controlling_playback_>`_ section of
 pyglet's media guide.
 
-Changing Parameters from the Start
-""""""""""""""""""""""""""""""""""
-You can alter playback when :ref:`sound-basics-playing` through `keyword
-arguments <keyword argument>`_ with the same or similar names as the
-properties mentioned above. See the following to learn more:
+.. _sound-advanced-playback-change-aspects-new:
+
+Configure New Playbacks via Keyword Arguments
+"""""""""""""""""""""""""""""""""""""""""""""
+Arcade's functions for :ref:`sound-basics-playing` also accept `keyword
+arguments <keyword argument>`_ for configuring playback. The names of
+these keywords are similar or identical to the properties mentioned
+above. See the following to learn more:
 
 * :ref:`sound_speed_demo`
 * :py:func:`arcade.play_sound`
-* :py:meth:`Sound.play <arcade.Sound.play>`
+* :py:meth:`Sound.play() <arcade.Sound.play>`
 
 .. _sound-compat:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -121,12 +121,16 @@ Playing Sounds
 
 There are two easy ways to play a :py:class:`~arcade.Sound` object.
 
-One is to call :py:meth:`Sound.play <arcade.Sound.play>` directly::
+One is to call :py:meth:`Sound.play <arcade.Sound.play>` directly:
+
+.. code-block:: python
 
     self.hurt_player = hurt_sound.play()
 
 The other is to pass a :py:class:`~arcade.Sound` instance as the first
-argument of :py:func:`arcade.play_sound`::
+argument of :py:func:`arcade.play_sound`:
+
+.. code-block:: python
 
     # Important: this *must* be a Sound instance, not a path or string!
     self.hurt_player = arcade.play_sound(hurt_sound)

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -22,15 +22,15 @@ This page will help you get started by covering the essentials of sound.
 In addition each section's concepts, there may also be links to example
 code and documentation.
 
-#. :ref:`pgsound-why-important`
-#. :ref:`pgsound-tech-overview`
+#. :ref:`sound-why-important`
+#. :ref:`sound-basics`
 
-   * :ref:`pgsound-loading`
-   * :ref:`pgsound-playing`
-   * :ref:`pgsound-stopping`
+   * :ref:`sound-basics-loading`
+   * :ref:`sound-basics-playing`
+   * :ref:`sound-basics-stopping`
 
-#. :ref:`pgsound-compat`
-#. :ref:`pgsound-other-audio-libs` (for advanced users)
+#. :ref:`sound-compat`
+#. :ref:`sound-other-libraries` (for advanced users)
 
 .. rubric:: I'm Impatient!
 
@@ -44,7 +44,7 @@ Users who want to skip to example code should consult the following:
    #. :ref:`platformer_part_seven_loading_sounds`
    #. :ref:`platformer_part_seven_playing_sounds`
 
-.. _pgsound-why-important:
+.. _sound-why-important:
 
 Why Is Sound Important?
 -----------------------
@@ -67,12 +67,12 @@ You can use sound to prevent moments like these. In each example above,
 the right audio can provide the information players need for the game
 to feel fair.
 
-.. _pgsound-tech-overview:
+.. _sound-basics:
 
 Sound Basics
 ------------
 
-.. _pgsound-loading:
+.. _sound-basics-loading:
 
 Loading Sounds
 ^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ See the following to learn more:
 #. :py:mod:`pathlib`
 #. :ref:`pgsound-static-vs-streaming`
 
-.. _pgsound-playing:
+.. _sound-basics-playing:
 
 Playing Sounds
 ^^^^^^^^^^^^^^
@@ -150,14 +150,14 @@ perform some other action.
 Although this may seem unimportant, it is crucial if for games which
 hide parts of the world from view. An enemy with no way to know it's
 there is the most common version of an "unknown danger" as described in
-:ref:`pgsound-why-important`.
+:ref:`sound-why-important`.
 
 See the following to learn more:
 
 #. :ref:`Platformer Tutorial - Part 7 - Collision Detection <platformer_part_seven_playing_sounds>`
 #. :ref:`sound_demo`
 
-.. _pgsound-stopping:
+.. _sound-basics-stopping:
 
 Stopping Sounds
 ^^^^^^^^^^^^^^^
@@ -189,8 +189,8 @@ To use them, do the following:
 
 See the following to learn more:
 
-* :ref:`pgsound-reliability`
-* :ref:`pgsound-playback-details`
+* :ref:`sound-compat-easy`
+* :ref:`sound-advanced-playback`
 * `Python's contributor guide article on garbage collection <garbage collection_>`_
 
 .. _pgsound-static-vs-streaming:
@@ -225,7 +225,7 @@ This is the best option for most game sound effects. It's called
 
 The alternative is streaming. Enable it by passing ``True`` through the
 ``streaming`` `keyword argument`_  when you :ref:`load a sound
-<pgsound-loading>`::
+<sound-basics-loading>`::
 
     # Both loading approaches accept the streaming keyword.
     classical_music_track = arcade.load_sound(":resources:music/1918.mp3", streaming=True)
@@ -237,7 +237,7 @@ For an interactive example, see the :ref:`music_control_demo`.
 The following subheadings will explain each option in detail.
 
 .. [#meaningbestformatheader]
-   See :ref:`pgsound-reliability` to learn more.
+   See :ref:`sound-compat-easy` to learn more.
 
 .. [#staticsourcefoot]
    See the :py:class:`pyglet.media.StaticSource` class used by arcade.
@@ -313,7 +313,7 @@ downgrade quality, your game will be at risk of stuttering or freezing.
 
 The best way to handle this is to only use streaming when necessary.
 
-.. _pgsound-playback-details:
+.. _sound-advanced-playback:
 
 Advanced Playback Control
 -------------------------
@@ -326,13 +326,13 @@ You can alter the playback of a :py:class:`arcade.Sound`'s data by:
 * Using properties and methods of a :py:class:`~pyglet.media.player.Player`
   any time before playback has finished
 * Passing keyword arguments with the same (or similar) names as the
-  Player's properties when :ref:`playing the sound <pgsound-playing>`.
+  Player's properties when :ref:`playing the sound <sound-basics-playing>`.
 
 Stopping via the Player Object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can stop playback through its pyglet :py:meth:`pyglet.media.player.Player`
-instead of the :ref:`stopping helpers <pgsound-stopping>` as follows:
+instead of the :ref:`stopping helpers <sound-basics-stopping>` as follows:
 
 #. Call the player's :py:meth:`~pyglet.media.player.Player.pause`
    method.
@@ -387,7 +387,7 @@ of properties and their equivalent keyword arguments in arcade functions.
    controlling playback <pyglet_controlling_playback_>`_.
 
 .. [#inconsistencyspeed]
-   Arcade's equivalent keyword for :ref:`pgsound-playing` is ``speed``
+   Arcade's equivalent keyword for :ref:`sound-basics-playing` is ``speed``
 
 These are only a few of :py:class:`~pyglet.media.player.Player`'s many
 features. Consult its documentation and the `relevant section of the pyglet
@@ -395,7 +395,7 @@ media guide <pyglet_controlling_playback_>`_ to learn more.
 
 Changing Parameters from the Start
 """"""""""""""""""""""""""""""""""
-You can alter playback when :ref:`pgsound-playing` through `keyword
+You can alter playback when :ref:`sound-basics-playing` through `keyword
 arguments <keyword argument>`_ with the same or similar names as the
 properties mentioned above. See the following to learn more:
 
@@ -403,7 +403,7 @@ properties mentioned above. See the following to learn more:
 * :py:func:`arcade.play_sound`
 * :py:meth:`Sound.play <arcade.Sound.play>`
 
-.. _pgsound-compat:
+.. _sound-compat:
 
 Cross-Platform Compatibility
 ----------------------------
@@ -418,7 +418,7 @@ requires grappling with the factors affecting audio compatibility:
 #. The hardware, software, and settings limitations on the first two
 #. The interactions of project requirements with all of the above
 
-.. _pgsound-reliability:
+.. _sound-compat-easy:
 
 The Most Reliable Formats & Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -431,26 +431,26 @@ For most users, the best formats are the following ones:
 As long as a user has working audio hardware and drivers, the following
 basic features should work:
 
-#. :ref:`pgsound-loading` sound effects from Wave files
-#. :ref:`pgsound-playing` and :ref:`pgsound-stopping`
-#. :ref:`Adjusting playback volume and speed of playback <pgsound-playback-details>`
+#. :ref:`sound-basics-loading` sound effects from Wave files
+#. :ref:`sound-basics-playing` and :ref:`sound-basics-stopping`
+#. :ref:`Adjusting playback volume and speed of playback <sound-advanced-playback>`
 
 Advanced functionality or subsets of it may not, especially
 `positional audio`_. To learn more, see the rest of this page and the
 links below:
 
-* :ref:`pgsound-compat-playback`
-* :ref:`pgsound-converting`
+* :ref:`sound-compat-playback`
+* :ref:`sound-compat-easy-converting`
 * `pyglet's supported media types`_
 
-.. _pgsound-reliability-best-effects:
+.. _sound-compat-easy-best-effects:
 
 Why 16-bit PCM Wave for Effects?
 """"""""""""""""""""""""""""""""
 Loading 16-bit PCM ``.wav`` ensures all users can load sound effects because:
 
-#. pyglet :ref:`has built-in in support for this format <pgsound-compat-loading>`
-#. :ref:`Some platforms can only play 16-bit audio <pgsound-compat-playback>`
+#. pyglet :ref:`has built-in in support for this format <sound-compat-loading>`
+#. :ref:`Some platforms can only play 16-bit audio <sound-compat-playback>`
 
 There is another requirement if you want to use  `positional audio`_:
 the files must be mono (single-channel) instead of stereo.
@@ -458,7 +458,7 @@ the files must be mono (single-channel) instead of stereo.
 Accepting these limitations is usually worth the compatibility benefits,
 especially as a beginner.
 
-.. _pgsound-reliability-best-stream:
+.. _sound-compat-easy-best-stream:
 
 Why MP3 For Music and Ambiance?
 """""""""""""""""""""""""""""""
@@ -468,10 +468,10 @@ Why MP3 For Music and Ambiance?
 
 See the following to learn more:
 
-* :ref:`pgsound-compat-loading`
+* :ref:`sound-compat-loading`
 * `Pyglet's Supported Media Types <pyglet's supported media types_>`_
 
-.. _pgsound-converting:
+.. _sound-compat-easy-converting:
 
 Converting Audio Formats
 """"""""""""""""""""""""
@@ -503,7 +503,7 @@ documentation to learn how.
    Linux users may need to `install the LAME MP3 encoder separately
    to export MP3 files <https://manual.audacityteam.org/man/faq_installing_the_lame_mp3_encoder.html>`_.
 
-.. _pgsound-compat-loading:
+.. _sound-compat-loading:
 
 Loading In-Depth
 ^^^^^^^^^^^^^^^^
@@ -531,7 +531,7 @@ These benefits become even more important during game jams.
    The only time MP3 will be absent is on unusual Linux configurations.
    See `pyglet's supported media types`_ to learn more.
 
-.. _pgsound-compat-playback:
+.. _sound-compat-playback:
 
 Backends Determine Playback Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -560,7 +560,7 @@ number of simultaneous sounds.
 See the following to learn more:
 
 * `pyglet's audio driver overview <pyglet_audio_drivers_>`_
-* :ref:`pgsound-other-audio-libs`
+* :ref:`sound-other-libraries`
 
 Choosing the Audio Backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -595,7 +595,7 @@ Please see the following to learn more:
 * `pyglet's audio driver documentation <pyglet_audio_drivers_>`_
 * `Working with Environment Variables in Python <python_env_vars_>`_
 
-.. _pgsound-other-audio-libs:
+.. _sound-other-libraries:
 
 Other Sound Libraries
 ---------------------

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -394,8 +394,9 @@ of properties and their equivalent keyword arguments in arcade functions.
    Arcade's equivalent keyword for :ref:`sound-basics-playing` is ``speed``
 
 These are only a few of :py:class:`~pyglet.media.player.Player`'s many
-features. Consult its documentation and the `relevant section of the pyglet
-media guide <pyglet_controlling_playback_>`_ to learn more.
+features. To learn more, consult its documentation and the
+`Controlling playback <pyglet_controlling_playback_>`_ section of
+pyglet's media guide.
 
 Changing Parameters from the Start
 """"""""""""""""""""""""""""""""""
@@ -440,12 +441,8 @@ basic features should work:
 #. :ref:`Adjusting playback volume and speed of playback <sound-advanced-playback>`
 
 Advanced functionality or subsets of it may not, especially
-`positional audio`_. To learn more, see the rest of this page and the
-links below:
-
-* :ref:`sound-compat-playback`
-* :ref:`sound-compat-easy-converting`
-* `pyglet's supported media types`_
+`positional audio`_. To learn more, see the rest of this page and
+`pyglet's supported media types`_.
 
 .. _sound-compat-easy-best-effects:
 
@@ -566,7 +563,7 @@ number of simultaneous sounds.
 
 See the following to learn more:
 
-* `pyglet's audio driver overview <pyglet_audio_drivers_>`_
+* `Pyglet's Audio Backends <pyglet_audio_drivers_>`_
 * :ref:`sound-other-libraries`
 
 Choosing the Audio Backend

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -265,9 +265,16 @@ in-game slowdowns.
 
 This is because disk access is one of the slowest things a computer can
 do. Avoiding it during gameplay is important if your gameplay needs to
-be fast and smooth. For music, consider :
+be fast and smooth.
 
-Any of the following suggest a sound should be loaded as a static effect:
+However, storing full decompressed albums of music in RAM should be
+avoided. Each decompressed minute of CD quality audio uses slightly
+more than 10 MB of RAM. This adds up quickly, so you should strongly
+consider :ref:`streaming <sound-loading-modes-streaming>` music from
+compressed files instead.
+
+Any of the following will suggest specific audio should be loaded
+as a static effect:
 
 * You need to start playback quickly in response to gameplay.
 * Two or more "copies" of the sound can be playing at the same time.

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -573,7 +573,7 @@ These benefits become even more important during game jams.
 
 .. [#mp3linux]
    The only time MP3 will be absent is on unusual Linux configurations.
-   See `pyglet's supported media types`_ to learn more.
+   See `pyglet's guide to supported media types`_ to learn more.
 
 .. _sound-compat-playback:
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -92,12 +92,14 @@ The easiest way to use :py:func:`arcade.load_sound`:
     # You can pass strings containing a built-in resource handle,
     hurt_sound = arcade.load_sound(":resources:sounds/hurt1.wav")
     # a pathlib.Path,
-    pathlib_sound = arcade.load_sound(Path("imaginary\windows\path\\file.wav"))
+    pathlib_sound = arcade.load_sound(Path("imaginary\\windows\\path\\file.wav"))
     # or an ordinary string describing a path.
     string_path_sound = arcade.load_sound("imaginary/mac/style/path.wav")
 
 If you prefer a more object-oriented style, you can create
-:py:class:`~arcade.Sound` instances directly::
+:py:class:`~arcade.Sound` instances directly:
+
+.. code-block:: python
 
     from arcade import Sound  # You can also use arcade.Sound directly
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -8,8 +8,7 @@
 .. _SDL2: https://www.libsdl.org/
 
 .. _pyglet media guide: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html
-.. _positional audio: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#positional-audio
-.. _pyglet's supported media types: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#supported-media-types
+.. _pyglet's guide to supported media types: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#supported-media-types
 .. _pyglet_audio_drivers: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#choosing-the-audio-driver
 
 .. _sound:
@@ -136,25 +135,25 @@ Sounds vs pyglet Players
 """"""""""""""""""""""""
 This is a very important distinction:
 
-* A :py:class:`~arcade.Sound` represents a source of playable data
-* A pyglet :py:class:`~pyglet.media.player.Player` represents a
-  specific playback of that data
+* An :py:class:`arcade.Sound` represents a source of audio data
+* Arcade uses pyglet's :py:class:`~pyglet.media.player.Player` to
+  represent a specific playback of audio data
 
 Imagine you have two characters in a game which both play the same
 :py:class:`~arcade.Sound` when moving. Since they are separate
-characters in the world with separate playbacks of the sound,
-each stores its own :py:class:`~pyglet.media.player.Player`.
+characters in the world, they have separate playbacks of that sound.
+This means each stores its own :py:class:`~pyglet.media.player.Player`.
 
-This allows controlling their playbacks of the movement sound
-separately. For example, one character may get close enough to the
-user's character to talk, attack, or perform some other action.
-You would use that character's pyglet :py:class:`~pyglet.media.player.Player`
-to stop the movement sound's playback.
+The separate pyglet players allow controlling their playbacks of the
+movement sound separately. For example, one character may get close
+enough to the user's character to talk, attack, or perform some other
+action. You would use that character's specific pyglet
+:py:class:`~pyglet.media.player.Player` to stop the corresponding
+playback of the movement sound.
 
-Although this may seem unimportant, it is crucial for games which hide
-parts of the world from view. An enemy with no way to know it's there
-is the most common version of the unknown danger example listed in
-:ref:`sound-why-important`.
+This is crucial for games which hide parts of the world from view.
+An enemy with no way for the user to know it's there is the most
+common version of the unknown danger mentioned in :ref:`sound-why-important`.
 
 See the following to learn more:
 
@@ -339,35 +338,45 @@ You can alter the playback of a :py:class:`arcade.Sound`'s data by:
 Stopping via the Player Object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can stop playback through its pyglet :py:class:`~pyglet.media.player.Player`
-instead of the :ref:`stopping helpers <sound-basics-stopping>` as follows:
+Arcade's functions for :ref:`sound-basics-stopping` call methods on the
+passed pyglet :py:class:`~pyglet.media.player.Player`. This section
+covers how as an introduction to using the player object directly.
 
-#. Call the player's :py:meth:`~pyglet.media.player.Player.pause`
-   method.
-#. Call the player's :py:meth:`~pyglet.media.player.Player.delete`
-   method.
-#. Make sure all references to the player are discarded to allow
-   `garbage collection`_.
+Pausing
+"""""""
+There is no stop method. Instead, the stopping helpers call the
+:py:meth:`Player.pause() <pyglet.media.player.Player.pause>` method.
+
+Stopping Permanently
+""""""""""""""""""""
+The helper functions are for stopping a playback without resuming. If
+you are sure you want don't want to resume, do the following after
+pausing the player:
+
+#. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method
+#. Make sure all references to the player are replaced with ``None`` to
+   allow `garbage collection`_.
 
 Changing Aspects of Playback
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are more ways to alter playback than stopping. Some are more
-qualitative. Many of them can be applied to both ongoing and new sound
-sound data playbacks, but the way to do so differs.
+qualitative. Many of them can be applied to both new and ongoing sound
+data playbacks, but in different ways.
 
 .. _sound-advanced-playback-change-aspects-ongoing:
 
-Change an Ongoing Playback via its Player Object
-""""""""""""""""""""""""""""""""""""""""""""""""
-In addition to the pyglet :py:class:`~pyglet.media.player.Player`'s
-:py:meth:`~pyglet.media.player.Player.pause` method, it also has properties
-and methods for changing aspects of the ongoing playback it represents.
+Change Ongoing Playbacks via Player Objects
+"""""""""""""""""""""""""""""""""""""""""""
+:py:meth:`Player.pause() <pyglet.media.player.Player.pause>` is one of
+many method and property members which change aspects of an ongoing
+playback. It's impossible to cover them all here, especially given the
+complexity of :ref:`positional audio <sound-other-libraries-pyglet-positional>`.
 
-The table below summarizes the most commonly used ones. Superscripts
-link footnotes about potential issues, such as the differences between
-the names of properties and their equivalent keyword arguments in arcade
-functions.
+Instead, the table below summarizes a few of the most useful members in
+the context of arcade. Superscripts link info about potential issues,
+such as name differences between properties and equivalent keyword
+arguments to arcade functions.
 
 .. list-table::
    :header-rows: 1
@@ -377,10 +386,15 @@ functions.
      - Default
      - Purpose
 
+   * - :py:meth:`~pyglet.media.player.Player.pause`
+     - method
+     - N/A
+     - Pause playback resumably.
+
    * - :py:meth:`~pyglet.media.player.Player.play`
      - method
      - N/A
-     - Resume playback.
+     - Resume paused playback.
 
    * - :py:meth:`~pyglet.media.player.Player.seek`
      - method
@@ -421,23 +435,19 @@ functions.
 .. [#inconsistencyspeed]
    Arcade's equivalent keyword for :ref:`sound-basics-playing` is ``speed``
 
-These are only a few of the :py:class:`~pyglet.media.player.Player`'s
-many features. To learn more, consult its documentation and the
-`Controlling playback <pyglet_controlling_playback_>`_ section of
-pyglet's media guide.
-
 .. _sound-advanced-playback-change-aspects-new:
 
 Configure New Playbacks via Keyword Arguments
 """""""""""""""""""""""""""""""""""""""""""""
-Arcade's functions for :ref:`sound-basics-playing` also accept `keyword
-arguments <keyword argument>`_ for configuring playback. The names of
-these keywords are similar or identical to the properties mentioned
-above. See the following to learn more:
+Arcade's helper functions for playing sound also accept keyword
+arguments for configuring playback. As mentioned above, the names of
+these keywords are similar or identical to those of properties on
+:py:class:`~pyglet.media.player.Player`. See the following to learn
+more:
 
-* :ref:`sound_speed_demo`
 * :py:func:`arcade.play_sound`
 * :py:meth:`Sound.play() <arcade.Sound.play>`
+* :ref:`sound_speed_demo`
 
 .. _sound-compat:
 
@@ -446,8 +456,8 @@ Cross-Platform Compatibility
 
 The sections below cover the easiest approach to compatibility.
 
-You can try other options it if you need to. Be aware that doing so
-requires grappling with the factors affecting audio compatibility:
+You can try other options if you need to. Be aware that doing so
+requires grappling with the many factors affecting audio compatibility:
 
 #. The formats which can be loaded
 #. The features supported by playback
@@ -459,7 +469,7 @@ requires grappling with the factors affecting audio compatibility:
 The Most Reliable Formats & Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For most users, the best formats are the following ones:
+For most users, the best approach to formats is:
 
 * Use 16-bit PCM Wave (``.wav``) files for :ref:`sound effects <sound-loading-modes-static>`
 * Use MP3 files for :ref:`long background audio like music <sound-loading-modes-streaming>`
@@ -472,20 +482,21 @@ basic features should work:
 #. :ref:`Adjusting playback volume and speed of playback <sound-advanced-playback>`
 
 Advanced functionality or subsets of it may not, especially
-`positional audio`_. To learn more, see the rest of this page and
-`pyglet's supported media types`_.
+:ref:`positional audio <sound-other-libraries-pyglet-positional>`.
+To learn more, see the rest of this page and `pyglet's guide to
+supported media types`_.
 
 .. _sound-compat-easy-best-effects:
 
 Why 16-bit PCM Wave for Effects?
 """"""""""""""""""""""""""""""""
-Loading 16-bit PCM ``.wav`` ensures all users can load sound effects because:
+Storing sound effects as 16-bit PCM ``.wav`` ensures all users can load them:
 
 #. pyglet :ref:`has built-in in support for this format <sound-compat-loading>`
 #. :ref:`Some platforms can only play 16-bit audio <sound-compat-playback>`
 
-There is another requirement if you want to use  `positional audio`_:
-the files must be mono (single-channel) instead of stereo.
+The files must also be mono rather than stereo if you want to use
+:ref:`positional audio <sound-other-libraries-pyglet-positional>`.
 
 Accepting these limitations is usually worth the compatibility benefits,
 especially as a beginner.
@@ -501,7 +512,7 @@ Why MP3 For Music and Ambiance?
 See the following to learn more:
 
 * :ref:`sound-compat-loading`
-* `Pyglet's Supported Media Types <pyglet's supported media types_>`_
+* `Pyglet's Supported Media Types <pyglet's guide to supported media types_>`_
 
 .. _sound-compat-easy-converting:
 
@@ -527,9 +538,10 @@ convert existing audio. Two of the most famous are summarized below.
      - Advanced
      - Powerful media conversion tool included with the library
 
-These should be able to handle converting from stereo to mono
-for users who want to use `positional audio`_ . Consult their
-documentation to learn how.
+They should be able to handle converting from stereo to mono
+for any users who want to use :ref:`positional audio
+<sound-other-libraries-pyglet-positional>`. Consult the documentation
+for the utilities above to learn how.
 
 .. [#linuxlame]
    Linux users may need to `install the LAME MP3 encoder separately
@@ -577,7 +589,7 @@ common denominators among features. The most restrictive backends are:
 * Mac's only backend, an OpenAL version limited to 16-bit audio
 * PulseAudio on Linux, which has multiple limitations:
 
-  * It lacks support for `positional audio <positional audio_>`_.
+  * It lacks support for :ref:`positional audio <sound-other-libraries-pyglet-positional>`
   * It can `crash under certain circumstances <pyglet_pulseaudiobug_>`_
     when other backends will not:
 
@@ -637,19 +649,45 @@ Other Sound Libraries
 
 Advanced users may have reasons to use other libraries to handle sound.
 
-The most obvious choice is pyglet itself:
+.. _sound-other-libraries-pyglet:
+
+Using Pyglet
+^^^^^^^^^^^^
+The most obvious external library for audio handling is pyglet:
 
 * It's guaranteed to work wherever arcade's sound support does.
-* You are already familiar with using :py:class:`pyglet.media.player.Player`
-  to control playback.
-* It offers more control over media loading and playback than arcade.
+* It offers far better control over media than arcade
+* You may have already used parts of it directly for :ref:`sound-advanced-playback`
 
-If you are interested in porting to using pyglet directly, note that the
-:py:attr:`arcade.Sound.source` attribute is exposed. This means you can
-cleanly interface with pyglet code if you are porting code or want to use
-arcade's built-in resource path resolution.
+Note that :py:attr:`arcade.Sound`'s ``source`` attribute holds a
+:py:class:`pyglet.media.Source`. This means you can start off by cleanly
+using arcade's resource and sound loading with pyglet features as needed.
 
-To learn more, consult the `pyglet media guide`_.
+.. _sound-other-libraries-pyglet-positional:
+
+Notes on Positional Audio
+"""""""""""""""""""""""""
+Positional audio is a set of features which automatically adjust sound
+volumes across the channels for physical speakers based on in-game
+distances.
+
+Although pyglet exposes its support for this through its
+:py:class:`~pyglet.media.player.Player`, arcade does not currently offer
+integrations. You will have to do the setup work yourself.
+
+.. _pyglet_positional_guide: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#positional-audio
+
+If you already have some experience with Python, the following sequence
+of links should serve as a primer for trying positional audio:
+
+#. :ref:`sound-compat-easy-best-effects`
+#. :ref:`sound-compat-playback`
+#. The following sections of pyglet's media guide:
+
+   #. `Controlling playback <pyglet_controlling_playback_>`_
+   #. `Positional audio <pyglet_positional_guide>`_
+
+#. :py:class:`pyglet.media.player.Player`'s full documentation
 
 External Libraries
 ^^^^^^^^^^^^^^^^^^

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -356,10 +356,12 @@ The simplest form of advanced control is pausing and resuming playback.
 Pausing
 """""""
 There is no stop method. Instead, call the :py:meth:`Player.pause()
-<pyglet.media.player.Player.pause>` method::
+<pyglet.media.player.Player.pause>` method:
 
- # Assume this is inside an Enemy class subclassing arcade.Sprite
- self.current_player.pause()
+.. code-block:: python
+
+   # Assume this is inside an Enemy class subclassing arcade.Sprite
+   self.current_player.pause()
 
 Stopping Permanently
 """"""""""""""""""""
@@ -368,18 +370,22 @@ Stopping Permanently
 
 After you've paused a player, you can stop playback permanently:
 
-#. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method::
+#. Call the player's :py:meth:`~pyglet.media.player.Player.delete` method:
 
-    # Permanently deletes the operating system half of this playback.
-    self.current_player.delete()
+   .. code-block:: python
+
+      # Permanently deletes the operating system half of this playback.
+      self.current_player.delete()
 
    `This specific playback is now permanently over, but you can start
    new ones.`
 
-#. Make sure all references to the player are replaced with ``None``::
+#. Make sure all references to the player are replaced with ``None``:
 
-    # Python will delete the pyglet Player once there are 0 references to it
-    self.current_player = None
+   .. code-block:: python
+
+      # Python will delete the pyglet Player once there are 0 references to it
+      self.current_player = None
 
 For a more in-depth explanation of references and auto-deletion, skim
 the start of Python's page on `garbage collection`_. Reading the Abstract

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -339,7 +339,7 @@ You can alter the playback of a :py:class:`arcade.Sound`'s data by:
 Stopping via the Player Object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can stop playback through its pyglet :py:meth:`pyglet.media.player.Player`
+You can stop playback through its pyglet :py:class:`~pyglet.media.player.Player`
 instead of the :ref:`stopping helpers <sound-basics-stopping>` as follows:
 
 #. Call the player's :py:meth:`~pyglet.media.player.Player.pause`

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -29,6 +29,7 @@ code and documentation.
    * :ref:`sound-basics-playing`
    * :ref:`sound-basics-stopping`
 
+#. :ref:`sound-advanced-playback`
 #. :ref:`sound-compat`
 #. :ref:`sound-other-libraries` (for advanced users)
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -126,6 +126,32 @@ argument of :py:func:`arcade.play_sound`::
     # Important: this *must* be a Sound instance, not a path or string!
     self.hurt_player = arcade.play_sound(hurt_sound)
 
+Both return a :py:class:`pyglet.media.player.Player`. You should store
+it somewhere if you want to be able to stop or alter a specific playback of
+a :py:class:`~arcade.Sound`'s data.
+
+Sounds vs pyglet Players
+""""""""""""""""""""""""
+This is a very important distinction:
+
+* A :py:class:`~arcade.Sound` represents a source of playable data
+* A pyglet :py:class:`~pyglet.media.player.Player` represents a
+  specific playback of that data
+
+Imagine you have two characters in a game which both play the same
+:py:class:`~arcade.Sound` when moving. Since they are separate
+characters in the world with separate playbacks of the sound,
+each stores its own :py:class:`~pyglet.media.player.Player`.
+
+This allows controlling their movement sound playbacks separately. For
+example, one character may get close enough to the player to attack or
+perform some other action.
+
+Although this may seem unimportant, it is crucial if for games which
+hide parts of the world from view. An enemy with no way to know it's
+there is the most common version of an "unknown danger" as described in
+:ref:`pgsound-why-important`.
+
 See the following to learn more:
 
 #. :ref:`Platformer Tutorial - Part 7 - Collision Detection <platformer_part_seven_playing_sounds>`

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -564,10 +564,9 @@ There are 3 ways arcade can read audio data through pyglet:
 #. Platform-specific components or nearly-universal libraries
 #. Supported cross-platform media libraries, such as PyOgg or `FFmpeg`_
 
-.. warning:: To load through FFmpeg, you must use version 4 or 5!
+.. warning:: To load through FFmpeg, you must install FFmpeg 4.X, 5.X, or 6.X!
 
-             This is a requirement imposed by pyglet. See `pyglet's
-             notes on installing FFmpeg <pyglet_ffmpeg_install_>`_.
+             See `pyglet's notes on installing FFmpeg <pyglet_ffmpeg_install_>`_.
 
 Everyday Usage
 """"""""""""""

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -604,10 +604,10 @@ Advanced users may have reasons to use other libraries to handle sound.
 
 The most obvious choice is pyglet itself:
 
-* It's guaranteed to work wherever arcade's sound support does
-* You are already familiar with from using
-  :py:class:`pyglet.media.player.Player` to control playback
-* It offers more control over media loading and playback than arcade
+* It's guaranteed to work wherever arcade's sound support does.
+* You are already familiar with using :py:class:`pyglet.media.player.Player`
+  to control playback.
+* It offers more control over media loading and playback than arcade.
 
 If you are interested in porting to using pyglet directly, note that the
 :py:attr:`arcade.Sound.source` attribute is exposed. This means you can

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -270,7 +270,7 @@ be fast and smooth. For music, consider :
 Any of the following suggest a sound should be loaded as a static effect:
 
 * You need to start playback quickly in response to gameplay.
-* 2 or more "copies" of the sound can be playing at the same time.
+* Two or more "copies" of the sound can be playing at the same time.
 * You will unpredictably restart or skip playback through the file.
 * You need to automatically loop playback.
 * The file is a short clip.

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -651,7 +651,7 @@ order until it finds one which loads:
 #. ``"silent"``
 
 You can override through the ``ARCADE_SOUND_BACKENDS`` `environment
-variable <python_env_vars>`_. The following rules apply to its value:
+variable <python_env_vars_>`_. The following rules apply to its value:
 
 #. It must be a comma-separated string
 #. Each name must be an audio back-ends supported by pyglet

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -147,9 +147,9 @@ each stores its own :py:class:`~pyglet.media.player.Player`.
 
 This allows controlling their playbacks of the movement sound
 separately. For example, one character may get close enough to the
-user's character to talk, attack, attack perform some other action.
-You would use that character's pyglet player to stop the movement
-sound's playback.
+user's character to talk, attack, or perform some other action.
+You would use that character's pyglet :py:class:`~pyglet.media.player.Player`
+to stop the movement sound's playback.
 
 Although this may seem unimportant, it is crucial for games which hide
 parts of the world from view. An enemy with no way to know it's there

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -551,7 +551,10 @@ common denominators among features. The most restrictive backends are:
 
   * It lacks support for `positional audio <positional audio_>`_.
   * It can `crash under certain circumstances <pyglet_pulseaudiobug_>`_
-    where other backends will not.
+    when other backends will not:
+
+    * Pausing / resuming in debuggers
+    * Rarely and unpredictably when multiple sounds are playing
 
 On Linux, the best way to deal with the PulseAudio bug is to `install
 OpenAL <pyglet_openal_>`_. It will often already be installed as a

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -29,6 +29,7 @@ code and documentation.
    * :ref:`sound-basics-playing`
    * :ref:`sound-basics-stopping`
 
+#. :ref:`sound-loading-modes`
 #. :ref:`sound-advanced-playback`
 #. :ref:`sound-compat`
 #. :ref:`sound-other-libraries` (for advanced users)

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -712,7 +712,7 @@ of links should serve as a primer for trying positional audio:
 #. The following sections of pyglet's media guide:
 
    #. `Controlling playback <pyglet_controlling_playback_>`_
-   #. `Positional audio <pyglet_positional_guide>`_
+   #. `Positional audio <pyglet_positional_guide_>`_
 
 #. :py:class:`pyglet.media.player.Player`'s full documentation
 

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -139,8 +139,9 @@ Both return a :py:class:`pyglet.media.player.Player`. You should store
 it somewhere if you want to be able to stop or alter a specific playback of
 a :py:class:`~arcade.Sound`'s data.
 
-Sounds vs pyglet Players
-""""""""""""""""""""""""
+``arcade.Sound`` vs pyglet's ``Player``
+"""""""""""""""""""""""""""""""""""""""
+
 This is a very important distinction:
 
 * An :py:class:`arcade.Sound` represents a source of audio data
@@ -264,7 +265,7 @@ in-game slowdowns.
 
 This is because disk access is one of the slowest things a computer can
 do. Avoiding it during gameplay is important if your gameplay needs to
-be fast and smooth.
+be fast and smooth. For music, consider :
 
 Any of the following suggest a sound should be loaded as a static effect:
 

--- a/doc/tutorials/platform_tutorial/step_07.rst
+++ b/doc/tutorials/platform_tutorial/step_07.rst
@@ -27,7 +27,6 @@ the ground previously, and then add them to the scene.
     :caption: Add Coins and Sound
     :lines: 86-91
 
-
 .. _platformer_part_seven_loading_sounds:
 
 Loading Sounds

--- a/doc/tutorials/platform_tutorial/step_07.rst
+++ b/doc/tutorials/platform_tutorial/step_07.rst
@@ -48,7 +48,6 @@ Then we can play our jump sound when the player jumps, by adding it to the ``on_
     :lines: 110-120
     :emphasize-lines: 7
 
-
 .. _platformer_part_seven_playing_sounds:
 
 Collision Detection

--- a/doc/tutorials/platform_tutorial/step_07.rst
+++ b/doc/tutorials/platform_tutorial/step_07.rst
@@ -27,6 +27,9 @@ the ground previously, and then add them to the scene.
     :caption: Add Coins and Sound
     :lines: 86-91
 
+
+.. _platformer_part_seven_loading_sounds:
+
 Loading Sounds
 ~~~~~~~~~~~~~~
 
@@ -45,6 +48,9 @@ Then we can play our jump sound when the player jumps, by adding it to the ``on_
     :lines: 110-120
     :emphasize-lines: 7
 
+
+.. _platformer_part_seven_playing_sounds:
+
 Collision Detection
 ~~~~~~~~~~~~~~~~~~~
 
@@ -62,6 +68,8 @@ sprite from any SpriteLists it belongs to, effectively deleting it from the game
     Notice that any transparent "white-space" around the image counts as the hitbox.
     You can trim the space in a graphics editor, or later on, we'll go over how to customize the
     hitbox of a Sprite.
+
+
 
 Add the following to the ``on_update`` function to add collision detection and play a sound
 when the player picks up a coin.

--- a/doc/tutorials/platform_tutorial/step_07.rst
+++ b/doc/tutorials/platform_tutorial/step_07.rst
@@ -69,8 +69,6 @@ sprite from any SpriteLists it belongs to, effectively deleting it from the game
     You can trim the space in a graphics editor, or later on, we'll go over how to customize the
     hitbox of a Sprite.
 
-
-
 Add the following to the ``on_update`` function to add collision detection and play a sound
 when the player picks up a coin.
 


### PR DESCRIPTION
Closes #1274
Closes #1900

### Changes

1. Add link targets to the platformer tutorial
2. Add new Sound page to the programming guide covering usage and compatibility
3. Link the Sound page from the top-level index
 
### How to Test

1. Clone the branch locally
2. Run `pip install -I -e .[dev]` to make sure you have the dev dependencies fully installed & upgraded
3. `./make.py html` (optional, but helps prevent an occasional rebuild loop)
4. `./make.py serve`
5. Open https://localhost:8000 in your browser
6. Verify the page is in the sidebar and Programming Guide homepage section
7. Open http://localhost:8000/programming_guide/sound.html
8. Proof-read the Sound Basics sections brutally:
    * http://localhost:8000/programming_guide/sound.html#sound-basics-loading
    * http://localhost:8000/programming_guide/sound.html#sound-basics-playing
    * http://localhost:8000/programming_guide/sound.html#sound-basics-stopping
9. Verify that [#1900](https://github.com/pythonarcade/arcade/issues/1900) is covered by http://localhost:8000/programming_guide/sound.html#backends-determine-playback-features 
10. If time / interest allow, proof read and verify other parts

### Follow-up work for future PRs

1. Move some of the preloading concepts to a new performance page / heading
2. Add an easier to digest reference counting section somewhere and link it instead of the Python contributor doc
3. Move some compatibility information to its own page / heading