### PR TITLE
Fix exception types in arcade.sound

### DIFF
--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -210,8 +210,8 @@ def play_sound(
     elif not isinstance(sound, Sound):
         raise TypeError(
             f"Error, got {sound!r} instead of an arcade.Sound."
-            f"" if not isinstance(sound, (str, Path, bytes)) else\
-            " Make sure to use load_sound first, and use the result with play_sound.")
+            if not isinstance(sound, (str, Path, bytes)) else\
+            " Make sure to use load_sound first, then play the result with play_sound.")
 
     try:
         return sound.play(volume, pan, looping, speed)

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -206,11 +206,13 @@ def play_sound(
     if sound is None:
         print("Unable to play sound, no data passed in.")
         return None
+
     elif not isinstance(sound, Sound):
-        msg = [f"Error, got {sound!r} instead of an arcade.Sound."]
-        if isinstance(sound, (str, Path, bytes)):
-            msg.append("Make sure to use load_sound first, and use the result with play_sound.")
-        raise TypeError(' '.join(msg))
+        raise TypeError(
+            f"Error, got {sound!r} instead of an arcade.Sound."
+            f"" if not isinstance(sound, (str, Path, bytes)) else\
+            " Make sure to use load_sound first, and use the result with play_sound.")
+
     try:
         return sound.play(volume, pan, looping, speed)
     except Exception as ex:

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -224,16 +224,11 @@ def stop_sound(player: media.Player):
 
     :param player: Player returned from :func:`play_sound`.
     """
-    if isinstance(player, Sound):
-        raise TypeError(
-            "stop_sound takes a media player object returned from the play_sound() command, "
-            "not the loaded Sound object."
-        )
 
     if not isinstance(player, media.Player):
         raise TypeError(
-            "stop_sound takes a media player object returned from the play_sound() command."
-        )
+            "stop_sound takes a media player object returned from the play_sound() command, not a "
+            "loaded Sound object." if isinstance(player, Sound) else f"{player!r}")
 
     player.pause()
     player.delete()

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -211,7 +211,7 @@ def play_sound(
             "Error, passed in a string as a sound. "
             "Make sure to use load_sound first, and use that result in play_sound."
         )
-        raise Exception(msg)
+        raise TypeError(msg)
     try:
         return sound.play(volume, pan, looping, speed)
     except Exception as ex:

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -206,12 +206,11 @@ def play_sound(
     if sound is None:
         print("Unable to play sound, no data passed in.")
         return None
-    elif isinstance(sound, str):
-        msg = (
-            "Error, passed in a string as a sound. "
-            "Make sure to use load_sound first, and use that result in play_sound."
-        )
-        raise TypeError(msg)
+    elif not isinstance(sound, Sound):
+        msg = [f"Error, got {sound} instead of an arcade.Sound."]
+        if isinstance(sound, (str, Path, bytes)):
+            msg.append("Make sure to use load_sound first, and use the result with play_sound.")
+        raise TypeError(' '.join(msg))
     try:
         return sound.play(volume, pan, looping, speed)
     except Exception as ex:

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -184,7 +184,7 @@ def load_sound(path: Union[str, Path], streaming: bool = False) -> Optional[Soun
     except Exception as ex:
         raise FileNotFoundError(
             f'Unable to load sound file: "{file_name}". Exception: {ex}'
-        )
+        ) from ex
 
 
 def play_sound(

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -226,13 +226,13 @@ def stop_sound(player: media.Player):
     """
     if isinstance(player, Sound):
         raise TypeError(
-            "stop_sound takes the media player object returned from the play() command, "
+            "stop_sound takes a media player object returned from the play_sound() command, "
             "not the loaded Sound object."
         )
 
     if not isinstance(player, media.Player):
         raise TypeError(
-            "stop_sound takes a media player object returned from the play() command."
+            "stop_sound takes a media player object returned from the play_sound() command."
         )
 
     player.pause()

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -207,7 +207,7 @@ def play_sound(
         print("Unable to play sound, no data passed in.")
         return None
     elif not isinstance(sound, Sound):
-        msg = [f"Error, got {sound} instead of an arcade.Sound."]
+        msg = [f"Error, got {sound!r} instead of an arcade.Sound."]
         if isinstance(sound, (str, Path, bytes)):
             msg.append("Make sure to use load_sound first, and use the result with play_sound.")
         raise TypeError(' '.join(msg))

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -226,13 +226,13 @@ def stop_sound(player: media.Player):
     :param player: Player returned from :func:`play_sound`.
     """
     if isinstance(player, Sound):
-        raise ValueError(
+        raise TypeError(
             "stop_sound takes the media player object returned from the play() command, "
             "not the loaded Sound object."
         )
 
     if not isinstance(player, media.Player):
-        raise ValueError(
+        raise TypeError(
             "stop_sound takes a media player object returned from the play() command."
         )
 

--- a/tests/unit/test_sound.py
+++ b/tests/unit/test_sound.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 import arcade
 
 frame_count = 0
@@ -89,3 +93,23 @@ def test_sound_normal_load_and_playback(window):
     window.on_draw = on_draw
     window.test(140)
     player = None
+
+
+def test_sound_play_sound_type_errors(window):
+    # Non-pathlike raises and provides full loading guidance.
+    with pytest.raises(TypeError) as ctx:
+        arcade.play_sound(object())
+        assert ctx.value.args[0].endswith("arcade.Sound.")
+
+    #Pathlike raises and provides full loading guidance.
+    with pytest.raises(TypeError) as ctx:
+        arcade.play_sound("file.wav")
+        assert ctx.value.args[0].endswidth("play_sound.")
+
+    with pytest.raises(TypeError) as ctx:
+        arcade.play_sound(b"file.wav")
+        assert ctx.value.args[0].endswidth("play_sound.")
+
+    with pytest.raises(TypeError) as ctx:
+        arcade.play_sound(Path("file.wav"))
+        assert ctx.value.args[0].endswidth("play_sound.")

--- a/tests/unit/test_sound.py
+++ b/tests/unit/test_sound.py
@@ -4,7 +4,7 @@ frame_count = 0
 player = None
 
 
-def test_sound(window):
+def test_sound_normal_load_and_playback(window):
     global frame_count, player
 
     laser_wav = arcade.load_sound(":resources:sounds/laser1.wav")

--- a/tests/unit/test_sound.py
+++ b/tests/unit/test_sound.py
@@ -113,3 +113,15 @@ def test_sound_play_sound_type_errors(window):
     with pytest.raises(TypeError) as ctx:
         arcade.play_sound(Path("file.wav"))
         assert ctx.value.args[0].endswidth("play_sound.")
+
+
+def test_sound_stop_sound_type_errors(window):
+    sound = arcade.load_sound(":resources:sounds/laser1.wav")
+
+    # Sound raises specific type error
+    with pytest.raises(TypeError) as ctx:
+        arcade.stop_sound(sound)
+        assert ctx.value.args[0].endswith("not the loaded Sound object.")
+
+    with pytest.raises(TypeError) as ctx:
+        arcade.play_sound("file.wav")


### PR DESCRIPTION
### Changes

1. Use `TypeError` instead of `ValueError` when the wrong types are passed to sound helpers
2. Add unit tests to verify this + helper text phrasing
3. Turn a raise into a raise from
4. Rephrase some exceptions and restructure their generation

The items in 4 are generally well-separated out and easy to revert, and I can understand if reviewers think we should do that.

This is a follow-up to some reading done for #1922.
