### PR TITLE
Fix app crashes when touching bomb by passing correct type to `camera…

### DIFF
--- a/arcade/examples/camera_platform.py
+++ b/arcade/examples/camera_platform.py
@@ -10,6 +10,8 @@ python -m arcade.examples.camera_example
 
 import time
 
+from pyglet.math import Vec2
+
 import arcade
 
 TILE_SCALING = 0.5
@@ -254,7 +256,7 @@ class MyGame(arcade.Window):
         for bomb in bombs_hit:
             bomb.remove_from_sprite_lists()
             print("Pow")
-            self.camera.shake((4, 7))
+            self.camera.shake(Vec2(4, 7))
 
         # Pan to the user
         self.pan_camera_to_user(panning_fraction=0.12)


### PR DESCRIPTION
TLDR; 
* App crashes when touching a bomb with error. 
-- `AttributeError: 'tuple' object has no attribute 'x'`
* Made the following changes 
-- added `from pyglet.math import Vec2` to the top of the file 
-- passed `Vec2` to `camera.shake()` instead of tuple 
---- old line: `camera.shake((4, 7))` 
---- new line: `camera.shake(Vec2(4, 7))`

I initially thought this was intended behavior but I realized the app was actually just crashing.

The offending line was calling `camera.shake()` which according to it's definition in `./venv/lib/python3.11/site-packages/arcade/camera.py` expects a `Vec2` as it's argument which is being imported in that file with `from pyglet.math import Mat4, Vec2, Vec3` but the call to `camera.shake()` was getting a `tuple` hence the `AttributeError`.