### PR TITLE
Bump pyglet to 2.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.8,<2.1",
+    "pyglet>=2.0.10,<2.1",
     "pillow~=10.0.0",
     "pymunk~=6.5.1",
     "pytiled-parser~=2.2.3"


### PR DESCRIPTION
### Changes

* Set minimum pyglet version to 2.0.10 in `pyproject.toml`

### Test steps taken:

- [x] Run `pytest`
- [x] Run `arcade.examples.performance_statistics` to make sure shapes work correctly