### PR TITLE
Improve robustness for line of sight function

### DIFF
--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -348,8 +348,14 @@ def has_line_of_sight(observer: Point,
     """
     if max_distance <= 0:
         raise ValueError("max_distance must be greater than zero")
+    if check_resolution <= 0:
+        raise ValueError("check_resolution must be greater than zero")
+
     distance = get_distance(observer[0], observer[1],
                             target[0], target[1])
+    if distance == 0:
+        return False
+
     steps = int(distance // check_resolution)
     for step in range(steps + 1):
         step_distance = step * check_resolution

--- a/tests/unit/paths/test_line_of_sight.py
+++ b/tests/unit/paths/test_line_of_sight.py
@@ -21,6 +21,9 @@ def test_line_of_sight(window):
     result = arcade.has_line_of_sight(player.position, enemy.position, wall_list, 20)
     assert not result
 
+    result = arcade.has_line_of_sight(enemy.position, enemy.position, wall_list)
+    assert result
+
     wall = arcade.Sprite(":resources:images/tiles/grassCenter.png")
     wall.center_x = 0
     wall.center_y = 0


### PR DESCRIPTION
Previously, for the case where the `distance` between the `observer` and `target` is zero the function will crash with a Division by Zero Error. This error can happen if someone designs a chasing enemy that ends up at the players location. I added a check will return True indicating there is line of sight in such a case.

Perhaps this should instead be a configurable option?

Additionally, the Line of Sight function did not ensure that we have a positive non-zero value for the check resolution. I added a check that will raise a value error in such a case.