### PR TITLE
Bump to pyglet 2.0.12 + update doc and pyglet TextLayout method names

### DIFF
--- a/arcade/text.py
+++ b/arcade/text.py
@@ -583,7 +583,7 @@ def create_text_sprite(
     text: str,
     color: RGBA255 = arcade.color.WHITE,
     font_size: float = 12,
-    width: int = 0,
+    width: Optional[int] = None,
     align: str = "left",
     font_name: FontNameOrNames = ("calibri", "arial"),
     bold: bool = False,

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -446,28 +446,28 @@ class Text:
         """
         Pixel location of the left content border.
         """
-        return self._label._get_left()
+        return self._label._get_left_anchor()
 
     @property
     def right(self) -> int:
         """
         Pixel location of the right content border.
         """
-        return self._label._get_left() + self._label.content_width
+        return self._label._get_left_anchor() + self._label.content_width
 
     @property
     def top(self) -> int:
         """
         Pixel location of the top content border.
         """
-        return self._label._get_top(self._label._get_lines())
+        return self._label._get_top_anchor()
 
     @property
     def bottom(self) -> int:
         """
         Pixel location of the bottom content border.
         """
-        return self._label._get_bottom(self._label._get_lines())
+        return self._label._get_bottom_anchor()
 
     @property
     def content_size(self) -> Tuple[int, int]:

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -446,28 +446,28 @@ class Text:
         """
         Pixel location of the left content border.
         """
-        return self._label._get_left_anchor()
+        return self._label.left
 
     @property
     def right(self) -> int:
         """
         Pixel location of the right content border.
         """
-        return self._label._get_left_anchor() + self._label.content_width
+        return self._label.right
 
     @property
     def top(self) -> int:
         """
         Pixel location of the top content border.
         """
-        return self._label._get_top_anchor()
+        return self._label.top
 
     @property
     def bottom(self) -> int:
         """
         Pixel location of the bottom content border.
         """
-        return self._label._get_bottom_anchor()
+        return self._label.bottom
 
     @property
     def content_size(self) -> Tuple[int, int]:

--- a/doc/programming_guide/sound.rst
+++ b/doc/programming_guide/sound.rst
@@ -641,24 +641,17 @@ Backends Determine Playback Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _pyglet_openal: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#openal
-.. _pyglet_pulseaudiobug: https://pyglet.readthedocs.io/en/latest/programming_guide/media.html#the-bug
 
 As with formats, you can maximize compatibility by only using the lowest
 common denominators among features. The most restrictive backends are:
 
 * Mac's only backend, an OpenAL version limited to 16-bit audio
-* PulseAudio on Linux, which has multiple limitations:
+* PulseAudio on Linux, which lacks support for common features such as
+  :ref:`positional audio <sound-other-libraries-pyglet-positional>`.
 
-  * It lacks support for :ref:`positional audio <sound-other-libraries-pyglet-positional>`
-  * It can `crash under certain circumstances <pyglet_pulseaudiobug_>`_
-    when other backends will not:
-
-    * Pausing / resuming in debuggers
-    * Rarely and unpredictably when multiple sounds are playing
-
-On Linux, the best way to deal with the PulseAudio bug is to `install
-OpenAL <pyglet_openal_>`_. It will often already be installed as a
-dependency of other packages.
+On Linux, the best way to deal with the PulseAudio backend's limitations
+is to `install OpenAL <pyglet_openal_>`_. It will often already be installed
+as a dependency of other packages.
 
 Other differences between backends are less drastic. Usually, they will
 be things like the specific positional features supported and the maximum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.11,<2.1",
+    "pyglet>=2.0.12,<2.1",
     "pillow~=10.0.0",
     "pymunk~=6.5.1",
     "pytiled-parser~=2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet==2.0.10",
+    "pyglet>=2.0.11,<2.1",
     "pillow~=10.0.0",
     "pymunk~=6.5.1",
     "pytiled-parser~=2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet==2.0.11",
+    "pyglet>=2.0.11,<2.1",
     "pillow~=10.0.0",
     "pymunk~=6.5.1",
     "pytiled-parser~=2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.11,<2.1",
+    "pyglet==2.0.11",
     "pillow~=10.0.0",
     "pymunk~=6.5.1",
     "pytiled-parser~=2.2.3"


### PR DESCRIPTION
### Changes

* Bump minimum pyglet to 2.0.12
* Update `_get_left` and similar to `pyglet.layout.TextLayout`'s new `left`, `right`, and similar bound properties
* Fix `create_text_sprite` by using `None` as the default width
* Remove mention of a PulseAudio bug fixed in 2.0.11

### Testing steps taken

#### Platform independent

- [x] Build and preview the docs locally

#### OSes + Python versions Tested

- [x] Linux (Debian 11) with Python 3.9.2, 3.12.0
     - [x] Compare text drawing examples between `development` and this branch
     - [x] Run GUI examples and compare for breakage
- [ ] Mac
     - [ ] Compare text drawing examples between `development` and this branch
     - [ ] Run GUI examples and compare for breakage
- [ ] Windows
     - [ ] Compare text drawing examples between `development` and this branch
     - [ ] Run GUI examples and compare for breakage