### PR TITLE
Replace deprecated ruff options in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,11 +91,11 @@ build-backend = "setuptools.build_meta"
 # E731 do not assign a lambda expression, use a def
 # E741 Ambiguous variable name
 # F811: redefinition
-ignore = ["F811", "E731", "E741"]
-show-source = true
 line-length = 120
+output-format = "full"
 exclude = ["venv", ".venv*", "tests", "build", "doc", "util", ".mypy_cache", ".pytest_cache", "temp", "bugs", "arcade/examples/platform_tutorial"]
-select = [
+lint.ignore = ["F811", "E731", "E741"]
+lint.select = [
     "E",
     "F",
     # Whitespace linting must be re-enabled manually for ruff


### PR DESCRIPTION
### Changes

* s/ignore/lint.ignore/
* s/select/lint.select/
* s/show-source = "true"/output-format = "full"/

### Why
```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
warning: The `show-source` option has been deprecated in favor of `output-format`'s "full" and "concise" variants. Please update your configuration to use `output-format = <full|concise>` instead.
```