### PR TITLE
Improve SpriteList typing

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -106,7 +106,7 @@ class SpriteList(Generic[SpriteType]):
         lazy: bool = False,
         visible: bool = True,
     ):
-        self.program = None
+        self.program: Optional["Program"] = None
         self._atlas: Optional[TextureAtlas] = atlas
         self._initialized = False
         self._lazy = lazy

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -759,7 +759,7 @@ class SpriteList(Generic[SpriteType]):
 
         self._sprite_index_changed = True
 
-    def sort(self, *, key: Callable, reverse: bool = False):
+    def sort(self, *, key: Callable, reverse: bool = False) -> None:
         """
         Sort the spritelist in place using ``<`` comparison between sprites.
         This function is similar to python's :py:meth:`list.sort`.

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -885,7 +885,6 @@ class SpriteList(Generic[SpriteType]):
             self._atlas.add( # type: ignore
                 texture)
 
-
     def write_sprite_buffers_to_gpu(self) -> None:
         """
         Ensure buffers are resized and fresh sprite data

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -732,7 +732,7 @@ class SpriteList(Generic[SpriteType]):
 
         self._sprite_index_changed = True
 
-    def shuffle(self):
+    def shuffle(self) -> None:
         """
         Shuffles the current list in-place
         """

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -676,7 +676,7 @@ class SpriteList(Generic[SpriteType]):
         if self.spatial_hash is not None:
             self.spatial_hash.remove(sprite)
 
-    def extend(self, sprites: Union[Iterable[SpriteType], "SpriteList"]):
+    def extend(self, sprites: Union[Iterable[SpriteType], SpriteList[SpriteType]]):
         """
         Extends the current list with the given iterable
 
@@ -1168,7 +1168,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_texture_data[slot] = tex_slot
         self._sprite_texture_changed = True
 
-    def _update_texture(self, sprite) -> None:
+    def _update_texture(self, sprite: SpriteType) -> None:
         """Make sure we update the texture for this sprite for the next batch
         drawing"""
         # We cannot interact with texture atlases unless the context
@@ -1274,7 +1274,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_size_data[slot * 2 + 1] = sprite._height
         self._sprite_size_changed = True
 
-    def _update_width(self, sprite: SpriteType):
+    def _update_width(self, sprite: SpriteType) -> None:
         """
         Called by the Sprite class to update the size/scale in this sprite.
         Necessary for batch drawing of items.

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -809,7 +809,7 @@ class SpriteList(Generic[SpriteType]):
         else:
             LOG.debug("Spatial hashing is already enabled with size %s", spatial_hash_cell_size)
 
-    def _recalculate_spatial_hashes(self):
+    def _recalculate_spatial_hashes(self) -> None:
         if self.spatial_hash is None:
             from .spatial_hash import SpatialHash
             self.spatial_hash = SpatialHash(cell_size=self._spatial_hash_cell_size)

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -179,7 +179,7 @@ class SpriteList(Generic[SpriteType]):
         except RuntimeError:
             pass
 
-    def _init_deferred(self):
+    def _init_deferred(self) -> None:
         """
         Since spritelist can be created before the window we need to defer initialization.
         It also makes us able to support lazy loading.

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -249,7 +249,7 @@ class SpriteList(Generic[SpriteType]):
         """Return an iterable object of sprites."""
         return iter(self.sprite_list)
 
-    def __getitem__(self, i) -> SpriteType:
+    def __getitem__(self, i):
         return self.sprite_list[i]
 
     def __setitem__(self, index: int, sprite: SpriteType):

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -139,22 +139,25 @@ class SpriteList(Generic[SpriteType]):
         # Index buffer
         self._sprite_index_data = array("i", [0] * self._idx_capacity)
 
-        self._sprite_pos_buf = None
-        self._sprite_size_buf = None
-        self._sprite_angle_buf = None
-        self._sprite_color_buf = None
-        self._sprite_texture_buf = None
-        # Index buffer
-        self._sprite_index_buf = None
+        # Define and annotate storage space for buffers
+        self._sprite_pos_buf: Optional[Buffer] = None
+        self._sprite_size_buf: Optional[Buffer] = None
+        self._sprite_angle_buf: Optional[Buffer] = None
+        self._sprite_color_buf: Optional[Buffer] = None
+        self._sprite_texture_buf: Optional[Buffer] = None
 
-        self._geometry = None
+        # Index buffer
+        self._sprite_index_buf: Optional[Buffer] = None
+
+        self._geometry: Optional[Geometry] = None
+
         # Flags for signaling if a buffer needs to be written to the opengl buffer
-        self._sprite_pos_changed = False
-        self._sprite_size_changed = False
-        self._sprite_angle_changed = False
-        self._sprite_color_changed = False
-        self._sprite_texture_changed = False
-        self._sprite_index_changed = False
+        self._sprite_pos_changed: bool = False
+        self._sprite_size_changed: bool = False
+        self._sprite_angle_changed: bool = False
+        self._sprite_color_changed: bool = False
+        self._sprite_texture_changed: bool = False
+        self._sprite_index_changed: bool = False
 
         # Used in collision detection optimization
         from .spatial_hash import SpatialHash

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -525,7 +525,7 @@ class SpriteList(Generic[SpriteType]):
         """
         return self.sprite_list.index(sprite)
 
-    def clear(self, deep: bool = True):
+    def clear(self, deep: bool = True) -> None:
         """
         Remove all the sprites resetting the spritelist
         to it's initial state.

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -676,7 +676,7 @@ class SpriteList(Generic[SpriteType]):
         if self.spatial_hash is not None:
             self.spatial_hash.remove(sprite)
 
-    def extend(self, sprites: Union[Iterable[SpriteType], SpriteList[SpriteType]]):
+    def extend(self, sprites: Union[Iterable[SpriteType], SpriteList[SpriteType]]) -> None:
         """
         Extends the current list with the given iterable
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -35,7 +35,7 @@ from arcade import (
     get_window,
     gl,
 )
-from arcade.gl import Texture2D
+from arcade.gl import Texture2D, Program
 from arcade.types import Color, RGBA255
 from arcade.gl.types import OpenGlFilter, BlendFunction, PyGLenum
 from arcade.gl.buffer import Buffer
@@ -106,7 +106,7 @@ class SpriteList(Generic[SpriteType]):
         lazy: bool = False,
         visible: bool = True,
     ):
-        self.program: Optional["Program"] = None
+        self.program: Optional[Program] = None
         self._atlas: Optional[TextureAtlas] = atlas
         self._initialized = False
         self._lazy = lazy

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -252,7 +252,7 @@ class SpriteList(Generic[SpriteType]):
     def __getitem__(self, i):
         return self.sprite_list[i]
 
-    def __setitem__(self, index: int, sprite: SpriteType):
+    def __setitem__(self, index: int, sprite: SpriteType) -> None:
         """Replace a sprite at a specific index"""
         # print(f"{id(self)} : {id(sprite)} __setitem__({index})")
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -799,7 +799,7 @@ class SpriteList(Generic[SpriteType]):
         """
         self.spatial_hash = None
 
-    def enable_spatial_hashing(self, spatial_hash_cell_size: int = 128):
+    def enable_spatial_hashing(self, spatial_hash_cell_size: int = 128) -> None:
         """Turn on spatial hashing."""
         if self.spatial_hash is None or self.spatial_hash.cell_size != spatial_hash_cell_size:
             LOG.debug("Enabled spatial hashing with cell size %s", spatial_hash_cell_size)

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -24,9 +24,7 @@ from typing import (
     Union,
     Generic,
     Callable,
-    cast,
-    overload,
-    Sized
+    cast, Sized,
 )
 
 from arcade import (
@@ -253,14 +251,6 @@ class SpriteList(Generic[SpriteType]):
     def __iter__(self) -> Iterator[SpriteType]:
         """Return an iterable object of sprites."""
         return iter(self.sprite_list)
-
-    @overload
-    def __getitem__(self, i: int) -> SpriteType:
-        ...
-
-    @overload
-    def __getitem__(self, i: slice) -> List[SpriteType]:
-        ...
 
     def __getitem__(self, i):
         return self.sprite_list[i]

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -249,7 +249,7 @@ class SpriteList(Generic[SpriteType]):
         """Return an iterable object of sprites."""
         return iter(self.sprite_list)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i) -> SpriteType:
         return self.sprite_list[i]
 
     def __setitem__(self, index: int, sprite: SpriteType):

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -685,7 +685,7 @@ class SpriteList(Generic[SpriteType]):
         for sprite in sprites:
             self.append(sprite)
 
-    def insert(self, index: int, sprite: SpriteType):
+    def insert(self, index: int, sprite: SpriteType) -> None:
         """
         Inserts a sprite at a given index.
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -624,7 +624,7 @@ class SpriteList(Generic[SpriteType]):
                 raise ValueError("Sprite must have a texture when added to a SpriteList")
             self._atlas.add(sprite.texture)  # type: ignore
 
-    def swap(self, index_1: int, index_2: int):
+    def swap(self, index_1: int, index_2: int) -> None:
         """
         Swap two sprites by index
         :param index_1: Item index to swap

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -24,7 +24,9 @@ from typing import (
     Union,
     Generic,
     Callable,
-    cast, Sized,
+    cast,
+    overload,
+    Sized
 )
 
 from arcade import (
@@ -248,6 +250,14 @@ class SpriteList(Generic[SpriteType]):
     def __iter__(self) -> Iterator[SpriteType]:
         """Return an iterable object of sprites."""
         return iter(self.sprite_list)
+
+    @overload
+    def __getitem__(self, i: int) -> SpriteType:
+        ...
+
+    @overload
+    def __getitem__(self, i: slice) -> List[SpriteType]:
+        ...
 
     def __getitem__(self, i):
         return self.sprite_list[i]

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -716,7 +716,7 @@ class SpriteList(Generic[SpriteType]):
         if self.spatial_hash is not None:
             self.spatial_hash.add(sprite)
 
-    def reverse(self):
+    def reverse(self) -> None:
         """
         Reverses the current list in-place
         """

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -1099,11 +1099,12 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_texture_data.extend([0] * extend_by)
 
         if self._initialized:
-            self._sprite_pos_buf.orphan(double=True)
-            self._sprite_size_buf.orphan(double=True)
-            self._sprite_angle_buf.orphan(double=True)
-            self._sprite_color_buf.orphan(double=True)
-            self._sprite_texture_buf.orphan(double=True)
+            # Proper initialization implies these buffers are allocated
+            self._sprite_pos_buf.orphan(double=True) # type: ignore
+            self._sprite_size_buf.orphan(double=True) # type: ignore
+            self._sprite_angle_buf.orphan(double=True) # type: ignore
+            self._sprite_color_buf.orphan(double=True) # type: ignore
+            self._sprite_texture_buf.orphan(double=True) # type: ignore
 
         self._sprite_pos_changed = True
         self._sprite_size_changed = True

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -825,14 +825,14 @@ class SpriteList(Generic[SpriteType]):
         for sprite in self.sprite_list:
             sprite.update()
 
-    def on_update(self, delta_time: float = 1 / 60):
+    def on_update(self, delta_time: float = 1 / 60) -> None:
         """
         Update the sprite. Similar to update, but also takes a delta-time.
         """
         for sprite in self.sprite_list:
             sprite.on_update(delta_time)
 
-    def update_animation(self, delta_time: float = 1 / 60):
+    def update_animation(self, delta_time: float = 1 / 60) -> None:
         """
         Call the update_animation in every sprite in the sprite list.
         """

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -902,7 +902,7 @@ class SpriteList(Generic[SpriteType]):
         """
         self._write_sprite_buffers_to_gpu()
 
-    def _write_sprite_buffers_to_gpu(self):
+    def _write_sprite_buffers_to_gpu(self) -> None:
         LOG.debug(
             "[%s] SpriteList._write_sprite_buffers_to_gpu: pos=%s, size=%s, angle=%s, color=%s tex=%s idx=%s",
             id(self),
@@ -1042,7 +1042,7 @@ class SpriteList(Generic[SpriteType]):
         for sprite in self.sprite_list:
             sprite.draw_hit_box(color, line_thickness)
 
-    def _normalize_index_buffer(self):
+    def _normalize_index_buffer(self) -> None:
         """
         Removes unused slots in the index buffer.
         The other buffers don't need this because they re-use slots.
@@ -1061,7 +1061,7 @@ class SpriteList(Generic[SpriteType]):
         # NOTE: Right now the index buffer is always normalized
         pass
 
-    def _grow_sprite_buffers(self):
+    def _grow_sprite_buffers(self) -> None:
         """Double the internal buffer sizes"""
         # Resize sprite buffers if needed
         if self._sprite_buffer_slots <= self._buf_capacity:
@@ -1098,7 +1098,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_color_changed = True
         self._sprite_texture_changed = True
 
-    def _grow_index_buffer(self):
+    def _grow_index_buffer(self) -> None:
         # Extend the index buffer capacity if needed
         if self._sprite_index_slots <= self._idx_capacity:
             return
@@ -1126,7 +1126,7 @@ class SpriteList(Generic[SpriteType]):
 
         self._sprite_index_changed = True
 
-    def _update_all(self, sprite: SpriteType):
+    def _update_all(self, sprite: SpriteType) -> None:
         """
         Update all sprite data. This is faster when adding and moving sprites.
         This duplicate code, but reduces call overhead, dict lookups etc.
@@ -1284,7 +1284,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_size_data[slot * 2] = sprite._width
         self._sprite_size_changed = True
 
-    def _update_height(self, sprite: SpriteType):
+    def _update_height(self, sprite: SpriteType) -> None:
         """
         Called by the Sprite class to update the size/scale in this sprite.
         Necessary for batch drawing of items.
@@ -1295,7 +1295,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_size_data[slot * 2 + 1] = sprite._height
         self._sprite_size_changed = True
 
-    def _update_angle(self, sprite: SpriteType):
+    def _update_angle(self, sprite: SpriteType) -> None:
         """
         Called by the Sprite class to update the angle in this sprite.
         Necessary for batch drawing of items.

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -588,7 +588,7 @@ class SpriteList(Generic[SpriteType]):
         self.remove(sprite)
         return sprite
 
-    def append(self, sprite: SpriteType):
+    def append(self, sprite: SpriteType) -> None:
         """
         Add a new sprite to the list.
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -644,7 +644,7 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_index_data[i1] = slot_2
         self._sprite_index_data[i2] = slot_1
 
-    def remove(self, sprite: SpriteType):
+    def remove(self, sprite: SpriteType) -> None:
         """
         Remove a specific sprite from the list.
         :param sprite: Item to remove from the list

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -870,7 +870,7 @@ class SpriteList(Generic[SpriteType]):
             sprite.center_x += change_x
             sprite.center_y += change_y
 
-    def preload_textures(self, texture_list: List["Texture"]) -> None:
+    def preload_textures(self, texture_list: Iterable["Texture"]) -> None:
         """
         Preload a set of textures that will be used for sprites in this
         sprite list.


### PR DESCRIPTION
Addresses the SpriteList portion of #1867.

### Changes

* Add missing return types
 * Many `None`s
 * `SpriteType` `TypeVar` where appropriate
* Annotate `SpriteList.extend`'s argument with `Iterable[SpriteType]` instead of `List[SpriteType]`
* Annotate `SpriteList.program` and many protected attributes as `Optional[Program]`
* Remove some extra whitespace