### PR TITLE
Add empty __slots__ to arcade.types.Color

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -103,6 +103,8 @@ class Color(RGBA255):
         0 and 255
     """
 
+    __slots__ = ()
+
     def __new__(cls, r: int, g: int, b: int, a: int = 255):
 
         if not 0 <= r <= 255:


### PR DESCRIPTION
Closes #1841

### Changes

* Add an empty `__slots__` class attribute to `arcade.types.Color`

