### PR TITLE
Escape a Win32 path which Python thinks is an escape code

### DIFF
--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -50,7 +50,7 @@ def check_submodules(parent_module_absolute_name: str) -> None:
     It is important to understand that module names and file paths are different things:
 
     * A module name is what Python sees the module's name as (``"arcade.color"``)
-    * A file path is the location on disk (``C:|Users\\Reader\python_project\game.py``)
+    * A file path is the location on disk (``C:\|Users\\Reader\\python_project\game.py``)
 
     :param parent_module_absolute_name: The absolute import name of the module to check.
     """

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -50,7 +50,7 @@ def check_submodules(parent_module_absolute_name: str) -> None:
     It is important to understand that module names and file paths are different things:
 
     * A module name is what Python sees the module's name as (``"arcade.color"``)
-    * A file path is the location on disk (``C:\|Users\\Reader\\python_project\game.py``)
+    * A file path is the location on disk (``C:\\Users\\Reader\\python_project\game.py``)
 
     :param parent_module_absolute_name: The absolute import name of the module to check.
     """

--- a/tests/unit/test_example_docstrings.py
+++ b/tests/unit/test_example_docstrings.py
@@ -50,7 +50,7 @@ def check_submodules(parent_module_absolute_name: str) -> None:
     It is important to understand that module names and file paths are different things:
 
     * A module name is what Python sees the module's name as (``"arcade.color"``)
-    * A file path is the location on disk (``C:|Users\Reader\python_project\game.py``)
+    * A file path is the location on disk (``C:|Users\\Reader\python_project\game.py``)
 
     :param parent_module_absolute_name: The absolute import name of the module to check.
     """


### PR DESCRIPTION
### Changes

* Escape the backslash before an R in a docstring
* Escape the other backslashes in the same docstring:
  * More consistent
  * Stops it from looking like a typo which someone would waste time fixing

### Why

While testing #1982, I once again ran into pytest outputting noisy error messages about `\R` being a deprecated escape code:
```console
$ pytest -k test_color_type
================================ test session starts ================================
platform linux -- Python 3.9.2, pytest-8.0.1, pluggy-1.4.0
rootdir: /home/user/src/arcade
configfile: pyproject.toml
plugins: cov-3.0.0, mock-3.11.1
collected 786 items / 768 deselected / 18 selected                                  

tests/unit/color/test_color_type.py ..................                        [100%]

================================= warnings summary ==================================
tests/unit/test_example_docstrings.py:47
  /home/user/src/arcade/tests/unit/test_example_docstrings.py:47: DeprecationWarning: invalid escape sequence \R
    """

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 18 passed, 768 deselected, 1 warning in 2.57s ===================
```