### PR TITLE
Experiment with texture compression

### DIFF
--- a/arcade/context.py
+++ b/arcade/context.py
@@ -448,6 +448,8 @@ class ArcadeContext(Context):
         *,
         flip: bool = True,
         build_mipmaps: bool = False,
+        internal_format: Optional[int] = None,
+        compressed: bool = False,
     ) -> Texture2D:
         """
         Loads and creates an OpenGL 2D texture.
@@ -457,12 +459,24 @@ class ArcadeContext(Context):
 
             # Load a texture in current working directory
             texture = window.ctx.load_texture("background.png")
+
             # Load a texture using Arcade resource handle
             texture = window.ctx.load_texture(":textures:background.png")
+
+            # Load and compress a texture
+            texture = window.ctx.load_texture(
+                ":textures:background.png",
+                internal_format=gl.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
+                compressed=True,
+            )
 
         :param path: Path to texture
         :param flip: Flips the image upside down
         :param build_mipmaps: Build mipmaps for the texture
+        :param internal_format: The internal format of the texture. This can be used to
+            override the default internal format when using sRGBA or compressed textures.
+        :param compressed: If the internal format is a compressed format meaning your
+            texture will be compressed by the GPU.
         """
         from arcade.resources import resolve
 
@@ -474,7 +488,11 @@ class ArcadeContext(Context):
             image = image.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
 
         texture = self.texture(
-            image.size, components=4, data=image.convert("RGBA").tobytes()
+            image.size,
+            components=4,
+            data=image.convert("RGBA").tobytes(),
+            internal_format=internal_format,
+            compressed=compressed,
         )
         image.close()
 

--- a/arcade/examples/gl/texture_compression.py
+++ b/arcade/examples/gl/texture_compression.py
@@ -1,0 +1,103 @@
+"""
+Creating compressed textures in OpenGL
+
+Simple formats to test:
+* DXT1: gl.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 6:1 compression ratio
+* DXT5: gl.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 4:1 compression ratio
+
+Running this example:
+python -m arcade.examples.gl.texture_compression
+"""
+import PIL.Image
+import arcade
+import arcade.gl
+from pyglet import gl
+
+class CompressedTextures(arcade.Window):
+
+    def __init__(self):
+        super().__init__(1280, 720, "Compressed Textures Example")
+
+        # self.texture = self.create_compressed_manual()
+        self.texture = self.create_simple()
+
+        self.geometry = arcade.gl.geometry.quad_2d_fs()
+        self.program = self.ctx.program(
+            vertex_shader="""
+            #version 330
+
+            in vec2 in_vert;
+            in vec2 in_uv;
+
+            out vec2 uv;
+
+            void main() {
+                gl_Position = vec4(in_vert, 0.0, 1.0);
+                uv = in_uv;
+            }
+            """,
+            fragment_shader="""
+            #version 330
+
+            uniform sampler2D tex;
+
+            in vec2 uv;
+
+            out vec4 fragColor;
+
+            void main() {
+                fragColor = texture(tex, uv);
+            }
+            """
+        )
+
+    def create_simple(self):
+        """Create a simple texture"""
+        return self.ctx.load_texture(
+            ":assets:images/backgrounds/abstract_1.jpg",
+            internal_format=gl.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,
+            compressed=True,
+        )
+
+    def create_compressed_manual(self):
+        """Manually load and compress a texture"""
+        path = arcade.resources.resolve_resource_path(":assets:images/backgrounds/abstract_1.jpg")
+        image = PIL.Image.open(path)
+        components = 3 if image.mode == "RGB" else 4
+        if components == 3:
+            compression_format = gl.GL_COMPRESSED_RGB_S3TC_DXT1_EXT
+        elif components == 4:
+            compression_format = gl.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
+        else:
+            raise Exception(f"Invalid number of components: {components}")
+
+        return self.ctx.texture(
+            size=image.size,
+            components=components,
+            internal_format=compression_format,
+            compressed=True,
+            data=image.tobytes(),
+        )
+
+    def create_from_compressed_data(self):
+        """Create data from compressed bytes"""
+        # TODO: This is not easy to replicate with only arcade
+        # compressed_data = <get compressed data from some source>
+        # size = <the with and height of the image when decompressed>
+        # components = <1, 3 or 4 depending on the image format>
+        # return self.ctx.texture(
+        #     size=size,
+        #     components=components,
+        #     internal_format=gl.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,  # tweak to match the format
+        #     compressed=True,
+        #     data=compressed_data,
+        # )
+        raise NotImplementedError
+
+    def on_draw(self):
+        self.clear()
+        self.texture.use(0)
+        self.geometry.render(self.program)
+
+
+CompressedTextures().run()

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -877,6 +877,8 @@ class Context:
         filter: Optional[Tuple[PyGLenum, PyGLenum]] = None,
         samples: int = 0,
         immutable: bool = False,
+        internal_format: Optional[PyGLenum] = None,
+        compressed: bool = False,
     ) -> Texture2D:
         """Create a 2D Texture.
 
@@ -898,6 +900,9 @@ class Context:
         :param samples: Creates a multisampled texture for values > 0
         :param immutable: Make the storage (not the contents) immutable. This can sometimes be
                                required when using textures with compute shaders.
+        :param internal_format: The internal format of the texture. This can be used to 
+                                enable sRGB or texture compression.
+        :param compressed: If the texture should be compressed.
         """
         return Texture2D(
             self,
@@ -910,6 +915,8 @@ class Context:
             filter=filter,
             samples=samples,
             immutable=immutable,
+            internal_format=internal_format,
+            compressed=compressed,
         )
 
     def depth_texture(self, size: Tuple[int, int], *, data: Optional[BufferProtocol] = None) -> Texture2D:

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -879,8 +879,37 @@ class Context:
         immutable: bool = False,
         internal_format: Optional[PyGLenum] = None,
         compressed: bool = False,
+        compressed_data: bool = False,
     ) -> Texture2D:
-        """Create a 2D Texture.
+        """
+        Create a 2D Texture.
+
+        Example::
+
+            # Create a 1024 x 1024 RGBA texture
+            image = PIL.Image.open("my_texture.png")
+            ctx.texture(size=(1024, 1024), components=4, data=image.tobytes())
+
+            # Create and compress a texture. The compression format is set by the internal_format
+            image = PIL.Image.open("my_texture.png")
+            ctx.texture(
+                size=(1024, 1024),
+                components=4,
+                compressed=True,
+                internal_format=gl.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,
+                data=image.tobytes(),
+            )
+
+            # Create a compressed texture from raw compressed data. This is an extremely
+            # fast way to load a large number of textures.
+            image_bytes = "<raw compressed data from some source>"
+            ctx.texture(
+                size=(1024, 1024),
+                components=4,
+                internal_format=gl.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,
+                compressed_data=True,
+                data=image_bytes,
+            )
 
         Wrap modes: ``GL_REPEAT``, ``GL_MIRRORED_REPEAT``, ``GL_CLAMP_TO_EDGE``, ``GL_CLAMP_TO_BORDER``
 
@@ -900,10 +929,15 @@ class Context:
         :param samples: Creates a multisampled texture for values > 0
         :param immutable: Make the storage (not the contents) immutable. This can sometimes be
                                required when using textures with compute shaders.
-        :param internal_format: The internal format of the texture. This can be used to 
+        :param internal_format: The internal format of the texture. This can be used to
                                 enable sRGB or texture compression.
-        :param compressed: If the texture should be compressed.
+        :param compressed: Set to True if you want the texture to be compressed.
+                           This assumes you have set a internal_format to a compressed format.
+        :param compressed_data: Set to True if you are passing in raw compressed pixel data.
+                                This implies ``compressed=True``.
         """
+        compressed = compressed or compressed_data
+
         return Texture2D(
             self,
             size,
@@ -917,6 +951,7 @@ class Context:
             immutable=immutable,
             internal_format=internal_format,
             compressed=compressed,
+            compressed_data=compressed_data,
         )
 
     def depth_texture(self, size: Tuple[int, int], *, data: Optional[BufferProtocol] = None) -> Texture2D:

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -80,6 +80,7 @@ class Texture2D:
         "_immutable",
         "__weakref__",
         "_compressed",
+        "_compressed_data",
     )
     _compare_funcs = {
         None: gl.GL_NONE,
@@ -127,6 +128,7 @@ class Texture2D:
         immutable: bool = False,
         internal_format: Optional[PyGLuint] = None,
         compressed: bool = False,
+        compressed_data: bool = False,
     ):
         self._glo = glo = gl.GLuint()
         self._ctx = ctx
@@ -143,6 +145,7 @@ class Texture2D:
         self._anisotropy = 1.0
         self._internal_format = internal_format
         self._compressed = compressed
+        self._compressed_data = compressed_data
         # Default filters for float and integer textures
         # Integer textures should have NEAREST interpolation
         # by default 3.3 core doesn't really support it consistently.
@@ -271,7 +274,7 @@ class Texture2D:
                 else:
                     # glTexImage2D can be called multiple times to re-allocate storage
                     # Specify mutable storage for this texture.
-                    if self._compressed is True:
+                    if self._compressed_data is True:
                         gl.glCompressedTexImage2D(
                             self._target,  # target
                             0,  # level
@@ -321,6 +324,15 @@ class Texture2D:
         :type: GLuint
         """
         return self._glo
+
+    @property
+    def compressed(self) -> bool:
+        """
+        Is this using a compressed format?
+
+        :type: bool
+        """
+        return self._compressed
 
     @property
     def width(self) -> int:


### PR DESCRIPTION
Reviving this one. This would be rewritten a little bit. 

* Instead of polluting the normal texture method we should created a separate method for now. `texture_compressed(..)`. 
* The change changes in `Texture2D` itself is fine.
