### PR TITLE
remove pause

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -76,7 +76,6 @@ from .window_commands import exit
 from .window_commands import finish_render
 from .window_commands import get_display_size
 from .window_commands import get_window
-from .window_commands import pause
 from .window_commands import schedule
 from .window_commands import run
 from .window_commands import set_background_color

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -351,7 +351,6 @@ __all__ = [
     'make_soft_circle_texture',
     'make_soft_square_texture',
     'open_window',
-    'pause',
     'print_timings',
     'play_sound',
     'read_tmx',

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -27,7 +27,6 @@ _window: Optional["Window"] = None
 
 __all__ = [
     "get_display_size",
-    "pause",
     "get_window",
     "set_window",
     "set_viewport",

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -6,7 +6,6 @@ It also has commands for scheduling pauses and scheduling interval functions.
 from __future__ import annotations
 
 import gc
-import time
 import os
 
 import pyglet

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -14,7 +14,6 @@ import pyglet
 from typing import (
     Callable,
     Optional,
-    cast,
     Tuple,
     TYPE_CHECKING
 )
@@ -56,20 +55,6 @@ def get_display_size(screen_id: int = 0) -> Tuple[int, int]:
     display = pyglet.canvas.Display()
     screen = display.get_screens()[screen_id]
     return screen.width, screen.height
-
-
-def pause(seconds: float) -> None:
-    """
-    Pause for the specified number of seconds. This is a convenience function that just calls time.sleep().
-
-    .. Warning::
-
-        This is mostly used for unit tests and is not likely to be
-        a good solution for pausing an application or game.
-
-    :param seconds: Time interval to pause in seconds.
-    """
-    time.sleep(cast(float, seconds))
 
 
 def get_window() -> "Window":

--- a/tests/unit/window/test_window.py
+++ b/tests/unit/window/test_window.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 import arcade
 import pyglet
@@ -53,6 +54,6 @@ def test_window(window: arcade.Window):
         pass
 
     arcade.schedule(f, 1/60)
-    arcade.pause(0.01)
+    time.sleep(0.01)
     arcade.unschedule(f)
     window.test()


### PR DESCRIPTION
This is super unnecessary and nothing uses it (now). Even before this PR, it was used once. So, I'm counting this as "weird cruft that should be cut in 3.0." If it's a teaching concern, I recommend to teach them to use `time.sleep()`.

## Changes
- Removes `arcade.pause()`