### PR TITLE
Speed up Color.random() via bit math

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -39,6 +39,15 @@ if TYPE_CHECKING:
 MAX_UINT24 = 0xFFFFFF
 MAX_UINT32 = 0xFFFFFFFF
 
+MASK_RGBA_R = 0xFF000000
+MASK_RGBA_G = 0x00FF0000
+MASK_RGBA_B = 0x0000FF00
+MASK_RGBA_A = 0x000000FF
+
+MASK_RGB_R = 0xFF0000
+MASK_RGB_G = 0x00FF00
+MASK_RGB_B = 0x0000FF
+
 ChannelType = TypeVar('ChannelType')
 
 RGB = Tuple[ChannelType, ChannelType, ChannelType]
@@ -408,15 +417,15 @@ class Color(RGBA255):
         :param b: Fixed value for blue channel
         :param a: Fixed value for alpha channel
         """
-        rand = random.randint(0, 0xFFFFFFFF)
+        rand = random.randint(0, MAX_UINT32)
         if r is None:
-            r = (rand & 0xFF000000) >> 24
+            r = (rand & MASK_RGBA_R) >> 24
         if g is None:
-            g = (rand & 0x00FF0000) >> 16
+            g = (rand & MASK_RGBA_G) >> 16
         if b is None:
-            b = (rand & 0x0000FF00) >> 8
+            b = (rand & MASK_RGBA_B) >> 8
         if a is None:
-            a = (rand & 0x000000FF)
+            a = (rand & MASK_RGBA_A)
 
         return cls(r, g, b, a)
 

--- a/arcade/types.py
+++ b/arcade/types.py
@@ -408,14 +408,15 @@ class Color(RGBA255):
         :param b: Fixed value for blue channel
         :param a: Fixed value for alpha channel
         """
+        rand = random.randint(0, 0xFFFFFFFF)
         if r is None:
-            r = random.randint(0, 255)
+            r = (rand & 0xFF000000) >> 24
         if g is None:
-            g = random.randint(0, 255)
+            g = (rand & 0x00FF0000) >> 16
         if b is None:
-            b = random.randint(0, 255)
+            b = (rand & 0x0000FF00) >> 8
         if a is None:
-            a = random.randint(0, 255)
+            a = (rand & 0x000000FF)
 
         return cls(r, g, b, a)
 

--- a/tests/unit/color/test_color_type.py
+++ b/tests/unit/color/test_color_type.py
@@ -206,7 +206,14 @@ RANDINT_RETURN_RESULT = 128
 
 @pytest.fixture
 def randint_is_constant(monkeypatch):
-    monkeypatch.setattr('random.randint', Mock(return_value=RANDINT_RETURN_RESULT))
+    """
+    Replace the randomized color uint32 with a known signal value.
+
+    Since the color randomization masks out channels, we use a known
+    repeated value (128, or 0x80 in hex) to represent a channel fetched
+    from random rather than taken from user input.
+    """
+    monkeypatch.setattr('random.randint', Mock(return_value=0x80808080))
 
 
 def test_color_random(randint_is_constant):


### PR DESCRIPTION
## What?
**[Why call `randint()` four time when one time do trick?](https://www.youtube.com/watch?v=VvPaEsuz-tY)**
This PR speeds up `Color.random()` by **~250%** in local testing.
~~It uses bitmasking/bitshifting sorry~~

## Profiling
### Old (current)
*39006028 function calls in 12.579 seconds*
|ncalls       |tottime  |percall  |cumtime  |percall |filename:lineno(function)|
|-------------|---------|---------|---------|------|------------------------------------------|
|  4000000    |2.868    |0.000    |3.872    |0.000 |`random.py:235(_randbelow_with_getrandbits)`|
|  4000000    |3.810    |0.000    |8.449    |0.000 |`random.py:284(randrange)`|
|  4000000    |1.423    |0.000    |9.873    |0.000 |`random.py:358(randint)`|
|  1000000    |0.789    |0.000    |1.001    |0.000 |`types.py:108(__new__)`|
|  1000000    |1.705    |0.000   |12.579    |0.000 |`types.py:381(random)`|
|  1000000    |0.212    |0.000    |0.212    |0.000 |`{built-in method __new__ of type object at 0x00007FFB7F5D9480}`|
| 12000000    |0.768    |0.000    |0.768    |0.000 |`{built-in method _operator.index}`|
|  4000000    |0.264    |0.000    |0.264    |0.000 |`{method 'bit_length' of 'int' objects}`|
|        1    |0.000    |0.000    |0.000    |0.000 |`{method 'disable' of '_lsprof.Profiler' objects}`|
|  8006027    |0.740    |0.000    |0.740    |0.000 |`{method 'getrandbits' of '_random.Random' objects}`|

### New (PR)
*12001096 function calls in 5.101 seconds*
|ncalls     |tottime  |percall  |cumtime  |percall |`filename:lineno(function)`|
|-----------|---------|---------|---------|--------|---------------------------|
|1000000    |0.777    |0.000    |1.126    |0.000   |`random.py:235(_randbelow_with_getrandbits)`|
|1000000    |1.071    |0.000    |2.408    |0.000   |`random.py:284(randrange)`|
|1000000    |0.424    |0.000    |2.831    |0.000   |`random.py:358(randint)`|
|1000000    |0.803    |0.000    |1.004    |0.000   |`types.py:108(__new__)`|
|1000000    |1.266    |0.000    |5.101    |0.000   |`types.py:381(random)`|
|1000000    |0.200    |0.000    |0.200    |0.000   |`{built-in method __new__ of type object at 0x00007FFB7F5D9480}`|
|3000000    |0.210    |0.000    |0.210    |0.000   |`{built-in method _operator.index}`|
|1000000    |0.071    |0.000    |0.071    |0.000   |`{method 'bit_length' of 'int' objects}`|
|1          |0.000    |0.000    |0.000    |0.000   |`{method 'disable' of '_lsprof.Profiler' objects}`|
|2001095    |0.278    |0.000    |0.278    |0.000   |`{method 'getrandbits' of '_random.Random' objects}`|