### PR TITLE
Clean up arcade.Text

### DIFF
--- a/arcade/examples/asteroid_smasher.py
+++ b/arcade/examples/asteroid_smasher.py
@@ -181,14 +181,14 @@ class MyGame(arcade.Window):
         # Text fields
         self.text_score = arcade.Text(
             f"Score: {self.score}",
-            start_x=10,
-            start_y=70,
+            x=10,
+            y=70,
             font_size=13,
         )
         self.text_asteroid_count = arcade.Text(
             f"Asteroid Count: {len(self.asteroid_list)}",
-            start_x=10,
-            start_y=50,
+            x=10,
+            y=50,
             font_size=13,
         )
 

--- a/arcade/examples/camera_platform.py
+++ b/arcade/examples/camera_platform.py
@@ -79,15 +79,15 @@ class MyGame(arcade.Window):
         # Text
         self.text_fps = arcade.Text(
             "",
-            start_x=10,
-            start_y=40,
+            x=10,
+            y=40,
             color=arcade.color.BLACK,
             font_size=14,
         )
         self.text_score = arcade.Text(
             f"Score: {self.score}",
-            start_x=10,
-            start_y=20,
+            x=10,
+            y=20,
             color=arcade.color.BLACK,
             font_size=14,
         )

--- a/arcade/examples/gl/3d_sphere.py
+++ b/arcade/examples/gl/3d_sphere.py
@@ -69,32 +69,32 @@ class Sphere3D(arcade.Window):
         self.text_batch = Batch()
         self.text_cull = arcade.Text(
             "F2: Toggle cull face (True)",
-            start_x=10, start_y=10, font_size=15, color=arcade.color.WHITE,
+            x=10, y=10, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
         self.text_depth = arcade.Text(
             "F1: Toggle depth test (True)",
-            start_x=10, start_y=30, font_size=15, color=arcade.color.WHITE,
+            x=10, y=30, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
         self.text_wireframe = arcade.Text(
             "SPACE: Toggle wireframe (False)",
-            start_x=10, start_y=50, font_size=15, color=arcade.color.WHITE,
+            x=10, y=50, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
         self.text_fs = arcade.Text(
             "F: Toggle fullscreen (False)",
-            start_x=10, start_y=70, font_size=15, color=arcade.color.WHITE,
+            x=10, y=70, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
         self.text_vert_count = arcade.Text(
             "Use mouse wheel to add/remove vertices",
-            start_x=10, start_y=90, font_size=15, color=arcade.color.WHITE,
+            x=10, y=90, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
         self.text_rotate = arcade.Text(
             "Drag mouse to rotate object",
-            start_x=10, start_y=110, font_size=15, color=arcade.color.WHITE,
+            x=10, y=110, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
 

--- a/arcade/examples/music_control_demo.py
+++ b/arcade/examples/music_control_demo.py
@@ -169,7 +169,7 @@ class MyView(arcade.View):
         # This draws our UI elements
         self.ui_manager.draw()
         arcade.draw_text("Music Demo",
-                         start_x=0, start_y=self.window.height - 55,
+                         x=0, y=self.window.height - 55,
                          width=self.window.width,
                          font_size=40,
                          align="center",
@@ -180,10 +180,10 @@ class MyView(arcade.View):
             minutes = int(seconds // 60)
             seconds = int(seconds % 60)
             arcade.draw_text(f"Time: {minutes}:{seconds:02}",
-                             start_x=10, start_y=10, color=arcade.color.BLACK, font_size=24)
+                             x=10, y=10, color=arcade.color.BLACK, font_size=24)
             volume = self.media_player.volume
             arcade.draw_text(f"Volume: {volume:3.1f}",
-                             start_x=10, start_y=50, color=arcade.color.BLACK, font_size=24)
+                             x=10, y=50, color=arcade.color.BLACK, font_size=24)
 
     def on_show_view(self):
         self.window.background_color = arcade.color.ALMOND

--- a/arcade/examples/net_process_animal_facts.py
+++ b/arcade/examples/net_process_animal_facts.py
@@ -48,14 +48,14 @@ class AnimalFacts(arcade.View):
         self.loading = False
         self.text_fact = arcade.Text(
             "",
-            start_x=self.window.width / 2, start_y=self.window.height / 2 + 50,
+            x=self.window.width / 2, y=self.window.height / 2 + 50,
             width=1100, font_size=36, anchor_x="center", anchor_y="center",
             multiline=True,
         )
         self.text_info = arcade.Text(
             "Press SPACE to request new fact",
             font_size=20,
-            start_x=20, start_y=40, color=arcade.color.LIGHT_BLUE,
+            x=20, y=40, color=arcade.color.LIGHT_BLUE,
         )
         self.angle = 0  # Rotation for the spinning loading initicator
         # Keep track of time to auto request new facts

--- a/arcade/examples/platform_tutorial/10_score.py
+++ b/arcade/examples/platform_tutorial/10_score.py
@@ -128,7 +128,7 @@ class MyGame(arcade.Window):
         self.score = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/11_scene.py
+++ b/arcade/examples/platform_tutorial/11_scene.py
@@ -117,7 +117,7 @@ class MyGame(arcade.Window):
         self.score = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/12_tiled.py
+++ b/arcade/examples/platform_tutorial/12_tiled.py
@@ -100,7 +100,7 @@ class MyGame(arcade.Window):
         self.score = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/13_more_layers.py
+++ b/arcade/examples/platform_tutorial/13_more_layers.py
@@ -108,7 +108,7 @@ class MyGame(arcade.Window):
         self.score = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/14_multiple_levels.py
+++ b/arcade/examples/platform_tutorial/14_multiple_levels.py
@@ -119,7 +119,7 @@ class MyGame(arcade.Window):
         self.reset_score = True
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/15_ladders_moving_platforms.py
+++ b/arcade/examples/platform_tutorial/15_ladders_moving_platforms.py
@@ -119,7 +119,7 @@ class MyGame(arcade.Window):
         self.reset_score = True
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/16_better_input.py
+++ b/arcade/examples/platform_tutorial/16_better_input.py
@@ -125,7 +125,7 @@ class MyGame(arcade.Window):
         self.reset_score = True
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/17_animations.py
+++ b/arcade/examples/platform_tutorial/17_animations.py
@@ -202,7 +202,7 @@ class MyGame(arcade.Window):
         self.reset_score = True
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/18_enemies.py
+++ b/arcade/examples/platform_tutorial/18_enemies.py
@@ -277,7 +277,7 @@ class MyGame(arcade.Window):
         self.reset_score = True
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/19_shooting.py
+++ b/arcade/examples/platform_tutorial/19_shooting.py
@@ -290,7 +290,7 @@ class MyGame(arcade.Window):
         self.shoot_timer = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/platform_tutorial/20_views.py
+++ b/arcade/examples/platform_tutorial/20_views.py
@@ -310,7 +310,7 @@ class GameView(arcade.View):
         self.shoot_timer = 0
 
         # Initialize our arcade.Text object for score
-        self.score_text = arcade.Text(f"Score: {self.score}", start_x = 0, start_y = 5)
+        self.score_text = arcade.Text(f"Score: {self.score}", x=0, y=5)
 
         self.background_color = arcade.csscolor.CORNFLOWER_BLUE
 

--- a/arcade/examples/sprite_collect_coins.py
+++ b/arcade/examples/sprite_collect_coins.py
@@ -57,7 +57,7 @@ class MyGame(arcade.Window):
         # Reset the score and the score display
         self.score = 0
         self.score_display = arcade.Text(
-            text="Score: 0", start_x=10, start_y=20,
+            text="Score: 0", x=10, y=20,
             color=arcade.color.WHITE, font_size=14)
 
         # Set up the player

--- a/arcade/examples/sprite_tiled_map.py
+++ b/arcade/examples/sprite_tiled_map.py
@@ -68,15 +68,15 @@ class MyGame(arcade.Window):
         # Text
         self.fps_text = arcade.Text(
             "",
-            start_x=10,
-            start_y=40,
+            x=10,
+            y=40,
             color=arcade.color.BLACK,
             font_size=14
         )
         self.distance_text = arcade.Text(
             "0.0",
-            start_x=10,
-            start_y=20,
+            x=10,
+            y=20,
             color=arcade.color.BLACK,
             font_size=14,
         )

--- a/arcade/examples/template_platformer.py
+++ b/arcade/examples/template_platformer.py
@@ -126,8 +126,8 @@ class MyGame(arcade.Window):
         # Draw our score on the screen, scrolling it with the viewport
         score_text = f"Score: {self.score}"
         arcade.draw_text(score_text,
-                         start_x=10,
-                         start_y=10,
+                         x=10,
+                         y=10,
                          color=arcade.csscolor.WHITE,
                          font_size=18)
 

--- a/arcade/examples/timer.py
+++ b/arcade/examples/timer.py
@@ -21,8 +21,8 @@ class MyGame(arcade.Window):
         self.total_time = 0.0
         self.timer_text = arcade.Text(
             text="00:00:00",
-            start_x=SCREEN_WIDTH // 2,
-            start_y=SCREEN_HEIGHT // 2 - 50,
+            x=SCREEN_WIDTH // 2,
+            y=SCREEN_HEIGHT // 2 - 50,
             color=arcade.color.WHITE,
             font_size=100,
             anchor_x="center",

--- a/arcade/experimental/sprite_depth_cosine.py
+++ b/arcade/experimental/sprite_depth_cosine.py
@@ -43,7 +43,7 @@ class MyGame(arcade.Window):
         self.use_depth: bool = True
         self.text_use_depth = arcade.Text(
             "SPACE: Toggle depth testing (True)",
-            start_x=10, start_y=30, font_size=15, color=arcade.color.WHITE,
+            x=10, y=30, font_size=15, color=arcade.color.WHITE,
             batch=self.text_batch
         )
 

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -98,8 +98,8 @@ class UILabel(UIWidget):
 
         # Use Arcade Text wrapper of pyglet.Label for text rendering
         self.label = arcade.Text(
-            start_x=0,
-            start_y=0,
+            x=0,
+            y=0,
             text=text,
             font_name=font_name,
             font_size=font_size,
@@ -136,6 +136,7 @@ class UILabel(UIWidget):
             self.label.height = int(height)
 
         bind(self, "rect", self._update_layout)
+        self._update_size_hint_min()
 
     def fit_content(self):
         """
@@ -164,6 +165,7 @@ class UILabel(UIWidget):
         if self.label.text != value:
             self.label.text = value
             self._update_layout()
+            self._update_size_hint_min()
             self.trigger_full_render()
 
     def _update_layout(self):
@@ -175,6 +177,9 @@ class UILabel(UIWidget):
             layout.position = 0, 0, 0  # layout always drawn in scissor box
             layout.width = int(self.content_width)
             layout.height = int(self.content_height)
+
+    def _update_size_hint_min(self):
+        self.size_hint_min = self.label.content_width, self.label.content_height
 
     def do_render(self, surface: Surface):
         self.prepare_render(surface)
@@ -249,11 +254,11 @@ class UITextWidget(UIAnchorLayout):
         If you want a scrollable text widget, please use :py:class:`~arcade.gui.UITextArea`
         instead.
         """
-        return self.label.multiline
+        return self._label.label.multiline
 
     @multiline.setter
     def multiline(self, value):
-        self.label.multiline = value
+        self._label.label.multiline = value
         self.ui_label.fit_content()
         self.trigger_render()
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -202,6 +202,9 @@ class Text:
         if align not in ("left", "center", "right"):
             raise ValueError("The 'align' parameter must be equal to 'left', 'right', or 'center'.")
 
+        if multiline and width == 0:
+            raise ValueError("The 'width' parameter must be set when 'multiline' is True.")
+
         adjusted_font = _attempt_font_name_resolution(font_name)
         self._label = pyglet.text.Label(
             text=text,

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -845,11 +845,12 @@ def draw_text(
     key = f"{font_size}{font_name}{bold}{italic}{anchor_x}{anchor_y}{align}{width}{rotation}"
     ctx = arcade.get_window().ctx
     label = ctx.label_cache.get(key)
-    if align != "center" and align != "left" and align != "right":
+
+    if align not in ("left", "center", "right"):
         raise ValueError("The 'align' parameter must be equal to 'left', 'right', or 'center'.")
 
-    # if align != "left":
-    #     multiline = True
+    if multiline and width == 0:
+        raise ValueError("The 'width' parameter must be set when 'multiline' is True.")
 
     if not label:
         adjusted_font = _attempt_font_name_resolution(font_name)

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -664,7 +664,7 @@ def create_text_sprite(
 @warning(
     message="draw_text is an extremely slow function for displaying text. Consider using Text objects instead.",
     warning_type=PerformanceWarning,
-    )
+)
 def draw_text(
     text: Any,
     x: int,

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -9,10 +9,9 @@ from typing import Any, Optional, Tuple, Union
 import pyglet
 
 import arcade
-from arcade.types import Color, Point, RGBA255, Point3, RGBOrA255
 from arcade.resources import resolve
+from arcade.types import Color, Point, RGBA255, Point3, RGBOrA255
 from arcade.utils import PerformanceWarning, warning
-
 
 __all__ = [
     "load_font",
@@ -129,9 +128,9 @@ class Text:
     explanation for how to use each of them. For example code, see :ref:`drawing_text_objects`.
 
     :param text: Initial text to display. Can be an empty string
-    :param start_x: x position to align the text's anchor point with
-    :param start_y: y position to align the text's anchor point with
-    :param start_z: z position to align the text's anchor point with
+    :param x: x position to align the text's anchor point with
+    :param y: y position to align the text's anchor point with
+    :param z: z position to align the text's anchor point with
     :param color: Color of the text as an RGBA tuple or a
         :py:class:`~arcade.types.Color` instance.
     :param font_size: Size of the text in points
@@ -153,8 +152,8 @@ class Text:
 
     By default, the text is placed so that:
 
-    - the left edge of its bounding box is at ``start_x``
-    - its baseline is at ``start_y``
+    - the left edge of its bounding box is at ``x``
+    - its baseline is at ``y``
 
     The baseline is located along the line the bottom of the text would
     be written on, excluding letters with tails such as y:
@@ -180,8 +179,8 @@ class Text:
     def __init__(
         self,
         text: str,
-        start_x: int,
-        start_y: int,
+        x: int,
+        y: int,
         color: RGBOrA255 = arcade.color.WHITE,
         font_size: float = 12,
         width: Optional[int] = 0,
@@ -195,20 +194,20 @@ class Text:
         rotation: float = 0,
         batch: Optional[pyglet.graphics.Batch] = None,
         group: Optional[pyglet.graphics.Group] = None,
-        start_z: int = 0
+        z: int = 0
     ):
         # Raises a RuntimeError if no window for better user feedback
         arcade.get_window()
 
-        if align != "center" and align != "left" and align != "right":
+        if align not in ("left", "center", "right"):
             raise ValueError("The 'align' parameter must be equal to 'left', 'right', or 'center'.")
 
         adjusted_font = _attempt_font_name_resolution(font_name)
         self._label = pyglet.text.Label(
             text=text,
-            x=start_x,
-            y=start_y,
-            z=start_z,
+            x=x,
+            y=y,
+            z=z,
             font_name=adjusted_font,
             font_size=font_size,
             anchor_x=anchor_x,
@@ -219,7 +218,7 @@ class Text:
             bold=bold,
             italic=italic,
             multiline=multiline,
-            rotation=rotation, # type: ignore  # pending https://github.com/pyglet/pyglet/issues/843
+            rotation=rotation,  # type: ignore  # pending https://github.com/pyglet/pyglet/issues/843
             batch=batch,
             group=group
         )
@@ -311,17 +310,17 @@ class Text:
         self._label.y = y
 
     @property
-    def start_z(self) -> float:
+    def z(self) -> float:
         """
         Get or set the z position of the label
         """
         return self._label.z
 
-    @start_z.setter
-    def start_z(self, start_z: float):
-        if self._label.z == start_z:
+    @z.setter
+    def z(self, z: float):
+        if self._label.z == z:
             return
-        self._label.z = start_z
+        self._label.z = z
 
     @property
     def font_name(self) -> FontNameOrNames:
@@ -480,11 +479,6 @@ class Text:
 
     @align.setter
     def align(self, align: str):
-
-        # duplicates the logic used in the rest of this module
-        if align != "left":
-            self.multiline = True
-
         self._label.set_style("align", align)
 
     @property
@@ -534,10 +528,10 @@ class Text:
         _draw_pyglet_label(self._label)
 
     def draw_debug(
-        self,
-        anchor_color: RGBA255 = arcade.color.RED,
-        background_color: RGBA255 = arcade.color.DARK_BLUE,
-        outline_color: RGBA255 = arcade.color.WHITE,
+            self,
+            anchor_color: RGBA255 = arcade.color.RED,
+            background_color: RGBA255 = arcade.color.DARK_BLUE,
+            outline_color: RGBA255 = arcade.color.WHITE,
     ) -> None:
         """
         Draw test with debug geometry showing the content
@@ -583,18 +577,18 @@ class Text:
 
 
 def create_text_sprite(
-    text: str,
-    color: RGBA255 = arcade.color.WHITE,
-    font_size: float = 12,
-    width: int = 0,
-    align: str = "left",
-    font_name: FontNameOrNames = ("calibri", "arial"),
-    bold: bool = False,
-    italic: bool = False,
-    anchor_x: str = "left",
-    multiline: bool = False,
-    texture_atlas: Optional[arcade.TextureAtlas] = None,
-    background_color: Optional[RGBA255] = None,
+        text: str,
+        color: RGBA255 = arcade.color.WHITE,
+        font_size: float = 12,
+        width: int = 0,
+        align: str = "left",
+        font_name: FontNameOrNames = ("calibri", "arial"),
+        bold: bool = False,
+        italic: bool = False,
+        anchor_x: str = "left",
+        multiline: bool = False,
+        texture_atlas: Optional[arcade.TextureAtlas] = None,
+        background_color: Optional[RGBA255] = None,
 ) -> arcade.Sprite:
     """
     Creates a sprite containing text based off of :py:class:`~arcade.Text`.
@@ -629,8 +623,8 @@ def create_text_sprite(
     """
     text_object = Text(
         text,
-        start_x=0,
-        start_y=0,
+        x=0,
+        y=0,
         color=color,
         font_size=font_size,
         width=width,
@@ -667,23 +661,23 @@ def create_text_sprite(
 @warning(
     message="draw_text is an extremely slow function for displaying text. Consider using Text objects instead.",
     warning_type=PerformanceWarning,
-    )
+)
 def draw_text(
-    text: Any,
-    start_x: int,
-    start_y: int,
-    color: RGBA255 = arcade.color.WHITE,
-    font_size: float = 12,
-    width: int = 0,
-    align: str = "left",
-    font_name: FontNameOrNames = ("calibri", "arial"),
-    bold: bool = False,
-    italic: bool = False,
-    anchor_x: str = "left",
-    anchor_y: str = "baseline",
-    multiline: bool = False,
-    rotation: float = 0,
-    start_z: int = 0
+        text: Any,
+        x: int,
+        y: int,
+        color: RGBA255 = arcade.color.WHITE,
+        font_size: float = 12,
+        width: int = 0,
+        align: str = "left",
+        font_name: FontNameOrNames = ("calibri", "arial"),
+        bold: bool = False,
+        italic: bool = False,
+        anchor_x: str = "left",
+        anchor_y: str = "baseline",
+        multiline: bool = False,
+        rotation: float = 0,
+        z: int = 0
 ):
     """
     A simple way for beginners to draw text.
@@ -708,9 +702,9 @@ def draw_text(
     Example code can be found at :ref:`drawing_text`.
 
     :param text: Text to display. The object passed in will be converted to a string
-    :param start_x: x position to align the text's anchor point with
-    :param start_y: y position to align the text's anchor point with
-    :param start_z: z position to align the text's anchor point with
+    :param x: x position to align the text's anchor point with
+    :param y: y position to align the text's anchor point with
+    :param z: z position to align the text's anchor point with
     :param color: Color of the text as an RGBA tuple or
         :py:class:`~arcade.types.Color` instance.
     :param font_size: Size of the text in points
@@ -726,8 +720,8 @@ def draw_text(
 
     By default, the text is placed so that:
 
-    - the left edge of its bounding box is at ``start_x``
-    - its baseline is at ``start_y``
+    - the left edge of its bounding box is at ``x``
+    - its baseline is at ``y``
 
     The baseline of text is the line it would be written on:
 
@@ -750,11 +744,11 @@ def draw_text(
     ``anchor_x`` and ``anchor_y`` specify how to calculate the anchor point,
     which affects how the text is:
 
-    - Placed relative to ``start_x`` and ``start_y``
+    - Placed relative to ``x`` and ``y``
     - Rotated
 
-    By default, the text is drawn so that ``start_x`` is at the left of
-    the text's bounding box and ``start_y`` is at the baseline.
+    By default, the text is drawn so that ``x`` is at the left of
+    the text's bounding box and ``y`` is at the baseline.
 
     You can set a custom anchor point by passing combinations of the
     following values for ``anchor_x`` and ``anchor_y``:
@@ -768,15 +762,15 @@ def draw_text(
           - Anchor Position
 
         * - ``"left"`` `(default)`
-          - Text drawn with its left side at ``start_x``
+          - Text drawn with its left side at ``x``
           - Anchor point on the left side of the text's bounding box
 
         * - ``"center"``
-          - Text drawn horizontally centered on ``start_x``
+          - Text drawn horizontally centered on ``x``
           - Anchor point at horizontal center of text's bounding box
 
         * - ``"right"``
-          - Text drawn with its right side at ``start_x``
+          - Text drawn with its right side at ``x``
           - Anchor placed on the right side of the text's bounding box
 
 
@@ -789,21 +783,21 @@ def draw_text(
           - Anchor Position
 
         * - ``"baseline"`` `(default)`
-          - Text drawn with baseline on ``start_y``.
+          - Text drawn with baseline on ``y``.
           - Anchor placed at the text rendering baseline
 
         * - ``"top"``
-          - Text drawn with its top aligned with ``start_y``
+          - Text drawn with its top aligned with ``y``
           - Anchor point placed at the top of the text
 
         * - ``"bottom"``
-          - Text drawn with its absolute bottom aligned with ``start_y``,
+          - Text drawn with its absolute bottom aligned with ``y``,
             including the space for tails on letters such as y and g
           - Anchor point placed at the bottom of the text after the
             space allotted for letters such as y and g
 
         * - ``"center"``
-          - Text drawn with its vertical center on ``start_y``
+          - Text drawn with its vertical center on ``y``
           - Anchor placed at the vertical center of the text
 
 
@@ -830,8 +824,8 @@ def draw_text(
            the text value, styling, as well as values for ``anchor_x``
            and ``anchor_y``
 
-    2. The text is placed so its anchor point is at ``(start_x,
-       start_y))``
+    2. The text is placed so its anchor point is at ``(x,
+       y))``
 
     3. The text is rotated around its anchor point before finally
        being drawn
@@ -851,17 +845,17 @@ def draw_text(
     if align != "center" and align != "left" and align != "right":
         raise ValueError("The 'align' parameter must be equal to 'left', 'right', or 'center'.")
 
-    if align != "left":
-        multiline = True
+    # if align != "left":
+    #     multiline = True
 
     if not label:
         adjusted_font = _attempt_font_name_resolution(font_name)
 
         label = arcade.Text(
             text=str(text),
-            start_x=start_x,
-            start_y=start_y,
-            start_z=start_z,
+            x=x,
+            y=y,
+            z=z,
             font_name=adjusted_font,
             font_size=font_size,
             anchor_x=anchor_x,
@@ -879,8 +873,8 @@ def draw_text(
     # These updates are quite expensive
     if label.text != text:
         label.text = str(text)
-    if label.x != start_x or label.y != start_y or label.start_z != start_z:
-        label.position = start_x, start_y, start_z  # type: ignore
+    if label.x != x or label.y != y or label.z != z:
+        label.position = x, y, z  # type: ignore
     if label.color != color:
         label.color = color
     if label.rotation != rotation:

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -531,10 +531,10 @@ class Text:
         _draw_pyglet_label(self._label)
 
     def draw_debug(
-            self,
-            anchor_color: RGBA255 = arcade.color.RED,
-            background_color: RGBA255 = arcade.color.DARK_BLUE,
-            outline_color: RGBA255 = arcade.color.WHITE,
+        self,
+        anchor_color: RGBA255 = arcade.color.RED,
+        background_color: RGBA255 = arcade.color.DARK_BLUE,
+        outline_color: RGBA255 = arcade.color.WHITE,
     ) -> None:
         """
         Draw test with debug geometry showing the content
@@ -580,18 +580,18 @@ class Text:
 
 
 def create_text_sprite(
-        text: str,
-        color: RGBA255 = arcade.color.WHITE,
-        font_size: float = 12,
-        width: int = 0,
-        align: str = "left",
-        font_name: FontNameOrNames = ("calibri", "arial"),
-        bold: bool = False,
-        italic: bool = False,
-        anchor_x: str = "left",
-        multiline: bool = False,
-        texture_atlas: Optional[arcade.TextureAtlas] = None,
-        background_color: Optional[RGBA255] = None,
+    text: str,
+    color: RGBA255 = arcade.color.WHITE,
+    font_size: float = 12,
+    width: int = 0,
+    align: str = "left",
+    font_name: FontNameOrNames = ("calibri", "arial"),
+    bold: bool = False,
+    italic: bool = False,
+    anchor_x: str = "left",
+    multiline: bool = False,
+    texture_atlas: Optional[arcade.TextureAtlas] = None,
+    background_color: Optional[RGBA255] = None,
 ) -> arcade.Sprite:
     """
     Creates a sprite containing text based off of :py:class:`~arcade.Text`.
@@ -664,23 +664,23 @@ def create_text_sprite(
 @warning(
     message="draw_text is an extremely slow function for displaying text. Consider using Text objects instead.",
     warning_type=PerformanceWarning,
-)
+    )
 def draw_text(
-        text: Any,
-        x: int,
-        y: int,
-        color: RGBA255 = arcade.color.WHITE,
-        font_size: float = 12,
-        width: int = 0,
-        align: str = "left",
-        font_name: FontNameOrNames = ("calibri", "arial"),
-        bold: bool = False,
-        italic: bool = False,
-        anchor_x: str = "left",
-        anchor_y: str = "baseline",
-        multiline: bool = False,
-        rotation: float = 0,
-        z: int = 0
+    text: Any,
+    x: int,
+    y: int,
+    color: RGBA255 = arcade.color.WHITE,
+    font_size: float = 12,
+    width: int = 0,
+    align: str = "left",
+    font_name: FontNameOrNames = ("calibri", "arial"),
+    bold: bool = False,
+    italic: bool = False,
+    anchor_x: str = "left",
+    anchor_y: str = "baseline",
+    multiline: bool = False,
+    rotation: float = 0,
+    z: int = 0
 ):
     """
     A simple way for beginners to draw text.

--- a/doc/programming_guide/release_notes.rst
+++ b/doc/programming_guide/release_notes.rst
@@ -48,6 +48,8 @@ API in a way that is not compatible with how it was used in 2.6.
 * The GUI package has been changed significantly.
 * Buffered shapes (shape list items) have been moved to their own sub-module.
 * `use_spatial_hash` parameter for `SpriteList` and `TileMap` is now a `bool` instead of `Optional[bool]`
+* :py:meth:`~arcade.draw_text()` and :py:class:`~arcade.text.Text` arguments have changed. The `start_x` and `start_y` parameters have been
+  removed. The `x` and `y` parameters are now required. `align!=left` does not interfere with `multiline` parameter anymore.
 * GUI
 
   * Removed :py:class:`~arcade.gui.widgets.UIWrapper` this is now general available in :py:class:`~arcade.gui.widgets.UILayout`

--- a/tests/unit/text/test_text.py
+++ b/tests/unit/text/test_text.py
@@ -152,7 +152,3 @@ def test_text_instances(window):
         text.draw()
 
     window.flip()
-
-
-# def test_create_text_sprite(window):
-#     pass

--- a/tests/unit/text/test_text_error_handling.py
+++ b/tests/unit/text/test_text_error_handling.py
@@ -1,0 +1,17 @@
+import pytest
+
+import arcade
+
+
+def test_text_instance_raise_multiline_error(window):
+    with pytest.raises(ValueError) as e:
+        _ = arcade.Text("Initial text", 0, 0, multiline=True)
+
+    assert e.value.args[0] == "The 'width' parameter must be set when 'multiline' is True."
+
+
+def test_text_function_raise_multiline_error(window):
+    with pytest.raises(ValueError) as e:
+        _ = arcade.draw_text("Initial text", 0, 0, multiline=True)
+
+    assert e.value.args[0] == "The 'width' parameter must be set when 'multiline' is True."

--- a/tests/unit/text/test_text_instance_properties.py
+++ b/tests/unit/text/test_text_instance_properties.py
@@ -66,8 +66,8 @@ def test_text_instance_align_not_left(ctx, align):
 
     assert instance.align == align
 
-    # Should be true whenever align != "left", per logic from draw_text
-    assert instance.multiline
+    # Multiline value should not be influenced by align like in 2.X
+    assert instance.multiline is False
 
 
 def test_text_instance_position_setter(instance):


### PR DESCRIPTION
Change arcade.Text and draw_text to match general argument names,
remove interference between align and multiline.

Fix:
- #933 
- #1839 
- https://github.com/pyglet/pyglet/issues/915

Covers PR:
- #1864 