### PR TITLE
Add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+default_language_version:
+    python: python3.9
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.2.2'
+    hooks:
+      - id: ruff
+        types_or: [ python ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python ]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.8.0'
+    hooks:
+    -   id: mypy
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.351
+    hooks:
+    - id: pyright
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,7 +6,7 @@ Arcade welcomes contributions, including:
 * `Bug reports & feature suggestions <https://github.com/pythonarcade/arcade/issues>`_
 * Bug fixes
 * Implementations of requested features
-* Corrections & additions to the documentation 
+* Corrections & additions to the documentation
 * Improvements to the tests
 
 If you're looking for a way to contribute, try checking
@@ -116,7 +116,7 @@ If you want to run either of these tools individually, you can do
 
     python make.py ruff
 
-or 
+or
 
 .. code-block:: shell
 
@@ -127,6 +127,24 @@ Now you run the framework's unit tests with the following command:
 .. code-block:: shell
 
     python make.py test
+
+Use pre-commit to automatically run tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use `pre-commit <https://pre-commit.com/>`_ to automatically run lint, ruff, mypy, and pyright against your changes before you commit them.
+To install pre-commit, run the following command:
+
+.. code-block:: shell
+
+    pip install pre-commit
+    # or on Mac
+    brew install pre-commit
+
+Then, run the following command to install the pre-commit hooks:
+
+.. code-block:: shell
+
+    pre-commit install
 
 Building & Testing Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This adds pre-commit hooks for
- ruff
- ruff formater
- mypy
- pyright
- black

These can be optionally enabled following the contribution guide.