### PR TITLE
Fix #1999

### DIFF
--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -59,7 +59,7 @@ class Rect(NamedTuple):
 
     def collide_with_point(self, x, y):
         left, bottom, width, height = self
-        return left < x < left + width and bottom < y < bottom + height
+        return left <= x <= left + width and bottom <= y <= bottom + height
 
     def scale(self, scale: float) -> "Rect":
         """Returns a new rect with scale applied"""

--- a/tests/unit/gui/test_rect.py
+++ b/tests/unit/gui/test_rect.py
@@ -166,3 +166,12 @@ def test_rect_union():
 
     # THEN
     assert new_rect == (0, 0, 20, 10)
+
+
+def test_collide_with_point():
+    rect = Rect(0, 0, 100, 100)
+
+    assert rect.collide_with_point(0, 0)
+    assert rect.collide_with_point(50, 50)
+    assert rect.collide_with_point(100, 100)
+    assert not rect.collide_with_point(150, 150)


### PR DESCRIPTION
Rect.collide_with_point did not match if the point was on the outline,
which lead to the SubMenu to not catch mouse events with x or y == 0 values.