### PR TITLE
Pytest changes to better support arcade-accelerate

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
+import gc
 import os
 from pathlib import Path
-import gc
 
 if os.environ.get("ARCADE_PYTEST_USE_RUST"):
-    import arcade_accelerate # pyright: ignore [reportMissingImports]
+    import arcade_accelerate  # pyright: ignore [reportMissingImports]
     arcade_accelerate.bootstrap()
 
 import pytest
@@ -21,6 +21,9 @@ def create_window():
     if not WINDOW:
         WINDOW = arcade.Window(title="Testing", vsync=False, antialiasing=False)
         WINDOW.set_vsync(False)
+        # This value is being monkey-patched into the Window class so that tests can identify if we are using
+        # arcade-accelerate easily in case they need to disable something when it is enabled.
+        WINDOW.using_accelerate = os.environ.get("ARCADE_PYTEST_USE_RUST")  # pyright: ignore
     return WINDOW
 
 

--- a/tests/unit/hitbox/test_hitbox.py
+++ b/tests/unit/hitbox/test_hitbox.py
@@ -49,4 +49,4 @@ def test_create_rotatable():
 
     rot_p = rot.get_adjusted_points()
     for i, (a, b) in enumerate(zip(rot_90, rot_p)):
-        assert a == pytest.approx(b), f"[{i}] {a} != {b}"
+        assert a == pytest.approx(b, abs = 1e-6), f"[{i}] {a} != {b}"

--- a/tests/unit/sprite/test_sprite_collision.py
+++ b/tests/unit/sprite/test_sprite_collision.py
@@ -1,4 +1,5 @@
 import pytest
+
 import arcade
 
 
@@ -183,10 +184,14 @@ def test_check_for_collision_with_list(window):
             sprite.position = x * 50, y * 50
             sl.append(sprite)
 
-    with pytest.raises(TypeError):
-        arcade.check_for_collision_with_list("moo", sl)
-    with pytest.raises(TypeError):
-        arcade.check_for_collision_with_list(a, "moo")
+    # There's no good way to perform this test with arcade-accelerate enabled.
+    # It causes a very different exception that without the inclusion of pyo3
+    # into Arcade would be next to impossible to test for in a sane way.
+    if not window.using_accelerate:
+        with pytest.raises(TypeError):
+            arcade.check_for_collision_with_list("moo", sl)
+        with pytest.raises(TypeError):
+            arcade.check_for_collision_with_list(a, "moo")
 
     a.position = 100, 100
     assert len(arcade.check_for_collision_with_list(a, sl)) == 1
@@ -213,8 +218,12 @@ def test_check_for_collision_with_lists(window):
             sl.append(sprite)
             sls.append(sl)
 
-    with pytest.raises(TypeError):
-        arcade.check_for_collision_with_lists("moo", sl)
+    # There's no good way to perform this test with arcade-accelerate enabled.
+    # It causes a very different exception that without the inclusion of pyo3
+    # into Arcade would be next to impossible to test for in a sane way.
+    if not window.using_accelerate:
+        with pytest.raises(TypeError):
+            arcade.check_for_collision_with_lists("moo", sl)
 
     a.position = 100, 100
     assert len(arcade.check_for_collision_with_lists(a, sls)) == 1


### PR DESCRIPTION
Just a few small things for better compatibility with arcade-accelerate. Mostly just checking if it's there for tests that don't make sense for it, and some float precision compatibility problems.