### PR TITLE
Quick nuitka fix

### DIFF
--- a/arcade/resources/__init__.py
+++ b/arcade/resources/__init__.py
@@ -95,6 +95,12 @@ def resolve(path: Union[str, Path]) -> Path:
         else:
             path = Path(path)
 
+    try:
+        path = Path(path.resolve(strict=True))
+    except Exception:
+        print("WARNING: This is due to an issue caused by Nuitka overriding strings into janky path object")
+        path = Path(path.absolute())
+
     # Always return absolute paths
     # Check for the existence of the file and provide useful feedback to
     # avoid deep stack trace into pathlib

--- a/arcade/resources/__init__.py
+++ b/arcade/resources/__init__.py
@@ -98,7 +98,7 @@ def resolve(path: Union[str, Path]) -> Path:
     try:
         path = Path(path.resolve(strict=True))
     except AttributeError:
-        # WARNING: This is due to an issue caused by Nuitka overriding strings into janky path objec
+        # WARNING: This is due to an issue caused by Nuitka overriding strings into janky path object
         path = Path(path.absolute())
 
     # Always return absolute paths

--- a/arcade/resources/__init__.py
+++ b/arcade/resources/__init__.py
@@ -97,8 +97,8 @@ def resolve(path: Union[str, Path]) -> Path:
 
     try:
         path = Path(path.resolve(strict=True))
-    except Exception:
-        print("WARNING: This is due to an issue caused by Nuitka overriding strings into janky path object")
+    except AttributeError:
+        # WARNING: This is due to an issue caused by Nuitka overriding strings into janky path objec
         path = Path(path.absolute())
 
     # Always return absolute paths


### PR DESCRIPTION
Nuitka automatically converts strings which look like paths ("C:/foo/bar/file.type") into a weird class. This PR adds a small try block to catch this issue in the resolver. It does not fix the issue everywhere, but it should work for the most part.