### PR TITLE
Fix deprecated linter invocation and bump pyright version

### DIFF
--- a/make.py
+++ b/make.py
@@ -45,7 +45,7 @@ FULL_BUILD_DIR    = PROJECT_ROOT / FULL_BUILD_PREFIX
 
 # Linting
 RUFF        = "ruff"
-RUFFOPTS    = ["arcade"]
+RUFFOPTS    = ["check", "arcade"]
 MYPY        = "mypy"
 MYPYOPTS    = ["arcade"]
 PYRIGHT     = "pyright"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "pygments==2.16.1",
     "docutils==0.20.1",
     "furo",
-    "pyright==1.1.337",
+    "pyright==1.1.352",
     "pyyaml==6.0.1",
     "sphinx==7.2.2",
     "sphinx-autobuild==2021.3.14",


### PR DESCRIPTION
### Changes

* Update `./make.py` to use `ruff check` instead of the deprecated `ruff`
* Bump pyright to latest

### Why

1. Fix deprecation & old version warnings
2. Cleaner CI output since it uses `./make.py ruff` instead of a direct call