### PR TITLE
Fix homepage css

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -4,61 +4,110 @@ body {
 /* TOC - Main landing page */
 /* Show two columns if screen is wide enough */
 @media screen and (min-width: 700px) {
+    /* For regular items */
     .toctree-wrapper > ul {
         columns: 2;
     }
+    /* For Social and Learning Resources sections */
     .toc-outside-links {
         columns: 2;
     }
 }
-.item-framing-box {
+
+/* Wrap individual main page items for easier group manipulation
+ of contents and images. See PR #2027 for main page css changes */
+.main-page-item-wrapper {
     align-items: flex-start;
     display: flex;
     margin: 10px;
 }
-.item-framing-box .single-col-box {
+.main-page-item-wrapper > .toctree-wrapper {
     width: 100%;
 }
-.item-framing-box .single-col-box ul {
+
+/* single-col-box for items on main page with 2 bullet points, use if
+ wanting to avoid having 2 columns with 1 item each inside */
+.main-page-item-wrapper > .single-col-box {
+    width: 100%;
+}
+.main-page-item-wrapper > .single-col-box ul {
     columns: 1;
 }
-.item-framing-box-main {
-    align-items: center;
-    display: flex;
-    margin: 10px;
-}
-.item-framing-box .item-framing-sub-box {
+
+/* For Social and Learning Resources to make
+title + list appear like other categories */
+.main-page-item-wrapper > .main-page-item-sub-wrapper {
     display: flex;
     flex-direction: column;
     margin: 0px;
     width: 100%;
 }
-.item-framing-box .item-framing-title {
+.main-page-item-wrapper > .main-page-item-title {
     width: 100%;
 }
-.item-framing-title p {
+.main-page-item-title > p {
     font-size: var(--font-size--small);
     margin-bottom: 0;
     text-align: initial;
     text-transform: uppercase;
 }
-.item-framing-sub-box .toc-outside-links {
+.main-page-item-sub-wrapper > .toc-outside-links {
     margin-left: 0px;
     width: 100%;
 }
+
+/* Wrappers and formatting for sprinter, START HERE, github star button
+to align them neatly */
+.main-page-item-wrapper-header {
+    align-items: center;
+    display: flex;
+    margin: 10px;
+}
+.main-page-box {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.main-page-box > .main-page-link {
+    display: flex;
+    width: 100%;
+}
+.main-page-box > .main-page-link a {
+    display: flex;
+}
 .sprinter-box {
-    width: 55px;
+    margin-left: 10px;
     height: 55px;
     display: flex;
 }
 .start-here-box {
-    width: 100%;
     align-items: center;
     display: flex;
+    margin-left: -10px;
 }
-.toctree-wrapper {
+#the-python-arcade-library h2 {
+    font-size: var(--font-size--small);
+    font-weight: 400;
+    margin-bottom: 0;
+    margin-top: .5rem;
+    text-align: initial;
+    text-transform: uppercase;
     width: 100%;
+    display: flex;
 }
+.main-page-box > .main-page-box-gh {
+    display: flex;
+    align-items: center;
+    margin-right: 0px;
+}
+#github-stars {
+    width: 141px;
+    height: 30px;
+    margin-bottom: -9px;
+}
+
+/* Formatting for list items */
 .toctree-l1 {
     margin-left: 5px;
 }
@@ -81,24 +130,9 @@ body {
 .toctree-wrapper a:hover {
     text-decoration: underline;
 }
-#the-python-arcade-library h2 {
-    font-size: var(--font-size--small);
-    font-weight: 400;
-    margin-bottom: 0;
-    margin-top: .5rem;
-    text-align: initial;
-    text-transform: uppercase;
-    width: 100%;
-    display: flex;
-}
 #the-python-arcade-library ul {
     margin-top: 0;
     margin-bottom: 0;
-}
-#github-stars {
-    width: 141px;
-    height: 30px;
-    margin-bottom: -9px;
 }
 .heading-icon {
     columns: 2;
@@ -154,22 +188,6 @@ img.right-image {
 .section-logo {
     width: 78px;
     padding-right: 15px;
-}
-.main-page-box {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-.main-page-box .main-page-link {
-    display: flex;
-    width: 100%;
-}
-
-.main-page-box .main-page-box-gh {
-    display: flex;
-    align-items: center;
-    margin-right: 0px;
 }
 .vimeo-video {
     border: 0;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -7,15 +7,64 @@ body {
     .toctree-wrapper > ul {
         columns: 2;
     }
+    .toc-outside-links {
+        columns: 2;
+    }
+}
+.item-framing-box {
+    align-items: flex-start;
+    display: flex;
+    margin: 10px;
+}
+.item-framing-box .single-col-box {
+    width: 100%;
+}
+.item-framing-box .single-col-box ul {
+    columns: 1;
+}
+.item-framing-box-main {
+    align-items: center;
+    display: flex;
+    margin: 10px;
+}
+.item-framing-box .item-framing-sub-box {
+    display: flex;
+    flex-direction: column;
+    margin: 0px;
+    width: 100%;
+}
+.item-framing-box .item-framing-title {
+    width: 100%;
+}
+.item-framing-title p {
+    font-size: var(--font-size--small);
+    margin-bottom: 0;
+    text-align: initial;
+    text-transform: uppercase;
+}
+.item-framing-sub-box .toc-outside-links {
+    margin-left: 0px;
+    width: 100%;
+}
+.sprinter-box {
+    width: 55px;
+    height: 55px;
+    display: flex;
+}
+.start-here-box {
+    width: 100%;
+    align-items: center;
+    display: flex;
+}
+.toctree-wrapper {
+    width: 100%;
 }
 .toctree-l1 {
     margin-left: 5px;
 }
-.toc-outside-links {
-    margin-left: 35px;
-}
 .toc-outside-links ul {
-    columns: 2;
+    width: fit-content;
+    columns: 1;
 }
 .toc-outside-links li p, .toc-outside-links ul li {
     margin-left: 5px;
@@ -39,15 +88,17 @@ body {
     margin-top: .5rem;
     text-align: initial;
     text-transform: uppercase;
+    width: 100%;
+    display: flex;
 }
 #the-python-arcade-library ul {
     margin-top: 0;
     margin-bottom: 0;
 }
 #github-stars {
-    width: 170px;
+    width: 141px;
     height: 30px;
-    margin-bottom: -18px;
+    margin-bottom: -9px;
 }
 .heading-icon {
     columns: 2;
@@ -104,8 +155,21 @@ img.right-image {
     width: 78px;
     padding-right: 15px;
 }
-.main-page-table {
+.main-page-box {
     width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.main-page-box .main-page-link {
+    display: flex;
+    width: 100%;
+}
+
+.main-page-box .main-page-box-gh {
+    display: flex;
+    align-items: center;
+    margin-right: 0px;
 }
 .vimeo-video {
     border: 0;

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,13 +20,7 @@ The Python Arcade Library
       game without learning a complex framework.
    </p>
 
-.. container:: item-framing-box-main
-
-    .. image:: images/woman_sprinter.svg
-        :width: 48
-        :alt: Start Here
-        :class: heading-icon
-        :target: get_started.html
+.. container:: main-page-item-wrapper-header
 
     .. raw:: html
 
@@ -34,11 +28,14 @@ The Python Arcade Library
             <div class="main-page-link">
                 <h2 id="the-python-arcade-library">
                     <a class="reference internal" href="get_started/get_started.html">
+                        <div class="heading-icon sprinter-box">
+                            <img alt="Start Here" src="_images/woman_sprinter.svg" width="48">
+                        </div>
                         <div class="start-here-box">
                             <span class="std std-ref">Start Here</span>
                         </div>
+                        <a class="headerlink" href="#go-get-started-here" title="Permalink to this headline">¶</a>
                     </a>
-                    <a class="headerlink" href="#go-get-started-here" title="Permalink to this headline">¶</a>
                 </h2>
             </div>
             <div class="main-page-box-gh">
@@ -46,7 +43,7 @@ The Python Arcade Library
             </div>
         </div>
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/example_games.svg
        :alt: Get Started icon
@@ -61,7 +58,7 @@ The Python Arcade Library
        get_started/install/index
        get_started/how_to_get_help
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/example_code.svg
        :alt: Example Code
@@ -75,7 +72,7 @@ The Python Arcade Library
        example_code/game_jam_2020
        example_code/sample_games
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/learn.svg
        :alt: Tutorials
@@ -96,7 +93,7 @@ The Python Arcade Library
        tutorials/menu/index
        tutorials/framebuffer/index
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/example_games.svg
        :alt: Programming guide icon
@@ -121,7 +118,7 @@ The Python Arcade Library
        programming_guide/vsync
        programming_guide/pygame_comparison
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/API.svg
        :alt: API icon
@@ -135,7 +132,7 @@ The Python Arcade Library
        Reference<api_docs/arcade>
        api_docs/resources
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/source.svg
        :alt: Source icon
@@ -149,7 +146,7 @@ The Python Arcade Library
        programming_guide/release_notes
        License <https://github.com/pythonarcade/arcade/blob/development/license.rst>
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. container:: single-col-box
 
@@ -164,15 +161,15 @@ The Python Arcade Library
            contributing_guide/index
            contributing_guide/release_checklist
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/social.svg
        :alt: Social icon
        :class: heading-icon
 
-    .. container:: item-framing-sub-box
+    .. container:: main-page-item-sub-wrapper
 
-        .. container:: item-framing-title
+        .. container:: main-page-item-title
 
             Social
 
@@ -185,15 +182,15 @@ The Python Arcade Library
             * `Facebook @ArcadeLibrary <https://www.facebook.com/ArcadeLibrary/>`_
             * :ref:`diversity_statement`
 
-.. container:: item-framing-box
+.. container:: main-page-item-wrapper
 
     .. image:: images/performance.svg
        :alt: Performance icon
        :class: heading-icon
 
-    .. container:: item-framing-sub-box
+    .. container:: main-page-item-sub-wrapper
 
-        .. container:: item-framing-title
+        .. container:: main-page-item-title
 
             Learning Resources
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,161 +20,189 @@ The Python Arcade Library
       game without learning a complex framework.
    </p>
 
-.. |Go| image:: images/woman_sprinter.svg
-   :width: 48
-   :alt: Start Here
-   :target: get_started.html
+.. container:: item-framing-box-main
 
-.. raw:: html
+    .. image:: images/woman_sprinter.svg
+        :width: 48
+        :alt: Start Here
+        :class: heading-icon
+        :target: get_started.html
 
-    <table class="main-page-table">
-      <tr>
-        <td>
-           <h2>
-             <a class="reference internal" href="get_started/get_started.html">
-               <img alt="Start Here" src="_images/woman_sprinter.svg" width="48">
-               <span class="std std-ref">Start Here</span>
-             </a>
-             <a class="headerlink" href="#go-get-started-here" title="Permalink to this headline">¶</a>
-           </h2>
-        </td>
-        <td>
-          <iframe id="github-stars" src="https://ghbtns.com/github-btn.html?user=pythonarcade&repo=arcade&type=star&count=true&size=large" frameborder="0" scrolling="0" title="GitHub"></iframe>
-        </td>
-      </tr>
-   </table>
+    .. raw:: html
 
-.. image:: images/example_games.svg
-   :alt: Get Started icon
-   :class: heading-icon
+        <div class="main-page-box">
+            <div class="main-page-link">
+                <h2 id="the-python-arcade-library">
+                    <a class="reference internal" href="get_started/get_started.html">
+                        <div class="start-here-box">
+                            <span class="std std-ref">Start Here</span>
+                        </div>
+                    </a>
+                    <a class="headerlink" href="#go-get-started-here" title="Permalink to this headline">¶</a>
+                </h2>
+            </div>
+            <div class="main-page-box-gh">
+                <iframe id="github-stars" src="https://ghbtns.com/github-btn.html?user=pythonarcade&repo=arcade&type=star&count=true&size=large" frameborder="0" scrolling="0" title="GitHub"></iframe>
+            </div>
+        </div>
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Get Started
+.. container:: item-framing-box
 
-   get_started/introduction
-   get_started/get_started
-   get_started/install/index
-   get_started/how_to_get_help
+    .. image:: images/example_games.svg
+       :alt: Get Started icon
+       :class: heading-icon
 
-.. image:: images/example_code.svg
-   :alt: Example Code
-   :class: heading-icon
+    .. toctree::
+       :maxdepth: 1
+       :caption: Get Started
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Examples
+       get_started/introduction
+       get_started/get_started
+       get_started/install/index
+       get_started/how_to_get_help
 
-   example_code/how_to_examples/index
-   example_code/game_jam_2020
-   example_code/sample_games
+.. container:: item-framing-box
 
-.. image:: images/learn.svg
-   :alt: Tutorials
-   :class: heading-icon
+    .. image:: images/example_code.svg
+       :alt: Example Code
+       :class: heading-icon
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Tutorials
+    .. toctree::
+       :maxdepth: 1
+       :caption: Examples
 
-   tutorials/platform_tutorial/index
-   tutorials/pymunk_platformer/index
-   tutorials/views/index
-   tutorials/card_game/index
-   tutorials/lights/index
-   tutorials/bundling_with_pyinstaller/index
-   tutorials/compiling_with_nuitka/index
-   tutorials/shader_tutorials
-   tutorials/menu/index
-   tutorials/framebuffer/index
+       example_code/how_to_examples/index
+       example_code/game_jam_2020
+       example_code/sample_games
 
-.. image:: images/example_games.svg
-   :alt: Programming guide icon
-   :class: heading-icon
+.. container:: item-framing-box
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Guide
+    .. image:: images/learn.svg
+       :alt: Tutorials
+       :class: heading-icon
 
-   programming_guide/sprites/index
-   programming_guide/keyboard
-   programming_guide/sound
-   programming_guide/textures
-   programming_guide/sections
-   programming_guide/gui/index
-   programming_guide/texture_atlas
-   programming_guide/edge_artifacts/index
-   programming_guide/logging
-   programming_guide/opengl_notes
-   programming_guide/performance_tips
-   programming_guide/headless
-   programming_guide/vsync
-   programming_guide/pygame_comparison
+    .. toctree::
+       :maxdepth: 1
+       :caption: Tutorials
 
-.. image:: images/API.svg
-   :alt: API icon
-   :class: heading-icon
+       tutorials/platform_tutorial/index
+       tutorials/pymunk_platformer/index
+       tutorials/views/index
+       tutorials/card_game/index
+       tutorials/lights/index
+       tutorials/bundling_with_pyinstaller/index
+       tutorials/compiling_with_nuitka/index
+       tutorials/shader_tutorials
+       tutorials/menu/index
+       tutorials/framebuffer/index
 
-.. toctree::
-   :maxdepth: 1
-   :caption: API
+.. container:: item-framing-box
 
-   Index<api_docs/api/quick_index>
-   Reference<api_docs/arcade>
-   api_docs/resources
+    .. image:: images/example_games.svg
+       :alt: Programming guide icon
+       :class: heading-icon
 
-.. image:: images/source.svg
-   :alt: Source icon
-   :class: heading-icon
+    .. toctree::
+       :maxdepth: 1
+       :caption: Guide
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Source Code
+       programming_guide/sprites/index
+       programming_guide/keyboard
+       programming_guide/sound
+       programming_guide/textures
+       programming_guide/sections
+       programming_guide/gui/index
+       programming_guide/texture_atlas
+       programming_guide/edge_artifacts/index
+       programming_guide/logging
+       programming_guide/opengl_notes
+       programming_guide/performance_tips
+       programming_guide/headless
+       programming_guide/vsync
+       programming_guide/pygame_comparison
 
-   GitHub <https://github.com/pythonarcade/arcade>
-   programming_guide/release_notes
-   License <https://github.com/pythonarcade/arcade/blob/development/license.rst>
+.. container:: item-framing-box
 
-.. image:: images/source.svg
-   :alt: Source icon
-   :class: heading-icon
+    .. image:: images/API.svg
+       :alt: API icon
+       :class: heading-icon
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Contributing
+    .. toctree::
+       :maxdepth: 1
+       :caption: API
 
-   contributing_guide/index
-   contributing_guide/release_checklist
+       Index<api_docs/api/quick_index>
+       Reference<api_docs/arcade>
+       api_docs/resources
 
-.. image:: images/social.svg
-   :alt: Social icon
-   :class: heading-icon
+.. container:: item-framing-box
 
-Social
-------
+    .. image:: images/source.svg
+       :alt: Source icon
+       :class: heading-icon
 
-.. container:: toc-outside-links
+    .. toctree::
+       :maxdepth: 1
+       :caption: Source Code
 
-    * `Discord (most active spot) <https://discord.gg/ZjGDqMp>`_
-    * `Reddit /r/pythonarcade <https://www.reddit.com/r/pythonarcade/>`_
-    * `Twitter @ArcadeLibrary <https://twitter.com/arcadelibrary?lang=en>`_
-    * `Instagram @PythonArcadeLibrary <https://www.instagram.com/PythonArcadeLibrary/>`_
-    * `Facebook @ArcadeLibrary <https://www.facebook.com/ArcadeLibrary/>`_
-    * :ref:`diversity_statement`
+       GitHub <https://github.com/pythonarcade/arcade>
+       programming_guide/release_notes
+       License <https://github.com/pythonarcade/arcade/blob/development/license.rst>
 
-.. image:: images/performance.svg
-   :alt: Performance icon
-   :class: heading-icon
+.. container:: item-framing-box
 
-Learning Resources
-------------------
+    .. container:: single-col-box
 
-.. container:: toc-outside-links
+        .. image:: images/source.svg
+           :alt: Source icon
+           :class: heading-icon
 
-    * `Book - Learn to program with Arcade <https://learn.arcade.academy/en/latest/>`_
-    * `Peer To Peer Gaming With Arcade and Python Banyan <https://mryslab.github.io/bots-in-pieces/python-banyan/arcade/2020/02/21/p2p-arcade-1.html>`_
-    * `US PyCon 2022 Talk <https://youtu.be/JP6EnuQT2wA>`_
-    * `US PyCon 2019 Tutorial <https://youtu.be/Djtm1DzWSvo>`_
-    * `Aus PyCon 2018 Multiplayer Games <https://youtu.be/2SMkk63k6Ik>`_
-    * `US PyCon 2018 Talk <https://youtu.be/DAWHMHMPVHU>`_
+        .. toctree::
+           :maxdepth: 1
+           :caption: Contributing
+
+           contributing_guide/index
+           contributing_guide/release_checklist
+
+.. container:: item-framing-box
+
+    .. image:: images/social.svg
+       :alt: Social icon
+       :class: heading-icon
+
+    .. container:: item-framing-sub-box
+
+        .. container:: item-framing-title
+
+            Social
+
+        .. container:: toc-outside-links
+
+            * `Discord (most active spot) <https://discord.gg/ZjGDqMp>`_
+            * `Reddit /r/pythonarcade <https://www.reddit.com/r/pythonarcade/>`_
+            * `Twitter @ArcadeLibrary <https://twitter.com/arcadelibrary?lang=en>`_
+            * `Instagram @PythonArcadeLibrary <https://www.instagram.com/PythonArcadeLibrary/>`_
+            * `Facebook @ArcadeLibrary <https://www.facebook.com/ArcadeLibrary/>`_
+            * :ref:`diversity_statement`
+
+.. container:: item-framing-box
+
+    .. image:: images/performance.svg
+       :alt: Performance icon
+       :class: heading-icon
+
+    .. container:: item-framing-sub-box
+
+        .. container:: item-framing-title
+
+            Learning Resources
+
+        .. container:: toc-outside-links
+
+            * `Book - Learn to program with Arcade <https://learn.arcade.academy/en/latest/>`_
+            * `Peer To Peer Gaming With Arcade and Python Banyan <https://mryslab.github.io/bots-in-pieces/python-banyan/arcade/2020/02/21/p2p-arcade-1.html>`_
+            * `US PyCon 2022 Talk <https://youtu.be/JP6EnuQT2wA>`_
+            * `US PyCon 2019 Tutorial <https://youtu.be/Djtm1DzWSvo>`_
+            * `Aus PyCon 2018 Multiplayer Games <https://youtu.be/2SMkk63k6Ik>`_
+            * `US PyCon 2018 Talk <https://youtu.be/DAWHMHMPVHU>`_
 


### PR DESCRIPTION
Fixes #2023 

- Adjusted the top header where the sprinter and the star button are
- Made the Contributing section always have 1 column since there are only 2 items there. But if 2 columns are preferred, I'll change that back
- Added a little margin between sections
- Made Social and Learning Resources section swap to 1 column if screen is small enough, just like the other sections
- Adjusted star button for dark mode users. Before:
![image](https://github.com/pythonarcade/arcade/assets/73155687/1d1ccd08-5b94-4594-8354-d630895d844b)
After:
![image](https://github.com/pythonarcade/arcade/assets/73155687/09925f9d-4775-4883-a365-309261669fa3)
It's not currently possible to make the iframe background match the color of the dark mode docs. To fix that, we could use this other solution (https://buttons.github.io/) that involves loading a Javascript script, but it seems like this background issue is only present in Firefox and not in Chrome so I imagine it's low priority.