### PR TITLE
Make ColorLike match RGB/RGBA in both float and int

### DIFF
--- a/arcade/types.py
+++ b/arcade/types.py
@@ -59,6 +59,7 @@ RGBA255 = RGBA[int]
 RGBANormalized = RGBA[float]
 
 RGBA255OrNormalized = Union[RGBA255, RGBANormalized]
+ColorLike = Union[RGBOrA[int], RGBOrA[float]]
 
 
 __all__ = [
@@ -464,7 +465,6 @@ class Color(RGBA255):
         return tuple(ret)
 
 
-ColorLike = Union[RGB, RGBA255]
 
 # Point = Union[Tuple[float, float], List[float]]
 # Vector = Point


### PR DESCRIPTION
TL;DR: Make `ColorLike` mean something instead of being broken

Ty @DigiDuncan for noticing this issue.

* Make `ColorLike` match RGB and RGBA in both int and float
* Move it to top of file with other color aliases