### PR TITLE
Fix DefaultFramebuffer.read()

### DIFF
--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -429,14 +429,18 @@ class Framebuffer:
 
         with self.activate():
             # Configure attachment to read from
-            gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + attachment)
+            if not self.is_default:
+                gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + attachment)
+            gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
+            gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
             if viewport:
                 x, y, width, height = viewport
             else:
                 x, y, width, height = 0, 0, self._width, self._height
             data = (gl.GLubyte * (components * component_size * width * height))(0)
             gl.glReadPixels(x, y, width, height, base_format, pixel_type, data)
-            gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)  # Reset to default
+            if not self.is_default:
+                gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)  # Reset to default
 
         return string_at(data, len(data))
 

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -428,17 +428,21 @@ class Framebuffer:
             raise ValueError(f"Invalid dtype '{dtype}'")
 
         with self.activate():
-            # Configure attachment to read from
+            # Configure attachment to read from. Does not work on default framebuffer.
             if not self.is_default:
                 gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0 + attachment)
+
             gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
             gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
+
             if viewport:
                 x, y, width, height = viewport
             else:
-                x, y, width, height = 0, 0, self._width, self._height
+                x, y, width, height = 0, 0, *self.size
+
             data = (gl.GLubyte * (components * component_size * width * height))(0)
             gl.glReadPixels(x, y, width, height, base_format, pixel_type, data)
+
             if not self.is_default:
                 gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)  # Reset to default
 
@@ -574,6 +578,37 @@ class DefaultFrameBuffer(Framebuffer):
 
         # HACK: Signal the default framebuffer having depth buffer
         self._depth_attachment = True  # type: ignore
+
+    @property
+    def size(self) -> Tuple[int, int]:
+        """
+        Size as a ``(w, h)`` tuple
+
+        :type: tuple (int, int)
+        """
+        return self._ctx.window.get_framebuffer_size()
+
+    @property
+    def width(self) -> int:
+        """
+        The width of the framebuffer in pixels
+
+        :type: int
+        """
+        return self.size[0]
+
+    @property
+    def height(self) -> int:
+        """
+        The height of the framebuffer in pixels
+
+        :type: int
+        """
+        return self.size[1]
+
+    def _get_framebuffer_size(self) -> Tuple[int, int]:
+        """Get the framebuffer size of the window"""
+        return self._ctx.window.get_framebuffer_size()
 
     def _get_viewport(self) -> Tuple[int, int, int, int]:
         """

--- a/tests/unit/gl/test_opengl_framebuffer.py
+++ b/tests/unit/gl/test_opengl_framebuffer.py
@@ -156,3 +156,9 @@ def test_resize(ctx):
     fbo.resize()
     assert fbo.size == tex.size
     assert fbo.viewport == (0, 0, *fbo.size)
+
+def test_read_screen_framebuffer(window):
+    data = window.ctx.screen.read()
+    assert isinstance(data, bytes)
+    byte_size = int(window.width * window.height * 3 * window.get_pixel_ratio())
+    assert len(data) == byte_size

--- a/tests/unit/gl/test_opengl_framebuffer.py
+++ b/tests/unit/gl/test_opengl_framebuffer.py
@@ -158,7 +158,8 @@ def test_resize(ctx):
     assert fbo.viewport == (0, 0, *fbo.size)
 
 def test_read_screen_framebuffer(window):
-    data = window.ctx.screen.read()
+    components = 3
+    data = window.ctx.screen.read(components=components)
     assert isinstance(data, bytes)
-    byte_size = int(window.width * window.height * 3 * window.get_pixel_ratio())
-    assert len(data) == byte_size
+    w, h = window.get_framebuffer_size()
+    assert len(data) == w * h * components


### PR DESCRIPTION
`window.ctx.read()` doesn't work for the default framebuffer due to `glReadBuffer` settings for the default framebuffer. If default framebuffer we simply just skip these settings. Also added 1 byte alignment in case that changes.