### PR TITLE
Switch to Pyglet 2.1 or dev releases

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -152,7 +152,7 @@ class Window(pyglet.window.Window):
                     blue_size=8,
                     alpha_size=8,
                 )
-                display = pyglet.canvas.get_display()
+                display = pyglet.display.get_display()
                 screen = display.get_default_screen()
                 if screen:
                     config = screen.get_best_config(config)

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -13,7 +13,7 @@ import pyglet
 
 import pyglet.gl as gl
 import pyglet.window.mouse
-from pyglet.canvas.base import ScreenMode
+from pyglet.display.base import ScreenMode
 
 import arcade
 from arcade import get_display_size

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -54,7 +54,7 @@ def get_screens() -> List:
 
     :returns: List of screens, one for each monitor.
     """
-    display = pyglet.canvas.get_display()
+    display = pyglet.display.get_display()
     return display.get_screens()
 
 
@@ -83,7 +83,7 @@ class Window(pyglet.window.Window):
     :param antialiasing: Should OpenGL's anti-aliasing be enabled?
     :param gl_version: What OpenGL version to request. This is ``(3, 3)`` by default \
                                        and can be overridden when using more advanced OpenGL features.
-    :param screen: Pass a pyglet :py:class:`~pyglet.canvas.Screen` to
+    :param screen: Pass a pyglet :py:class:`~pyglet.display.Screen` to
         request the window be placed on it. See `pyglet's window size &
         position guide <pyglet_pg_window_size_position_>`_ to learn more.
     :param style: Request a non-default window style, such as borderless.
@@ -110,7 +110,7 @@ class Window(pyglet.window.Window):
         update_rate: float = 1 / 60,
         antialiasing: bool = True,
         gl_version: Tuple[int, int] = (3, 3),
-        screen: Optional[pyglet.canvas.Screen] = None,
+        screen: Optional[pyglet.display.Screen] = None,
         style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
         vsync: bool = False,

--- a/arcade/experimental/clock/clock_window.py
+++ b/arcade/experimental/clock/clock_window.py
@@ -97,7 +97,7 @@ class Window(pyglet.window.Window):
         update_rate: float = 1 / 60,
         antialiasing: bool = True,
         gl_version: Tuple[int, int] = (3, 3),
-        screen: Optional[pyglet.canvas.Screen] = None,
+        screen: Optional[pyglet.display.Screen] = None,
         style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
         vsync: bool = False,

--- a/arcade/experimental/clock/clock_window.py
+++ b/arcade/experimental/clock/clock_window.py
@@ -19,7 +19,7 @@ import pyglet
 
 import pyglet.gl as gl
 import pyglet.window.mouse
-from pyglet.canvas.base import ScreenMode
+from pyglet.display.base import ScreenMode
 
 import arcade
 from arcade import get_display_size
@@ -70,7 +70,7 @@ class Window(pyglet.window.Window):
     :param antialiasing: Should OpenGL's anti-aliasing be enabled?
     :param gl_version: What OpenGL version to request. This is ``(3, 3)`` by default \
                                        and can be overridden when using more advanced OpenGL features.
-    :param screen: Pass a pyglet :py:class:`~pyglet.canvas.Screen` to
+    :param screen: Pass a pyglet :py:class:`~pyglet.display.Screen` to
         request the window be placed on it. See `pyglet's window size &
         position guide <pyglet_pg_window_size_position_>`_ to learn more.
     :param style: Request a non-default window style, such as borderless.
@@ -141,7 +141,7 @@ class Window(pyglet.window.Window):
                     blue_size=8,
                     alpha_size=8,
                 )
-                display = pyglet.canvas.get_display()
+                display = pyglet.display.get_display()
                 screen = display.get_default_screen()
                 if screen:
                     config = screen.get_best_config(config)

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -352,7 +352,10 @@ class UIInputText(UIWidget):
         )
 
         self.layout = pyglet.text.layout.IncrementalTextLayout(
-            self.doc, int(width - self.LAYOUT_OFFSET), int(height), multiline=multiline
+            self.doc,
+            x=x +  self.LAYOUT_OFFSET, y=y, z=0.0,  # Position
+            width=width - self.LAYOUT_OFFSET, height=height,  # Size
+            multiline=multiline
         )
         self.layout.x += self.LAYOUT_OFFSET
         self.caret = Caret(self.layout, color=Color.from_iterable(caret_color))

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -357,7 +357,6 @@ class UIInputText(UIWidget):
             width=width - self.LAYOUT_OFFSET, height=height,  # Size
             multiline=multiline
         )
-        self.layout.x += self.LAYOUT_OFFSET
         self.caret = Caret(self.layout, color=Color.from_iterable(caret_color))
         self.caret.visible = False
 

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -354,7 +354,7 @@ class UIInputText(UIWidget):
         self.layout = pyglet.text.layout.IncrementalTextLayout(
             self.doc,
             x=x +  self.LAYOUT_OFFSET, y=y, z=0.0,  # Position
-            width=width - self.LAYOUT_OFFSET, height=height,  # Size
+            width=int(width - self.LAYOUT_OFFSET), height=int(height),  # Size
             multiline=multiline
         )
         self.caret = Caret(self.layout, color=Color.from_iterable(caret_color))

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -213,8 +213,9 @@ class Text:
             z=z,
             font_name=adjusted_font,
             font_size=font_size,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
+            # use type: ignore since cast is slow & pyglet used Literal
+            anchor_x=anchor_x,  # type: ignore
+            anchor_y=anchor_y,  # type: ignore
             color=Color.from_iterable(color),
             width=width,
             align=align,

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -49,7 +49,7 @@ def get_display_size(screen_id: int = 0) -> Tuple[int, int]:
     :param screen_id: The screen number
     :return: Tuple containing the width and height of the screen
     """
-    display = pyglet.canvas.Display()
+    display = pyglet.display.Display()
     screen = display.get_screens()[screen_id]
     return screen.width, screen.height
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet>=2.0.14,<2.1",
+    "pyglet == 2.1dev1",
+    # "pyglet>=2.0.14,<2.1",
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "pyglet == 2.1dev1",
-    # "pyglet>=2.0.14,<2.1",
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = [
-    "pyglet == 2.1dev1",
+    "pyglet == 2.1dev2",
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.3"


### PR DESCRIPTION
TL;DR: Get new pyglet bug fixes + immutable vecs for #2021

### Why?

Per Discord discussion with @Cleptomania, this change:

1. enables [backward-compatible `BasicSprite.scale` behavior](https://github.com/pythonarcade/arcade/pull/2021#issuecomment-1999386042) in #2021:
    ```py
   # Will work with scalars as it does now
   sprite_instance.scale *= 2.0
   # Cleaner & more efficient than setting individual scale components
   sprite_instance.scale *= 2.0, 3.0
   ```
2. seems to show it works fine according to preliminary tests
3. matches how we've never made a release that wasn't on a preview pyglet build

### Changes

1. Use `pyglet==2.1dev2`
2. Update references to `pyglet.canvas` to refer to `pyglet.display`
3. Use new layout syntax per 2.1 styles


## Testing Steps Taken

- [ ] Human spot-check of examples (GUI, Text, and Media) on
  - [x] Linux
  - [ ] Windows
  - [ ] Mac

- [ ] Run unit & integration tests on
  - [x] Linux
  - [ ] Windows
  - [ ] Mac

## Follow-up Work

* Update #2021 with `BasicSprite` changes
* Thorough example / functionality shakedown per [the 2.1 migration guide](https://pyglet.readthedocs.io/en/development/programming_guide/migration.html)
* (Optional) Make arcade match the x, y, z style of pyglet's text / etc?