### PR TITLE
Add window center properties

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -917,14 +917,17 @@ class Window(pyglet.window.Window):
 
     @property
     def center(self) -> tuple[float, float]:
+        """Returns the coordinates of the center of the window."""
         return (self.width / 2, self.height / 2)
 
     @property
     def center_x(self) -> float:
+        """Returns the X-coordinate of the center of the window."""
         return self.width / 2
 
     @property
     def center_y(self) -> float:
+        """Returns the Y-coordinate of the center of the window."""
         return self.height / 2
 
 

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -915,6 +915,18 @@ class Window(pyglet.window.Window):
         """
         pass
 
+    @property
+    def center(self) -> tuple[float, float]:
+        return (self.width / 2, self.height / 2)
+
+    @property
+    def center_x(self) -> float:
+        return self.width / 2
+
+    @property
+    def center_y(self) -> float:
+        return self.height / 2
+
 
 def open_window(
     width: int,


### PR DESCRIPTION
Adds `center`, `center_x`, and `center_y` to `Window`.

## Why?
You use `Window.height / 2` or `Window.width / 2` *so often.* Basically positioning anything requires you to do this math. This property is tried and tested in Charm, and it gets used *31* times.