### PR TITLE
Fix non-numeric pyright typing issues caused by pyglet changes

### DIFF
--- a/arcade/management/__init__.py
+++ b/arcade/management/__init__.py
@@ -34,7 +34,7 @@ def show_info():
     print('python:', sys.version)
     print('platform:', sys.platform)
     # The next line uses noqa because pyglet's .pyi is out of date
-    print('pyglet version:', pyglet.__version__)  # noqa
+    print('pyglet version:', pyglet.__version__)  # pyright: ignore  # noqa
     print('PIL version:', PIL.__version__)
 
 

--- a/arcade/management/__init__.py
+++ b/arcade/management/__init__.py
@@ -33,7 +33,8 @@ def show_info():
     print('version:', window.ctx.gl_version)
     print('python:', sys.version)
     print('platform:', sys.platform)
-    print('pyglet version:', pyglet.__version__)
+    # The next line uses noqa because pyglet's .pyi is out of date
+    print('pyglet version:', pyglet.__version__)  # noqa
     print('PIL version:', PIL.__version__)
 
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -367,11 +367,11 @@ class Text:
 
         Options : "top", "bottom", "center", or "baseline"
         """
-        return self._label.anchor_y  # type: ignore
+        return self._label.anchor_y
 
     @anchor_y.setter
     def anchor_y(self, anchor_y: str):
-        self._label.anchor_y = anchor_y
+        self._label.anchor_y = anchor_y  # type: ignore
 
     @property
     def rotation(self) -> float:

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -358,7 +358,7 @@ class Text:
 
     @anchor_x.setter
     def anchor_x(self, anchor_x: str):
-        self._label.anchor_x = anchor_x
+        self._label.anchor_x = anchor_x  # type: ignore
 
     @property
     def anchor_y(self) -> str:
@@ -367,7 +367,7 @@ class Text:
 
         Options : "top", "bottom", "center", or "baseline"
         """
-        return self._label.anchor_y
+        return self._label.anchor_y  # type: ignore
 
     @anchor_y.setter
     def anchor_y(self, anchor_y: str):


### PR DESCRIPTION
### Changes

1. `#  type: ignore` pyglet's incorrect and overly-strict use of `Literal`
2. `# noqa` an outdated `.pyi` which omits `__version__`

### Why

Pyright keeps marking PRs as broken when they didn't break anything.