### PR TITLE
 Clean up draw_commands in areas potentially helpful for #2065

### DIFF
--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -489,7 +489,7 @@ def draw_lines(point_list: PointList,
     # Validate & normalize to a pass the shader an RGBA float uniform
     color_normalized = Color.from_iterable(color).normalized
 
-    line_pos_array = array.array('f', tuple(v for point in point_list for v in point))
+    line_pos_array = array.array('f', (v for point in point_list for v in point))
     num_points = len(point_list)
 
     # Grow buffer until large enough to hold all our data

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -542,16 +542,17 @@ def draw_points(point_list: PointList, color: RGBA255, size: float = 1):
 
     # Validate & normalize to a pass the shader an RGBA float uniform
     color_normalized = Color.from_iterable(color).normalized
+    num_points = len(point_list)
 
     # Resize buffer
-    data_size = len(point_list) * 8
+    data_size = num_points * 8
     # if data_size > buffer.size:
     buffer.orphan(size=data_size)
 
     program['color'] = color_normalized
     program['shape'] = size, size, 0
     buffer.write(data=array.array('f', tuple(v for point in point_list for v in point)))
-    geometry.render(program, mode=ctx.POINTS, vertices=data_size // 8)
+    geometry.render(program, mode=ctx.POINTS, vertices=num_points)
 
 
 # --- END POINT FUNCTIONS # # #

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -489,20 +489,22 @@ def draw_lines(point_list: PointList,
     # Validate & normalize to a pass the shader an RGBA float uniform
     color_normalized = Color.from_iterable(color).normalized
 
+    line_pos_array = array.array('f', tuple(v for point in point_list for v in point))
+    num_points = len(point_list)
+
     # Grow buffer until large enough to hold all our data
-    goal_buffer_size = len(point_list) * 3 * 4
+    goal_buffer_size = num_points * 3 * 4
     while goal_buffer_size > line_buffer_pos.size:
-        ctx.shape_line_buffer_pos.orphan(ctx.shape_line_buffer_pos.size * 2)
+        ctx.shape_line_buffer_pos.orphan(line_buffer_pos.size * 2)
     else:
         ctx.shape_line_buffer_pos.orphan()
 
     # Pass data to shader
     program['line_width'] = line_width
     program['color'] = color_normalized
-    ctx.shape_line_buffer_pos.write(
-        data=array.array('f', tuple(v for point in point_list for v in point)))
+    line_buffer_pos.write(data=line_pos_array)
 
-    geometry.render(program, mode=gl.GL_LINES, vertices=len(point_list))
+    geometry.render(program, mode=gl.GL_LINES, vertices=num_points)
 
 
 # --- BEGIN POINT FUNCTIONS # # #

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -552,7 +552,9 @@ def draw_points(point_list: PointList, color: RGBA255, size: float = 1):
     program['color'] = color_normalized
     program['shape'] = size, size, 0
     buffer.write(data=array.array('f', tuple(v for point in point_list for v in point)))
-    geometry.render(program, mode=ctx.POINTS, vertices=num_points)
+
+    # Only render the # of points we have complete data for
+    geometry.render(program, mode=ctx.POINTS, vertices=data_size // 8)
 
 
 # --- END POINT FUNCTIONS # # #

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -542,16 +542,20 @@ def draw_points(point_list: PointList, color: RGBA255, size: float = 1):
 
     # Validate & normalize to a pass the shader an RGBA float uniform
     color_normalized = Color.from_iterable(color).normalized
+
+    # Get # of points and translate Python tuples to a C-style array
     num_points = len(point_list)
+    point_array = array.array('f', (v for point in point_list for v in point))
 
     # Resize buffer
     data_size = num_points * 8
     # if data_size > buffer.size:
     buffer.orphan(size=data_size)
 
+    # Pass data to shader
     program['color'] = color_normalized
     program['shape'] = size, size, 0
-    buffer.write(data=array.array('f', tuple(v for point in point_list for v in point)))
+    buffer.write(data=point_array)
 
     # Only render the # of points we have complete data for
     geometry.render(program, mode=ctx.POINTS, vertices=data_size // 8)

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import array
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import PIL.Image
 import PIL.ImageOps
@@ -18,7 +18,7 @@ import PIL.ImageDraw
 
 import pyglet.gl as gl
 
-from arcade.types import Color, RGBA255, PointList
+from arcade.types import Color, RGBA255, PointList, Point
 from arcade.earclip import earclip
 from .math import rotate_point
 from arcade import (
@@ -420,7 +420,7 @@ def draw_line_strip(point_list: PointList,
     if line_width == 1:
         _generic_draw_line_strip(point_list, color, gl.GL_LINE_STRIP)
     else:
-        triangle_point_list: PointList = []
+        triangle_point_list: List[Point] = []
         # This needs a lot of improvement
         last_point = None
         for point in point_list:

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -299,15 +299,9 @@ def draw_ellipse_filled(center_x: float, center_y: float,
     program = ctx.shape_ellipse_filled_unbuffered_program
     geometry = ctx.shape_ellipse_unbuffered_geometry
     buffer = ctx.shape_ellipse_unbuffered_buffer
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, 1.0
-    elif len(color) == 4:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
-    program['color'] = color_normalized
+    # We need to normalize the color because we are setting it as a float uniform
+    program['color'] = Color.from_iterable(color).normalized
     program['shape'] = width / 2, height / 2, tilt_angle
     program['segments'] = num_segments
     buffer.orphan()
@@ -345,15 +339,9 @@ def draw_ellipse_outline(center_x: float, center_y: float,
     program = ctx.shape_ellipse_outline_unbuffered_program
     geometry = ctx.shape_ellipse_outline_unbuffered_geometry
     buffer = ctx.shape_ellipse_outline_unbuffered_buffer
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, 1.0
-    elif len(color) == 4:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
-    program['color'] = color_normalized
+    # We need to normalize the color because we are setting it as a float uniform
+    program['color'] = Color.from_iterable(color).normalized
     program['shape'] = width / 2, height / 2, tilt_angle, border_width
     program['segments'] = num_segments
     buffer.orphan()
@@ -449,16 +437,10 @@ def draw_line(start_x: float, start_y: float, end_x: float, end_y: float,
 
     program = ctx.shape_line_program
     geometry = ctx.shape_line_geometry
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, 1.0
-    elif len(color) == 4:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
+    # We need to normalize the color because we are setting it as a float uniform
+    program['color'] = Color.from_iterable(color).normalized
     program['line_width'] = line_width
-    program['color'] = color_normalized
     ctx.shape_line_buffer_pos.orphan()  # Allocate new buffer internally
     ctx.shape_line_buffer_pos.write(
         data=array.array('f', (start_x, start_y, end_x, end_y)))
@@ -484,14 +466,9 @@ def draw_lines(point_list: PointList,
 
     program = ctx.shape_line_program
     geometry = ctx.shape_line_geometry
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, 1.0
-    elif len(color) == 4:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
+    # We need to normalize the color because we are setting it as a float uniform
+    color_normalized = Color.from_iterable(color).normalized
     while len(point_list) * 3 * 4 > ctx.shape_line_buffer_pos.size:
         ctx.shape_line_buffer_pos.orphan(ctx.shape_line_buffer_pos.size * 2)
     else:
@@ -536,14 +513,9 @@ def draw_points(point_list: PointList, color: RGBA255, size: float = 1):
     program = ctx.shape_rectangle_filled_unbuffered_program
     geometry = ctx.shape_rectangle_filled_unbuffered_geometry
     buffer = ctx.shape_rectangle_filled_unbuffered_buffer
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, 1.0
-    elif len(color) == 4:
-        color_normalized = color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
+    # We need to normalize the color because we are setting it as a float uniform
+    color_normalized = Color.from_iterable(color).normalized
     # Resize buffer
     data_size = len(point_list) * 8
     # if data_size > buffer.size:
@@ -881,15 +853,9 @@ def draw_rectangle_filled(center_x: float, center_y: float, width: float,
     program = ctx.shape_rectangle_filled_unbuffered_program
     geometry = ctx.shape_rectangle_filled_unbuffered_geometry
     buffer = ctx.shape_rectangle_filled_unbuffered_buffer
-    # We need to normalize the color because we are setting it as a float uniform
-    if len(color) == 3:
-        color_normalized = (color[0] / 255, color[1] / 255, color[2] / 255, 1.0)
-    elif len(color) == 4:
-        color_normalized = (color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255)  # type: ignore
-    else:
-        raise ValueError("Invalid color format. Use a 3 or 4 component tuple")
 
-    program['color'] = color_normalized
+    # We need to normalize the color because we are setting it as a float uniform
+    program['color'] = Color.from_iterable(color).normalized
     program['shape'] = width, height, tilt_angle
     buffer.orphan()
     buffer.write(data=array.array('f', (center_x, center_y)))

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -591,22 +591,29 @@ def draw_polygon_outline(point_list: PointList,
         :py:class:`~arcade.types.Color` instance.
     :param line_width: Width of the line in pixels.
     """
+    # Convert to modifiable list & close the loop
     new_point_list = list(point_list)
     new_point_list.append(point_list[0])
 
+    # Create a place to store the triangles we'll use to thicken the line
     triangle_point_list = []
+
     # This needs a lot of improvement
     last_point = None
     for point in new_point_list:
         if last_point is not None:
-            points = get_points_for_thick_line(last_point[0], last_point[1], point[0], point[1], line_width)
+            # Calculate triangles, then re-order to link up the quad?
+            points = get_points_for_thick_line(*last_point, *point, line_width)
             reordered_points = points[1], points[0], points[2], points[3]
+
             triangle_point_list.extend(reordered_points)
         last_point = point
 
-    points = get_points_for_thick_line(new_point_list[0][0], new_point_list[0][1], new_point_list[1][0],
-                                       new_point_list[1][1], line_width)
+    # Use first two points of new list to close the loop
+    new_start, new_next = new_point_list[:2]
+    points = get_points_for_thick_line(*new_start, *new_next, line_width)
     triangle_point_list.append(points[1])
+
     _generic_draw_line_strip(triangle_point_list, color, gl.GL_TRIANGLE_STRIP)
 
 


### PR DESCRIPTION
### Changes

TL;DR: Try to improve readability ahead of camera refactor research & prototyping

### Why?

TL;DR: Help @DragonMoffon & @DigiDuncan when working on cameras

1. Good news: I finished investigating our pyglet 2.1 `Vec*` issues much sooner than expected
  * Looks like a bad merge + overzealous `__eq__` check
  * Need to follow-up with pyglet team
  * Probably easily fixed with a `pyglet==2.1dev3` release
2. Rects would help make cameras less brittle (see #2065's follow-up / description)
  * We have a repeated root cause of projection / bounding box bugs due to lack of nice rect abstractions
  * The bugs due to this keep piling up as I perform intensive code review (newest is that up vector breaks properties)
3. Digi & Dragon's feasibility checks / "census" for rect abstraction may have glossed over function internals
   * Signatures inspected
   * Unsure about implementations, especially on hard to read code
4. The comments here a requests for further refactoring
5. Improving readability lowers friction for delivering those refactors in future PRs

### Where?

TL;DR: Function bodies where things help draw rects or might use quads

In `draw_commands.py`, wherever things look like:

1. Shared drawing helpers
7. Directly rectangle related
8. Appear to contain quad-like structures (see `draw_polygon_outline`)

### How?

TL;DR: Make the code understandable before even attempting to fix how fast it runs

1. Replace long ugly inlined logic with `Color`'s:
   1. `from_iterable` classmethod
   9. `normalized` property
7. Try to fail fast by putting these higher up:
   1. Window & context fetch
   2. Storing local refs to the context's shader & buffer singletons
   3. `Color.from_iterable(color)` validation
   4. Allocations of new `array.array`s
3. General readability improvements, including:
   1. Split nested one-liner expressions
   2. Store re-used quantities in local variables
   3. Add comments
   4. Remove redundant conversions such as the `tuple` in (`array.array('B', tuple(generator))`
   5. `*` unpacking positional point arguments instead of indexing