### PR TITLE
Update pymunk_demo_platformer_11.py

### DIFF
--- a/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_11.py
+++ b/doc/tutorials/pymunk_platformer/pymunk_demo_platformer_11.py
@@ -227,9 +227,7 @@ class GameWindow(arcade.Window):
         self.player_list.append(self.player_sprite)
 
         # Moving Sprite
-        self.moving_sprites_list = arcade.tilemap.process_layer(my_map,
-                                                                'Moving Platforms',
-                                                                SPRITE_SCALING_TILES)
+        self.moving_sprites_list = tile_map.sprite_lists['Moving Platforms']
 
         # --- Pymunk Physics Engine Setup ---
 


### PR DESCRIPTION
fixed an error when testing step11 
"AttributeError: module 'arcade.tilemap' has no attribute 'process_layer'"

when you run the step 11 the following line 230 caused an error when trying to run the file.
        self.moving_sprites_list = arcade.tilemap.process_layer(my_map,
                                                                'Moving Platforms',
                                                                SPRITE_SCALING_TILES)

AttributeError: module 'arcade.tilemap' has no attribute 'process_layer'
