### PR TITLE
Fix incorrect lrwh function name in arcade.draw_commands

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -122,6 +122,7 @@ from .draw_commands import draw_lrtb_rectangle_filled
 from .draw_commands import draw_lrbt_rectangle_filled
 from .draw_commands import draw_lrtb_rectangle_outline
 from .draw_commands import draw_lrbt_rectangle_outline
+from .draw_commands import draw_lbwh_rectangle_textured
 from .draw_commands import draw_lrwh_rectangle_textured
 from .draw_commands import draw_parabola_filled
 from .draw_commands import draw_parabola_outline
@@ -294,6 +295,7 @@ __all__ = [
     'draw_line',
     'draw_line_strip',
     'draw_lines',
+    'draw_lbwh_rectangle_textured',
     'draw_lrtb_rectangle_filled',
     'draw_lrbt_rectangle_filled',
     'draw_lrtb_rectangle_outline',

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -56,6 +56,7 @@ __all__ = [
     "draw_rectangle_filled",
     "draw_scaled_texture_rectangle",
     "draw_texture_rectangle",
+    "draw_lbwh_rectangle_textured",
     "draw_lrwh_rectangle_textured",
     "get_pixel",
     "get_image"
@@ -961,7 +962,35 @@ def draw_texture_rectangle(center_x: float, center_y: float,
     texture.draw_sized(center_x, center_y, width, height, angle, alpha)
 
 
+@warning(
+    warning_type=ReplacementWarning,
+    new_name="draw_lbwh_rectangle_textured"
+)
 def draw_lrwh_rectangle_textured(bottom_left_x: float, bottom_left_y: float,
+                                 width: float,
+                                 height: float,
+                                 texture: Texture, angle: float = 0,
+                                 alpha: int = 255):
+    """Draw a texture extending from bottom left to top right.
+
+   .. deprecated:: 3.0
+      Use :py:func:`draw_lbwh_rectangle_textured` instead!
+
+    :param bottom_left_x: The x coordinate of the left edge of the rectangle.
+    :param bottom_left_y: The y coordinate of the bottom of the rectangle.
+    :param width: The width of the rectangle.
+    :param height: The height of the rectangle.
+    :param texture: identifier of texture returned from load_texture() call
+    :param angle: rotation of the rectangle. Defaults to zero (clockwise).
+    :param alpha: Transparency of image. 0 is fully transparent, 255 (default) is visible
+    """
+
+    center_x = bottom_left_x + (width / 2)
+    center_y = bottom_left_y + (height / 2)
+    texture.draw_sized(center_x, center_y, width, height, angle=angle, alpha=alpha)
+
+
+def draw_lbwh_rectangle_textured(bottom_left_x: float, bottom_left_y: float,
                                  width: float,
                                  height: float,
                                  texture: Texture, angle: float = 0,

--- a/arcade/examples/sprite_collect_coins_background.py
+++ b/arcade/examples/sprite_collect_coins_background.py
@@ -89,7 +89,7 @@ class MyGame(arcade.Window):
         self.clear()
 
         # Draw the background texture
-        arcade.draw_lrwh_rectangle_textured(0, 0,
+        arcade.draw_lbwh_rectangle_textured(0, 0,
                                             SCREEN_WIDTH, SCREEN_HEIGHT,
                                             self.background)
 

--- a/arcade/examples/sprite_rooms.py
+++ b/arcade/examples/sprite_rooms.py
@@ -181,7 +181,7 @@ class MyGame(arcade.Window):
         self.clear()
 
         # Draw the background texture
-        arcade.draw_lrwh_rectangle_textured(0, 0,
+        arcade.draw_lbwh_rectangle_textured(0, 0,
                                             SCREEN_WIDTH, SCREEN_HEIGHT,
                                             self.rooms[self.current_room].background)
 

--- a/arcade/experimental/light_demo.py
+++ b/arcade/experimental/light_demo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import arcade
+from arcade.draw_commands import draw_lbwh_rectangle_textured
 from arcade.experimental.lights import Light, LightLayer
 
 # Do the math to figure out our screen dimensions
@@ -57,7 +58,7 @@ class MyGame(arcade.Window):
 
         # Everything that should be affected by lights in here
         with self.light_layer:
-            arcade.draw_lrwh_rectangle_textured(
+            draw_lbwh_rectangle_textured(
                 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, self.background)
             self.torch_list.draw()
 

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -6,6 +6,7 @@ from typing import Tuple, Union, Optional
 import arcade
 from arcade import Texture
 from arcade.color import TRANSPARENT_BLACK
+from arcade.draw_commands import draw_lbwh_rectangle_textured
 from arcade.camera import OrthographicProjector, OrthographicProjectionData, CameraData
 from arcade.gl import Framebuffer
 from arcade.gui.nine_patch import NinePatchTexture
@@ -119,7 +120,7 @@ class Surface:
 
             tex.draw_sized(size=(width, height))
         else:
-            arcade.draw_lrwh_rectangle_textured(
+            draw_lbwh_rectangle_textured(
                 bottom_left_x=x,
                 bottom_left_y=y,
                 width=width,

--- a/doc/programming_guide/release_notes.rst
+++ b/doc/programming_guide/release_notes.rst
@@ -182,6 +182,13 @@ Changes
   * :py:func:`~arcade.draw_text` and :py:class:`~arcade.Text` both now accept a ``start_z`` parameter. This will allow advanced usage to set the Z
     position of the underlying Label. This parameter defaults to 0 and does not change any existing usage.
 
+* :py:mod:`arcade.draw_commands`:
+
+  * Added :py:func:`arcade.draw_commands.draw_lbwh_rectangle_textured`
+
+    * Replaces the now-deprecated :py:func:`arcade.draw_commands.draw_lrwh_rectangle_textured`
+    * Usage is exactly the same
+
 * OpenGL
 
   * Support for OpenGL ES 3.1 and 3.2. 3.2 is fully supported, 3.1 is only supported if the ``EXT_geometry_shader`` extension

--- a/tests/unit/drawing_support/test_textured_rects.py
+++ b/tests/unit/drawing_support/test_textured_rects.py
@@ -17,7 +17,7 @@ def test_textured_rects(window: arcade.Window):
             texture.image.height * scale,
             texture, angle=45,
         )
-        arcade.draw_lrwh_rectangle_textured(10, 400, 64, 64, texture)
+        arcade.draw_lbwh_rectangle_textured(10, 400, 64, 64, texture)
 
         for i in range(15):
             arcade.draw_scaled_texture_rectangle(


### PR DESCRIPTION
TL;DR: `draw_lrwh_rectangle_textured` should be `draw_lbwh_rectangle_textured`

### Changes

1. Add new `draw_lbwh_rectangle_textured` function
   1. Add function itself
   2. Add it to local `__all__`
   3. Update `arcade.__all__`
2. Deprecate `draw_lrwh_rectangle_textured`
3. Switch usage:
   1. `arcade.gui.surface.Surface`
   3. Examples
   4. Tests