### PR TITLE
Add exception-raising copy dunders via reusable decorator

### DIFF
--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -34,6 +34,7 @@ from arcade.gui.nine_patch import NinePatchTexture
 from arcade.gui.property import Property, bind, ListProperty
 from arcade.gui.surface import Surface
 from arcade.types import RGBA255, Color, Point, AsFloat
+from arcade.utils import copy_dunders_unimplemented
 
 if TYPE_CHECKING:
     from arcade.gui.ui_manager import UIManager
@@ -263,6 +264,7 @@ class _ChildEntry(NamedTuple):
     data: Dict
 
 
+@copy_dunders_unimplemented
 class UIWidget(EventDispatcher, ABC):
     """
     The :class:`UIWidget` class is the base class required for creating widgets.

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -21,6 +21,8 @@ __all__ = [
     "PhysicsEnginePlatformer"
 ]
 
+from arcade.utils import copy_dunders_unimplemented
+
 
 def _circular_check(player: Sprite, walls: List[SpriteList]):
     """
@@ -221,6 +223,7 @@ def _move_sprite(moving_sprite: Sprite, walls: List[SpriteList[SpriteType]], ram
     return complete_hit_list
 
 
+@copy_dunders_unimplemented
 class PhysicsEngineSimple:
     """
     Simplistic physics engine for use in games without gravity, such as top-down
@@ -266,6 +269,7 @@ class PhysicsEngineSimple:
         return _move_sprite(self.player_sprite, self.walls, ramp_up=False)
 
 
+@copy_dunders_unimplemented
 class PhysicsEnginePlatformer:
     """
     Simplistic physics engine for use in a platformer. It is easier to get

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -18,6 +18,7 @@ __all__ = [
     "PymunkPhysicsEngine"
 ]
 
+from arcade.utils import copy_dunders_unimplemented
 
 LOG = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ class PymunkException(Exception):
     pass
 
 
+# Temp fix for https://github.com/pythonarcade/arcade/issues/2074
+@copy_dunders_unimplemented
 class PymunkPhysicsEngine:
     """
     Pymunk Physics Engine

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -26,6 +26,8 @@ from typing import (
 import pyglet.gl as gl
 
 from arcade.types import Color, Point, PointList, RGBA255
+
+from arcade.utils import copy_dunders_unimplemented
 from arcade import get_window, get_points_for_thick_line
 from arcade.gl import BufferDescription
 from arcade.gl import Program
@@ -59,6 +61,7 @@ __all__ = [
 ]
 
 
+@copy_dunders_unimplemented  # Temp fix for https://github.com/pythonarcade/arcade/issues/2074
 class Shape:
     """
     A container for arbitrary geometry representing a shape.
@@ -747,6 +750,7 @@ def create_ellipse_filled_with_colors(
 TShape = TypeVar('TShape', bound=Shape)
 
 
+@copy_dunders_unimplemented
 class ShapeElementList(Generic[TShape]):
     """
     A ShapeElementList is a list of shapes that can be drawn together

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, List, TypeVar, Any, Tuple
 
-from typing_extensions import Self
-
 import arcade
 from arcade.types import Point, Color, RGBA255, RGBOrA255, PointList
 from arcade.color import BLACK, WHITE
 from arcade.hitbox import HitBox
 from arcade.texture import Texture
+from arcade.utils import copy_dunders_unimplemented
 
 if TYPE_CHECKING:
     from arcade.sprite_list import SpriteList
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
 SpriteType = TypeVar("SpriteType", bound="BasicSprite")
 
 
+@copy_dunders_unimplemented # See https://github.com/pythonarcade/arcade/issues/2074
 class BasicSprite:
     """
     The absolute minimum needed for a sprite.
@@ -71,18 +71,6 @@ class BasicSprite:
         self._hit_box = HitBox(
             self._texture.hit_box_points, self._position, self._scale
         )
-
-    # --- See https://github.com/pythonarcade/arcade/issues/2074 ---
-
-    def __copy__(self) -> Self:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.__copy__ is not yet implemented,"
-            f" but you can implement it on a custom subclass if you wish.")
-
-    def __deepcopy__(self, memo) -> Self:
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.__deepcopy__ is not yet implemented,"
-            f" but you can implement it on a custom subclass if you wish.")
 
     # --- Core Properties ---
 

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -79,7 +79,7 @@ class BasicSprite:
             f"{self.__class__.__name__}.__copy__ is not yet implemented,"
             f" but you can implement it on a custom subclass if you wish.")
 
-    def __deepcopy__(self) -> Self:
+    def __deepcopy__(self, memo) -> Self:
         raise NotImplementedError(
             f"{self.__class__.__name__}.__deepcopy__ is not yet implemented,"
             f" but you can implement it on a custom subclass if you wish.")

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, List, TypeVar, Any, Tuple
 
+from typing_extensions import Self
+
 import arcade
 from arcade.types import Point, Color, RGBA255, RGBOrA255, PointList
 from arcade.color import BLACK, WHITE
@@ -69,6 +71,18 @@ class BasicSprite:
         self._hit_box = HitBox(
             self._texture.hit_box_points, self._position, self._scale
         )
+
+    # --- See https://github.com/pythonarcade/arcade/issues/2074 ---
+
+    def __copy__(self) -> Self:
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.__copy__ is not yet implemented,"
+            f" but you can implement it on a custom subclass if you wish.")
+
+    def __deepcopy__(self) -> Self:
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.__deepcopy__ is not yet implemented,"
+            f" but you can implement it on a custom subclass if you wish.")
 
     # --- Core Properties ---
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -38,6 +38,7 @@ from arcade.types import Color, RGBA255, RGBOrANormalized, RGBANormalized
 from arcade.gl.types import OpenGlFilter, BlendFunction, PyGLenum
 from arcade.gl.buffer import Buffer
 from arcade.gl.vertex_array import Geometry
+from arcade.utils import copy_dunders_unimplemented
 
 if TYPE_CHECKING:
     from arcade import Texture, TextureAtlas
@@ -53,6 +54,7 @@ _SPRITE_SLOT_INVISIBLE = 2000000000
 _DEFAULT_CAPACITY = 100
 
 
+@copy_dunders_unimplemented  # Temp fixes https://github.com/pythonarcade/arcade/issues/2074
 class SpriteList(Generic[SpriteType]):
     """
     The purpose of the spriteList is to batch draw a list of sprites.

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -112,7 +112,9 @@ class NormalizedRangeError(FloatOutsideRangeError):
         super().__init__(var_name, value, 0.0, 1.0)
 
 
-def copy_dunders_unimplemented(decorated_type: Type) -> Type:
+_TType = TypeVar('_TType', bound=Type)
+
+def copy_dunders_unimplemented(decorated_type: _TType) -> _TType:
     """Decorator stubs dunders raising :py:class:`NotImplementedError`.
 
     Temp fixes https://github.com/pythonarcade/arcade/issues/2074 by

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -11,6 +11,7 @@ import platform
 import sys
 import warnings
 from typing import Tuple, Type, TypeVar
+from typing_extensions import Self
 from pathlib import Path
 
 
@@ -24,6 +25,7 @@ __all__ = [
     "NormalizedRangeError",
     "PerformanceWarning",
     "ReplacementWarning",
+    "copy_dunders_unimplemented",
     "warning",
     "generate_uuid_from_kwargs",
     "is_raspberry_pi",
@@ -110,6 +112,53 @@ class NormalizedRangeError(FloatOutsideRangeError):
     def __init__(self, var_name: str, value: float):
         super().__init__(var_name, value, 0.0, 1.0)
 
+
+def copy_dunders_unimplemented(decorated_type: Type) -> Type:
+    """Decorator stubs dunders raising :py:class:`NotImplementedError`.
+
+    Temp fixes https://github.com/pythonarcade/arcade/issues/2074 by
+    stubbing the following instance methods:
+
+    * :py:meth:`object.__copy__` (used by :py:func:`copy.copy`)
+    * :py:meth:`object.__deepcopy__` (used by :py:func:`copy.deepcopy`)
+
+    Example usage:
+
+    .. code-block:: python
+
+       import copy
+       from arcade,utils import copy_dunders_unimplemented
+       from arcade.hypothetical_module import HypotheticalNasty
+
+       # Example usage
+       @copy_dunders_unimplemented
+       class CantCopy:
+            def __init__(self, nasty_state: HypotheticalNasty):
+                self.nasty_state = nasty_state
+
+       instance = CantCopy(HypotheticalNasty())
+
+       # These raise NotImplementedError
+       this_line_raises = copy.deepcopy(instance)
+       this_line_also_raises = copy.copy(instance)
+
+
+    """
+    def __copy__(self) -> Self:  # noqa  # Self outside classes
+       raise NotImplementedError(
+           f"{self.__class__.__name__} does not implement __copy__, but"
+           f"you may implement it on a custom subclass."
+       )
+    decorated_type.__copy__ =  __copy__
+
+    def __deepcopy__(self, memo) -> Self:  # noqa  # Self outside classes
+       raise NotImplementedError(
+           f"{self.__class__.__name__} does not implement __deepcopy__,"
+           f" but you may implement it on a custom subclass."
+       )
+    decorated_type.__deepcopy__ = __deepcopy__
+
+    return decorated_type
 
 class PerformanceWarning(Warning):
     """Use this for issuing performance warnings."""

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -11,7 +11,6 @@ import platform
 import sys
 import warnings
 from typing import Tuple, Type, TypeVar
-from typing_extensions import Self
 from pathlib import Path
 
 
@@ -144,14 +143,14 @@ def copy_dunders_unimplemented(decorated_type: Type) -> Type:
 
 
     """
-    def __copy__(self) -> Self:  # noqa  # Self outside classes
+    def __copy__(self):  # noqa
        raise NotImplementedError(
            f"{self.__class__.__name__} does not implement __copy__, but"
            f"you may implement it on a custom subclass."
        )
     decorated_type.__copy__ =  __copy__
 
-    def __deepcopy__(self, memo) -> Self:  # noqa  # Self outside classes
+    def __deepcopy__(self, memo):  # noqa
        raise NotImplementedError(
            f"{self.__class__.__name__} does not implement __deepcopy__,"
            f" but you may implement it on a custom subclass."

--- a/tests/unit/physics_engine/test_physics_engine2.py
+++ b/tests/unit/physics_engine/test_physics_engine2.py
@@ -1,4 +1,7 @@
 """ Physics engine tests. """
+import copy
+
+import pytest
 
 import arcade
 
@@ -287,6 +290,14 @@ def platformer_tests(moving_sprite, wall_list, physics_engine):
     assert moving_sprite.position == (3, -6)
 
 
+# Temp fix for https://github.com/pythonarcade/arcade/issues/2074
+def nocopy_tests(physics_engine):
+    with pytest.raises(NotImplementedError):
+        _ = copy.copy(physics_engine)
+    with pytest.raises(NotImplementedError):
+        _ = copy.deepcopy(physics_engine)
+
+
 def test_main(window: arcade.Window):
     character_list = arcade.SpriteList()
     wall_list = arcade.SpriteList()
@@ -303,9 +314,11 @@ def test_main(window: arcade.Window):
     physics_engine = arcade.PhysicsEngineSimple(moving_sprite, wall_list)
     basic_tests(moving_sprite, wall_list, physics_engine)
     simple_engine_tests(moving_sprite, wall_list, physics_engine)
+    nocopy_tests(physics_engine)
 
     physics_engine = arcade.PhysicsEnginePlatformer(
         moving_sprite, wall_list, gravity_constant=0.0
     )
     basic_tests(moving_sprite, wall_list, physics_engine)
     platformer_tests(moving_sprite, wall_list, physics_engine)
+    nocopy_tests(physics_engine)

--- a/tests/unit/physics_engine/test_pymunk.py
+++ b/tests/unit/physics_engine/test_pymunk.py
@@ -23,6 +23,18 @@ def test_pymunk():
     assert(my_sprite.center_y == -300.0)
 
 
+# Temp fix for https://github.com/pythonarcade/arcade/issues/2074
+def test_pymunk_engine_nocopy():
+    import copy
+    physics_engine = arcade.PymunkPhysicsEngine(
+        damping=1.0, gravity=(0, -100))
+
+    with pytest.raises(NotImplementedError):
+        _ = copy.copy(physics_engine)
+    with pytest.raises(NotImplementedError):
+        _ = copy.deepcopy(physics_engine)
+
+
 @pytest.mark.parametrize("moment_of_inertia_arg_name",
                          (
                              "moment_of_inertia",

--- a/tests/unit/shape_list/test_buffered_drawing.py
+++ b/tests/unit/shape_list/test_buffered_drawing.py
@@ -1,3 +1,6 @@
+import copy
+import pytest
+
 import arcade
 from arcade.shape_list import (
     ShapeElementList,
@@ -18,7 +21,9 @@ SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
 
 
-def test_buffered_drawing(window):
+@pytest.fixture
+def shape_list_instance() -> ShapeElementList:
+
     shape_list = ShapeElementList()
 
     center_x = 0
@@ -84,11 +89,35 @@ def test_buffered_drawing(window):
     shape = create_line_generic(points, arcade.color.ALIZARIN_CRIMSON, gl.GL_TRIANGLE_FAN)
     shape_list.append(shape)
 
-    shape_list.center_x = 200
-    shape_list.center_y = 200
+    return shape_list
+
+
+def test_shape_copy_dunders_raise_notimplemented_error(window, shape_list_instance):
+
+    for shape in shape_list_instance:
+        with pytest.raises(NotImplementedError):
+            _ = copy.copy(shape)
+        with pytest.raises(NotImplementedError):
+            _ = copy.deepcopy(shape)
+
+
+# Temp fix for https://github.com/pythonarcade/arcade/issues/2074
+def test_shapeelementlist_copy_dunders_raise_notimplemented_error(window, shape_list_instance):
+
+    with pytest.raises(NotImplementedError):
+        _ = copy.copy(shape_list_instance)
+
+    with pytest.raises(NotImplementedError):
+        _ = copy.deepcopy(shape_list_instance)
+
+
+def test_buffered_drawing(window, shape_list_instance):
+
+    shape_list_instance.center_x = 200
+    shape_list_instance.center_y = 200
 
     for _ in range(10):
-        shape_list.draw()
+        shape_list_instance.draw()
         window.flip()
         window.clear()
-        shape_list.move(1, 1)
+        shape_list_instance.move(1, 1)

--- a/tests/unit/sprite/test_copy_dunders.py
+++ b/tests/unit/sprite/test_copy_dunders.py
@@ -1,0 +1,43 @@
+import copy
+import pytest
+
+import arcade
+
+
+def test_copy_dunders_raise_notimplementederror():
+    """Make sure our sprite types raise NotImplentedError for copy dunders.
+
+    See the following GitHub issue for more context:
+    https://github.com/pythonarcade/arcade/issues/2074
+    """
+
+    # Make sure BasicSprite raises NotImplementedError
+    texture = arcade.load_texture(":resources:images/animated_characters/female_person/femalePerson_idle.png")
+    basic_sprite = arcade.BasicSprite(texture)
+
+    with pytest.raises(NotImplementedError):
+        copy.copy(basic_sprite)
+
+    with pytest.raises(NotImplementedError):
+        copy.deepcopy(basic_sprite)
+
+    sprite = arcade.Sprite(texture)
+    with pytest.raises(NotImplementedError):
+        copy.copy(sprite)
+
+    with pytest.raises(NotImplementedError):
+        copy.deepcopy(sprite)
+
+    circle = arcade.SpriteCircle(5, arcade.color.RED)
+    with pytest.raises(NotImplementedError):
+        copy.copy(circle)
+
+    with pytest.raises(NotImplementedError):
+        copy.deepcopy(circle)
+
+    solid = arcade.SpriteSolidColor(10, 10, color=arcade.color.RED)
+    with pytest.raises(NotImplementedError):
+        copy.copy(solid)
+
+    with pytest.raises(NotImplementedError):
+        copy.deepcopy(solid)

--- a/tests/unit/spritelist/test_spritelist.py
+++ b/tests/unit/spritelist/test_spritelist.py
@@ -18,6 +18,18 @@ def make_named_sprites(amount):
     return spritelist
 
 
+# Temp fix for  https://github.com/pythonarcade/arcade/issues/2074
+def test_copy_dunder_stubs_raise_notimplementederror():
+    spritelist = arcade.SpriteList()
+    import copy
+
+    with pytest.raises(NotImplementedError):
+       _ = copy.copy(spritelist)
+
+    with pytest.raises(NotImplementedError):
+       _ = copy.deepcopy(spritelist)
+
+
 def test_it_can_extend_a_spritelist_from_a_list():
     spritelist = arcade.SpriteList()
     sprites = []


### PR DESCRIPTION
TL;DR: Use decorator to stub `__copy__` and `__deepcopy__` per #2074 + add a bunch of tests

### Changes

1. Add decorator which adds stubs with informative messages
2. Apply it to the following + add tests:
   * `SpriteList`
   * `BasicSprite` + tests for subclasses:
      * `Sprite`
      * `SpriteSolidColor`
      * `SpriteCircle`
   * `ShapeElementList` and `Shape`

3. Apply the decorator to the base `UIWidget`
   * This should cover all child widgets
   * Tests omitted since adding / removing the decorator as needed is fast and easy
   * It seems unlikely that people will be trying to copy widgets
