### PR TITLE
Give Projectors `Project` and `Unproject` methods.

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -23,8 +23,6 @@ from arcade.context import ArcadeContext
 from arcade.types import Color, RGBOrA255, RGBANormalized
 from arcade import SectionManager
 from arcade.utils import is_raspberry_pi
-from arcade.camera import Projector
-from arcade.camera.default import DefaultProjector
 
 LOG = logging.getLogger(__name__)
 
@@ -217,8 +215,6 @@ class Window(pyglet.window.Window):
         self._background_color: Color = TRANSPARENT_BLACK
 
         self._current_view: Optional[View] = None
-        self._default_camera = DefaultProjector(window=self)
-        self.current_camera: Projector = self._default_camera
         self.textbox_time = 0.0
         self.key: Optional[int] = None
         self.flip_count: int = 0
@@ -611,8 +607,7 @@ class Window(pyglet.window.Window):
         #       The arcade context is not created at that time
         if hasattr(self, "_ctx"):
             # Retain projection scrolling if applied
-            self._ctx.viewport = (0, 0, width, height)
-            self.default_camera.use()
+            self.viewport = (0, 0, width, height)
 
     def set_min_size(self, width: int, height: int):
         """ Wrap the Pyglet window call to set minimum size
@@ -685,9 +680,37 @@ class Window(pyglet.window.Window):
         """
         Provides a reference to the default arcade camera.
         Automatically sets projection and view to the size
-        of the screen. Good for resetting the screen.
+        of the screen.
         """
-        return self._default_camera
+        return self._ctx._default_camera
+
+    @property
+    def current_camera(self):
+        """
+        Get/Set the current camera. This represents the projector
+        currently being used to define the projection and view matrices.
+        """
+        return self._ctx.current_camera
+
+    @current_camera.setter
+    def current_camera(self, next_camera):
+        self._ctx.current_camera = next_camera
+
+    @property
+    def viewport(self) -> tuple[int, int, int, int]:
+        """
+        Get/Set the viewport of the window. This is the viewport used for
+        on-screen rendering. If the screen is in use it will also update the
+        default camera.
+        """
+        return self.screen.viewport
+
+    @viewport.setter
+    def viewport(self, new_viewport: tuple[int, int, int, int]):
+        if self.screen == self._ctx.active_framebuffer:
+            self._ctx.viewport = new_viewport
+        else:
+            self.screen.viewport = new_viewport
 
     def test(self, frames: int = 10):
         """

--- a/arcade/camera/__init__.py
+++ b/arcade/camera/__init__.py
@@ -11,6 +11,12 @@ from arcade.camera.data_types import (
     PerspectiveProjectionData
 )
 
+from arcade.camera.projection_functions import (
+    generate_view_matrix,
+    generate_orthographic_matrix,
+    generate_perspective_matrix
+)
+
 from arcade.camera.orthographic import OrthographicProjector
 from arcade.camera.perspective import PerspectiveProjector
 
@@ -23,9 +29,12 @@ __all__ = [
     'Projection',
     'Projector',
     'CameraData',
+    'generate_view_matrix',
     'OrthographicProjectionData',
+    'generate_orthographic_matrix',
     'OrthographicProjector',
     'PerspectiveProjectionData',
+    'generate_perspective_matrix',
     'PerspectiveProjector',
     'Camera2D',
     'grips'

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Tuple, Iterator
+from typing import TYPE_CHECKING, Optional, Tuple, Generator
 from math import degrees, radians, atan2, cos, sin
 from contextlib import contextmanager
 
@@ -781,7 +781,7 @@ class Camera2D:
         self._ortho_projector.use()
 
     @contextmanager
-    def activate(self) -> Iterator[Projector]:
+    def activate(self) -> Generator[Self, None, None]:
         """
         Set internal projector as window projector,
         and set the projection and view matrix.

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -800,11 +800,15 @@ class Camera2D:
             previous_framebuffer.use()
             previous_projection.use()
 
-    def map_screen_to_world_coordinate(
-            self,
-            screen_coordinate: Tuple[float, float],
-            depth: Optional[float] = 0.0
-    ) -> Tuple[float, float]:
+    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+        """
+        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
+        """
+        return self._ortho_projector.project(world_coordinate)
+
+    def unproject(self,
+                  screen_coordinate: Tuple[float, float],
+                  depth: Optional[float] = None) -> Tuple[float, float]:
         """
         Take in a pixel coordinate from within
         the range of the window size and returns
@@ -815,12 +819,23 @@ class Camera2D:
         Args:
             screen_coordinate: A 2D position in pixels from the bottom left of the screen.
                                This should ALWAYS be in the range of 0.0 - screen size.
-            depth: The depth value which is mapped along with the screen coordinates. Because of how
-                   Orthographic perspectives work this does not impact how the screen_coordinates are mapped.
+            depth: The depth of the query
         Returns:
             A 2D vector (Along the XY plane) in world space (same as sprites).
             perfect for finding if the mouse overlaps with a sprite or ui element irrespective
             of the camera.
         """
+        world_coordinate = self._ortho_projector.unproject(screen_coordinate, depth)
 
-        return self._ortho_projector.map_screen_to_world_coordinate(screen_coordinate, depth)[:2]
+        return world_coordinate[0], world_coordinate[1]
+
+    def map_screen_to_world_coordinate(
+            self,
+            screen_coordinate: Tuple[float, float],
+            depth: Optional[float] = None
+    ) -> Tuple[float, float]:
+        """
+        Alias to Camera2D.unproject() for typing completion
+        """
+        return self.unproject(screen_coordinate, depth)
+

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -800,7 +800,7 @@ class Camera2D:
             previous_framebuffer.use()
             previous_projection.use()
 
-    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+    def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """
         Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
         """

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -8,7 +8,6 @@ from arcade.camera.orthographic import OrthographicProjector
 from arcade.camera.data_types import (
     CameraData,
     OrthographicProjectionData,
-    Projector,
     ZeroProjectionDimension
 )
 from arcade.gl import Framebuffer

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -808,7 +808,7 @@ class Camera2D:
 
     def unproject(self,
                   screen_coordinate: Tuple[float, float],
-                  depth: Optional[float] = None) -> Tuple[float, float]:
+                  depth: Optional[float] = None) -> Tuple[float, float, float]:
         """
         Take in a pixel coordinate from within
         the range of the window size and returns
@@ -821,19 +821,18 @@ class Camera2D:
                                This should ALWAYS be in the range of 0.0 - screen size.
             depth: The depth of the query
         Returns:
-            A 2D vector (Along the XY plane) in world space (same as sprites).
+            A 3D vector in world space (same as sprites).
             perfect for finding if the mouse overlaps with a sprite or ui element irrespective
             of the camera.
         """
-        world_coordinate = self._ortho_projector.unproject(screen_coordinate, depth)
 
-        return world_coordinate[0], world_coordinate[1]
+        return self._ortho_projector.unproject(screen_coordinate, depth)
 
     def map_screen_to_world_coordinate(
             self,
             screen_coordinate: Tuple[float, float],
             depth: Optional[float] = None
-    ) -> Tuple[float, float]:
+    ) -> Tuple[float, float, float]:
         """
         Alias to Camera2D.unproject() for typing completion
         """

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -4,7 +4,7 @@ These are placed in their own module to simplify imports due to their
 wide usage throughout Arcade's camera code.
 """
 from __future__ import annotations
-from typing import Protocol, Tuple, Iterator, Optional, Generator, Self
+from typing import Protocol, Tuple, Iterator, Optional, Generator
 from contextlib import contextmanager
 
 from typing_extensions import Self

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -4,9 +4,10 @@ These are placed in their own module to simplify imports due to their
 wide usage throughout Arcade's camera code.
 """
 from __future__ import annotations
-from typing import Protocol, Tuple, Iterator, Optional
+from typing import Protocol, Tuple, Iterator, Optional, Generator, Union
 from contextlib import contextmanager
 
+from typing_extensions import Self
 from pyglet.math import Vec3
 
 
@@ -184,19 +185,134 @@ class PerspectiveProjectionData:
 
 
 class Projection(Protocol):
+    """Matches the data universal in Arcade's projection data objects.
+
+    There are multiple types of projections used in games, but all the
+    common ones share key features. This :py:class:`~typing.Protocol`:
+
+    #. Defines those shared elements
+    #. Annotates these in code for both humans and automated type
+       checkers
+
+    The specific implementations which match it are used inside of
+    implementations of Arcade's :py:class:`.Projector` behavior. All
+    of these projectors rely on a ``viewport`` as well as ``near`` and
+    ``far`` values.
+
+    The ``viewport`` is measured in screen pixels. By default, the
+    conventions for this are the same as the rest of Arcade and
+    OpenGL:
+
+    * X is measured rightward from left of the screen
+    * Y is measured up from the bottom of the screen
+
+    Although the ``near`` and ``far`` values are describe the cutoffs
+    for what the camera sees in world space, the exact meaning differs
+    between projection type.
+
+    .. list-table::
+       :header-rows: 1
+
+       * - Common Projection Type
+         - Meaning of ``near`` & ``far``
+
+       * - Simple Orthographic
+         - The Z position in world space
+
+       * - Perspective & Isometric
+         - Where the rear and front clipping planes sit along a
+           camera's :py:attr:`.CameraData.forward` vector.
+
+    """
     viewport: Tuple[int, int, int, int]
     near: float
     far: float
 
 
 class Projector(Protocol):
+    """Projects from world coordinates to viewport pixel coordinates.
+
+    Projectors also support converting in the opposite direction from
+    screen pixel coordinates to world space coordinates.
+
+    The two key spatial methods which do this are:
+
+    .. list-table::
+       :header-rows: 1
+       * - Method
+         - Action
+
+       * - :py:meth:`.project`
+         - Turn world coordinates into pixel coordinates relative
+           to the origin (bottom left by default).
+
+       * - :py:meth:`.unproject`
+         - Convert screen pixel coordinates into world space.
+
+    .. note: Every :py:class:`.Camera` is also a kind of projector.
+
+    The other required methods are for helping manage which camera is
+    currently used to draw.
+
+    """
+
+    _window: Union["Window", None]
 
     def use(self) -> None:
+        """Set the GL context to use this projector and its settings.
+
+        .. warning:: You may be looking for:py:meth:`.activate`!
+
+                     This method only sets rendering state for a given
+                     projector. Since it doesn't restore any afterward,
+                     it's easy to misuse in ways which can cause bugs
+                     or temporarily break a game's rendering until
+                     relaunch. For reliable, automatic clean-up see
+                     the :py:meth:`.activate` method instead.
+
+        If you are implementing your own custom projector, this method
+        should only:
+
+        #. Set the Arcade :py:class:`~arcade.Window`'s
+           :py:attr:`~arcade.Window.current_camera` to this object
+        #. Calculate any required view and projection matrices
+        #. Set any resulting values on the current
+           :py:class:`~arcade.context.ArcadeContext`, including the:
+
+           * :py:attr:`~arcade.context.ArcadeContext.viewport`
+           * :py:attr:`~arcade.context.ArcadeContext.view_matrix`
+           * :py:attr:`~arcade.context.ArcadeContext.projection_matrix`
+
+        This method should **never** handle cleanup. That is the
+        responsibility of :py:attr:`.activate`.
+
+        """
         ...
 
     @contextmanager
-    def activate(self) -> Iterator[Projector]:
-        ...
+    def activate(self) -> Generator[Self, None, None]:
+        """Set this camera as the current one, then undo it after.
+
+        This method is a :ref+external:`context manager <context-managers>`
+        you can use inside ``with`` blocks. Using it this way guarantees
+        that the old camera and its settings will be restored, even if an
+        exception occurs:
+
+        .. code-block:: python
+
+           # Despite an Exception, the previous camera and its settings
+           # will be restored at the end of the with block below:
+           with projector_instance.activate():
+                sprite_list.draw()
+                _ = 1 / 0  # Guaranteed ZeroDivisionError
+
+        """
+        previous_projector = self._window.current_camera
+        try:
+            self.use()
+            yield self
+        finally:
+            previous_projector.use()
 
     def map_screen_to_world_coordinate(
             self,

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -4,7 +4,7 @@ These are placed in their own module to simplify imports due to their
 wide usage throughout Arcade's camera code.
 """
 from __future__ import annotations
-from typing import Protocol, Tuple, Iterator, Optional, Generator, Union
+from typing import Protocol, Tuple, Iterator, Optional, Generator, Self
 from contextlib import contextmanager
 
 from typing_extensions import Self
@@ -256,8 +256,6 @@ class Projector(Protocol):
 
     """
 
-    _window: Union["Window", None]
-
     def use(self) -> None:
         """Set the GL context to use this projector and its settings.
 
@@ -291,28 +289,7 @@ class Projector(Protocol):
 
     @contextmanager
     def activate(self) -> Generator[Self, None, None]:
-        """Set this camera as the current one, then undo it after.
-
-        This method is a :ref+external:`context manager <context-managers>`
-        you can use inside ``with`` blocks. Using it this way guarantees
-        that the old camera and its settings will be restored, even if an
-        exception occurs:
-
-        .. code-block:: python
-
-           # Despite an Exception, the previous camera and its settings
-           # will be restored at the end of the with block below:
-           with projector_instance.activate():
-                sprite_list.draw()
-                _ = 1 / 0  # Guaranteed ZeroDivisionError
-
-        """
-        previous_projector = self._window.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous_projector.use()
+        ...
 
     def map_screen_to_world_coordinate(
             self,

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -75,7 +75,7 @@ class ViewportProjector:
         finally:
             previous.use()
 
-    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+    def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """
         Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
         """
@@ -90,7 +90,7 @@ class ViewportProjector:
 
         Due to the nature of viewport projector this does not do anything.
         """
-        return screen_coordinate[0], screen_coordinate[1], depth
+        return screen_coordinate[0], screen_coordinate[1], depth or 0.0
 
     def map_screen_to_world_coordinate(
             self,

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -1,9 +1,9 @@
-from typing import Optional, Tuple, Generator, Self, TYPE_CHECKING
+from typing import Optional, Tuple, Generator, TYPE_CHECKING
+from typing_extensions import Self
 from contextlib import contextmanager
 
 from pyglet.math import Mat4
 
-from arcade.camera.data_types import Projector
 from arcade.window_commands import get_window
 if TYPE_CHECKING:
     from arcade.context import ArcadeContext

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -75,16 +75,31 @@ class ViewportProjector:
         finally:
             previous.use()
 
-    def map_screen_to_world_coordinate(
+    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+        """
+        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
+        """
+        return world_coordinate[0], world_coordinate[1]
+
+    def unproject(
             self,
             screen_coordinate: Tuple[float, float],
-            depth: Optional[float] = 0.0) -> Tuple[float, float]:
+            depth: Optional[float] = None) -> Tuple[float, float, float]:
         """
         Map the screen pos to screen_coordinates.
 
         Due to the nature of viewport projector this does not do anything.
         """
-        return screen_coordinate
+        return screen_coordinate[0], screen_coordinate[1], depth
+
+    def map_screen_to_world_coordinate(
+            self,
+            screen_coordinate: Tuple[float, float],
+            depth: Optional[float] = None) -> Tuple[float, float, float]:
+        """
+        Alias of ViewportProjector.unproject() for typing.
+        """
+        return self.unproject(screen_coordinate, depth)
 
 
 # As this class is only supposed to be used internally

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,5 +1,6 @@
-from typing import Optional, Tuple, Generator, Self, TYPE_CHECKING
+from typing import Optional, Tuple, Generator, TYPE_CHECKING
 from contextlib import contextmanager
+from typing_extensions import Self
 
 from pyglet.math import Mat4, Vec4
 

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
 
-from pyglet.math import Mat4, Vec3, Vec4
+from pyglet.math import Mat4, Vec4
 
 from arcade.camera.data_types import Projector, CameraData, OrthographicProjectionData
 from arcade.camera.projection_functions import generate_view_matrix, generate_orthographic_matrix
@@ -116,7 +116,7 @@ class OrthographicProjector:
         finally:
             previous_projector.use()
 
-    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+    def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """
         Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
         """

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import Optional, Tuple, Generator, Self, TYPE_CHECKING
+from contextlib import contextmanager
 
 from pyglet.math import Mat4, Vec4
 
@@ -101,6 +102,31 @@ class OrthographicProjector(Projector):
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
         self._window.view = _view
+
+    @contextmanager
+    def activate(self) -> Generator[Self, None, None]:
+        """Set this camera as the current one, then undo it after.
+
+        This method is a :ref+external:`context manager <context-managers>`
+        you can use inside ``with`` blocks. Using it this way guarantees
+        that the old camera and its settings will be restored, even if an
+        exception occurs:
+
+        .. code-block:: python
+
+           # Despite an Exception, the previous camera and its settings
+           # will be restored at the end of the with block below:
+           with projector_instance.activate():
+                sprite_list.draw()
+                _ = 1 / 0  # Guaranteed ZeroDivisionError
+
+        """
+        previous_projector = self._window.current_camera
+        try:
+            self.use()
+            yield self
+        finally:
+            previous_projector.use()
 
     def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -116,11 +116,33 @@ class OrthographicProjector:
         finally:
             previous_projector.use()
 
-    def map_screen_to_world_coordinate(
-            self,
+    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+        """
+        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
+        """
+        if len(world_coordinate) > 2:
+            z = world_coordinate[2]
+        else:
+            z = 0.0
+        x, y = world_coordinate[0], world_coordinate[1]
+
+        viewport = self._projection.viewport
+
+        world_position = Vec4(x, y, z, 1.0)
+
+        _projection = generate_orthographic_matrix(self._projection, self._view.zoom)
+        _view = generate_view_matrix(self._view)
+
+        projected_position = _projection @ _view @ world_position
+
+        screen_coordinate_x = viewport[0] + (0.5 * projected_position.x + 0.5) * viewport[2]
+        screen_coordinate_y = viewport[1] + (0.5 * projected_position.y + 0.5) * viewport[3]
+
+        return screen_coordinate_x, screen_coordinate_y
+
+    def unproject(self,
             screen_coordinate: Tuple[float, float],
-            depth: Optional[float] = None
-    ) -> Tuple[float, float, float]:
+            depth: Optional[float] = None) -> Tuple[float, float, float]:
         """
         Take in a pixel coordinate from within
         the range of the window size and returns
@@ -146,3 +168,14 @@ class OrthographicProjector:
         _world_position = _view @ Vec4(_unprojected_position.x, _unprojected_position.y, depth or 0.0, 1.0)
 
         return _world_position.x, _world_position.y, _world_position.z
+
+    def map_screen_to_world_coordinate(
+            self,
+            screen_coordinate: Tuple[float, float],
+            depth: Optional[float] = None
+    ) -> Tuple[float, float, float]:
+        """
+        Alias of OrthographicProjector.unproject() for typing.
+        """
+        return self.unproject(screen_coordinate, depth)
+

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -119,7 +119,7 @@ class OrthographicProjector:
     def map_screen_to_world_coordinate(
             self,
             screen_coordinate: Tuple[float, float],
-            depth: Optional[float] = 0.0
+            depth: Optional[float] = None
     ) -> Tuple[float, float, float]:
         """
         Take in a pixel coordinate from within
@@ -139,13 +139,10 @@ class OrthographicProjector:
         screen_x = 2.0 * (screen_coordinate[0] - self._projection.viewport[0]) / self._projection.viewport[2] - 1
         screen_y = 2.0 * (screen_coordinate[1] - self._projection.viewport[1]) / self._projection.viewport[3] - 1
 
-        _projection = generate_orthographic_matrix(self._projection, self._view.zoom)
-        _view = generate_view_matrix(self._view)
+        _projection = ~generate_orthographic_matrix(self._projection, self._view.zoom)
+        _view = ~generate_view_matrix(self._view)
 
-        screen_position = Vec4(screen_x, screen_y, 0.0, 1.0)
+        _unprojected_position = _projection @ Vec4(screen_x, screen_y, 0.0, 1.0)
+        _world_position = _view @ Vec4(_unprojected_position.x, _unprojected_position.y, depth or 0.0, 1.0)
 
-        _full = ~(_projection @ _view)
-
-        _mapped_position = _full @ screen_position
-
-        return _mapped_position.x, _mapped_position.y, depth
+        return _world_position.x, _world_position.y, _world_position.z

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,5 +1,4 @@
-from typing import Optional, Tuple, Iterator, TYPE_CHECKING
-from contextlib import contextmanager
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from pyglet.math import Mat4, Vec4
 
@@ -16,7 +15,7 @@ __all__ = [
 ]
 
 
-class OrthographicProjector:
+class OrthographicProjector(Projector):
     """
     The simplest from of an orthographic camera.
     Using ViewData and OrthographicProjectionData PoDs (Pack of Data)
@@ -102,19 +101,6 @@ class OrthographicProjector:
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
         self._window.view = _view
-
-    @contextmanager
-    def activate(self) -> Iterator[Projector]:
-        """
-        A context manager version of OrthographicProjector.use() which allows for the use of
-        `with` blocks. For example, `with camera.activate() as cam: ...`.
-        """
-        previous_projector = self._window.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous_projector.use()
 
     def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from pyglet.math import Mat4, Vec3, Vec4
 
 from arcade.camera.data_types import Projector, CameraData, OrthographicProjectionData
+from arcade.camera.projection_functions import generate_view_matrix, generate_orthographic_matrix
 
 from arcade.window_commands import get_window
 if TYPE_CHECKING:
@@ -74,53 +75,17 @@ class OrthographicProjector:
         """
         return self._projection
 
-    def _generate_projection_matrix(self) -> Mat4:
+    def generate_projection_matrix(self) -> Mat4:
         """
-        Using the OrthographicProjectionData a projection matrix is generated where the size of the
-        objects is not affected by depth.
-
-        Generally keep the scale value to integers or negative powers of integers (2^-1, 3^-1, 2^-2, etc.) to keep
-        the pixels uniform in size. Avoid a zoom of 0.0.
+        alias of arcade.camera.get_orthographic_matrix method
         """
+        return generate_orthographic_matrix(self._projection, self._view.zoom)
 
-        # Find the center of the projection values (often 0,0 or the center of the screen)
-        _projection_center = (
-            (self._projection.left + self._projection.right) / 2,
-            (self._projection.bottom + self._projection.top) / 2
-        )
-
-        # Find half the width of the projection
-        _projection_half_size = (
-            (self._projection.right - self._projection.left) / 2,
-            (self._projection.top - self._projection.bottom) / 2
-        )
-
-        # Scale the projection by the zoom value. Both the width and the height
-        # share a zoom value to avoid ugly stretching.
-        _true_projection = (
-            _projection_center[0] - _projection_half_size[0] / self._view.zoom,
-            _projection_center[0] + _projection_half_size[0] / self._view.zoom,
-            _projection_center[1] - _projection_half_size[1] / self._view.zoom,
-            _projection_center[1] + _projection_half_size[1] / self._view.zoom
-        )
-        return Mat4.orthogonal_projection(*_true_projection, self._projection.near, self._projection.far)
-
-    def _generate_view_matrix(self) -> Mat4:
+    def generate_view_matrix(self) -> Mat4:
         """
-        Using the ViewData it generates a view matrix from the pyglet Mat4 look at function
+        alias of arcade.camera.get_view_matrix method
         """
-        # Even if forward and up are normalised floating point error means every vector must be normalised.
-        fo = Vec3(*self._view.forward).normalize()  # Forward Vector
-        up = Vec3(*self._view.up)  # Initial Up Vector (Not necessarily perpendicular to forward vector)
-        ri = fo.cross(up).normalize()  # Right Vector
-        up = ri.cross(fo).normalize()  # Up Vector
-        po = Vec3(*self._view.position)
-        return Mat4((
-            ri.x,  up.x,  -fo.x,  0,
-            ri.y,  up.y,  -fo.y,  0,
-            ri.z,  up.z,  -fo.z,  0,
-            -ri.dot(po), -up.dot(po), fo.dot(po), 1
-        ))
+        return generate_view_matrix(self._view)
 
     def use(self) -> None:
         """
@@ -131,8 +96,8 @@ class OrthographicProjector:
 
         self._window.current_camera = self
 
-        _projection = self._generate_projection_matrix()
-        _view = self._generate_view_matrix()
+        _projection = generate_orthographic_matrix(self._projection, self._view.zoom)
+        _view = generate_view_matrix(self._view)
 
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
@@ -170,20 +135,17 @@ class OrthographicProjector:
         Returns:
             A 3D vector in world space.
         """
-        depth = depth or 0.0
 
-        # TODO: Integrate z-depth
         screen_x = 2.0 * (screen_coordinate[0] - self._projection.viewport[0]) / self._projection.viewport[2] - 1
         screen_y = 2.0 * (screen_coordinate[1] - self._projection.viewport[1]) / self._projection.viewport[3] - 1
-        screen_z = 2.0 * (depth - self._projection.near) / (self._projection.far - self._projection.near) - 1
 
-        _view = self._generate_view_matrix()
-        _projection = self._generate_projection_matrix()
+        _projection = generate_orthographic_matrix(self._projection, self._view.zoom)
+        _view = generate_view_matrix(self._view)
 
-        screen_position = Vec4(screen_x, screen_y, screen_z, 1.0)
+        screen_position = Vec4(screen_x, screen_y, 0.0, 1.0)
 
         _full = ~(_projection @ _view)
 
         _mapped_position = _full @ screen_position
 
-        return _mapped_position[0], _mapped_position[1], _mapped_position[2]
+        return _mapped_position.x, _mapped_position.y, depth

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Generator, Self, TYPE_CHECKING
+from typing import Optional, Tuple, Generator, TYPE_CHECKING
+from typing_extensions import Self
 from contextlib import contextmanager
 
 from math import tan, radians

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
 
 from math import tan, radians
-from pyglet.math import Mat4, Vec3, Vec4
+from pyglet.math import Mat4, Vec4
 
 from arcade.camera.data_types import Projector, CameraData, PerspectiveProjectionData
 from arcade.camera.projection_functions import generate_view_matrix, generate_perspective_matrix
@@ -116,7 +116,7 @@ class PerspectiveProjector:
         finally:
             previous_projector.use()
 
-    def project(self, world_coordinate: Tuple[float, float, ...]) -> Tuple[float, float]:
+    def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """
         Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
         """

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = ("PerspectiveProjector",)
 
 
-class PerspectiveProjector:
+class PerspectiveProjector(Projector):
     """
     The simplest from of a perspective camera.
     Using ViewData and PerspectiveProjectionData PoDs (Pack of Data)
@@ -101,20 +101,6 @@ class PerspectiveProjector:
         self._window.ctx.viewport = self._projection.viewport
         self._window.projection = _projection
         self._window.view = _view
-
-
-    @contextmanager
-    def activate(self) -> Iterator[Projector]:
-        """
-        A context manager version of OrthographicProjector.use() which allows for the use of
-        `with` blocks. For example, `with camera.activate() as cam: ...`.
-        """
-        previous_projector = self._window.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous_projector.use()
 
     def project(self, world_coordinate: Tuple[float, ...]) -> Tuple[float, float]:
         """

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Iterator, TYPE_CHECKING
+from typing import Optional, Tuple, Generator, Self, TYPE_CHECKING
 from contextlib import contextmanager
 
 from math import tan, radians
@@ -85,6 +85,31 @@ class PerspectiveProjector(Projector):
         alias of arcade.camera.get_view_matrix method
         """
         return generate_view_matrix(self._view)
+
+    @contextmanager
+    def activate(self) -> Generator[Self, None, None]:
+        """Set this camera as the current one, then undo it after.
+
+        This method is a :ref+external:`context manager <context-managers>`
+        you can use inside ``with`` blocks. Using it this way guarantees
+        that the old camera and its settings will be restored, even if an
+        exception occurs:
+
+        .. code-block:: python
+
+           # Despite an Exception, the previous camera and its settings
+           # will be restored at the end of the with block below:
+           with projector_instance.activate():
+                sprite_list.draw()
+                _ = 1 / 0  # Guaranteed ZeroDivisionError
+
+        """
+        previous_projector = self._window.current_camera
+        try:
+            self.use()
+            yield self
+        finally:
+            previous_projector.use()
 
     def use(self) -> None:
         """

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -1,0 +1,105 @@
+from math import tan, pi
+
+from pyglet.math import Vec3, Mat4
+from arcade.camera.data_types import CameraData, PerspectiveProjectionData, OrthographicProjectionData
+
+
+def generate_view_matrix(camera_data: CameraData) -> Mat4:
+    """
+    Using the ViewData it generates a view matrix from the pyglet Mat4 look at function
+    """
+    # Even if forward and up are normalised floating point error means every vector must be normalised.
+    fo = Vec3(*camera_data.forward).normalize()  # Forward Vector
+    up = Vec3(*camera_data.up)  # Initial Up Vector (Not necessarily perpendicular to forward vector)
+    ri = fo.cross(up).normalize()  # Right Vector
+    up = ri.cross(fo).normalize()  # Up Vector
+    po = Vec3(*camera_data.position)
+    return Mat4((
+        ri.x, up.x, -fo.x, 0,
+        ri.y, up.y, -fo.y, 0,
+        ri.z, up.z, -fo.z, 0,
+        -ri.dot(po), -up.dot(po), fo.dot(po), 1
+    ))
+
+
+def generate_orthographic_matrix(perspective_data: OrthographicProjectionData, zoom: float = 1.0):
+    """
+    Using the OrthographicProjectionData a projection matrix is generated where the size of the
+    objects is not affected by depth.
+
+    Generally keep the scale value to integers or negative powers of integers (2^-1, 3^-1, 2^-2, etc.) to keep
+    the pixels uniform in size. Avoid a zoom of 0.0.
+    """
+
+    # Find the center of the projection values (often 0,0 or the center of the screen)
+    _projection_center = (
+        (perspective_data.left + perspective_data.right) / 2,
+        (perspective_data.bottom + perspective_data.top) / 2
+    )
+
+    # Find half the width of the projection
+    _projection_half_size = (
+        (perspective_data.right - perspective_data.left) / 2,
+        (perspective_data.top - perspective_data.bottom) / 2
+    )
+
+    # Scale the projection by the zoom value. Both the width and the height
+    # share a zoom value to avoid ugly stretching.
+    right = _projection_center[0] - _projection_half_size[0] / zoom,
+    left = _projection_center[0] + _projection_half_size[0] / zoom,
+    bottom = _projection_center[1] - _projection_half_size[1] / zoom,
+    top = _projection_center[1] + _projection_half_size[1] / zoom
+
+    z_near, z_far = perspective_data.near, perspective_data.far
+
+    width = right - left
+    height = top - bottom
+    depth = z_far - z_near
+
+    sx = 2.0 / width
+    sy = 2.0 / height
+    sz = 2.0 / -depth
+
+    tx = -(right + left) / width
+    ty = -(top + bottom) / height
+    tz = -(z_far + z_near) / depth
+
+    return Mat4((
+         sx, 0.0, 0.0, 0.0,
+        0.0,  sy, 0.0, 0.0,
+        0.0, 0.0,  sz, 0.0,
+         tx,  ty,  tz, 1.0
+    ))
+
+
+def generate_perspective_matrix(perspective_data: PerspectiveProjectionData, zoom: float = 1.0):
+    """
+    Using the OrthographicProjectionData a projection matrix is generated where the size of the
+    objects is not affected by depth.
+
+    Generally keep the scale value to integers or negative powers of integers (2^-1, 3^-1, 2^-2, etc.) to keep
+    the pixels uniform in size. Avoid a zoom of 0.0.
+    """
+    fov = perspective_data.fov / zoom
+    z_near, z_far, aspect = perspective_data.near, perspective_data.far, perspective_data.aspect
+
+    xy_max = z_near * tan(fov * pi / 360)
+    y_min = -xy_max
+    x_min = -xy_max
+
+    width = xy_max - x_min
+    height = xy_max - y_min
+    depth = z_far - z_near
+    q = -(z_far + z_near) / depth
+    qn = -2 * z_far * z_near / depth
+
+    w = 2 * z_near / width
+    w = w / aspect
+    h = 2 * z_near / height
+
+    return Mat4((
+        w, 0, 0, 0,
+        0, h, 0, 0,
+        0, 0, q, -1,
+        0, 0, qn, 0
+    ))

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -45,8 +45,8 @@ def generate_orthographic_matrix(perspective_data: OrthographicProjectionData, z
 
     # Scale the projection by the zoom value. Both the width and the height
     # share a zoom value to avoid ugly stretching.
-    right = projection_x - half_width / zoom
-    left = projection_x + half_width / zoom
+    left = projection_x - half_width / zoom
+    right = projection_x + half_width / zoom
     bottom = projection_y - half_height / zoom
     top = projection_y + half_height / zoom
 

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -32,23 +32,23 @@ def generate_orthographic_matrix(perspective_data: OrthographicProjectionData, z
     """
 
     # Find the center of the projection values (often 0,0 or the center of the screen)
-    _projection_center = (
-        (perspective_data.left + perspective_data.right) / 2,
-        (perspective_data.bottom + perspective_data.top) / 2
+    projection_x, projection_y = (
+        (perspective_data.left + perspective_data.right) / 2.0,
+        (perspective_data.bottom + perspective_data.top) / 2.0
     )
 
     # Find half the width of the projection
-    _projection_half_size = (
-        (perspective_data.right - perspective_data.left) / 2,
-        (perspective_data.top - perspective_data.bottom) / 2
+    half_width, half_height = (
+        (perspective_data.right - perspective_data.left) / 2.0,
+        (perspective_data.top - perspective_data.bottom) / 2.0
     )
 
     # Scale the projection by the zoom value. Both the width and the height
     # share a zoom value to avoid ugly stretching.
-    right = _projection_center[0] - _projection_half_size[0] / zoom,
-    left = _projection_center[0] + _projection_half_size[0] / zoom,
-    bottom = _projection_center[1] - _projection_half_size[1] / zoom,
-    top = _projection_center[1] + _projection_half_size[1] / zoom
+    right = projection_x - half_width / zoom
+    left = projection_x + half_width / zoom
+    bottom = projection_y - half_height / zoom
+    top = projection_y + half_height / zoom
 
     z_near, z_far = perspective_data.near, perspective_data.far
 

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -22,6 +22,8 @@ from arcade.gl.vertex_array import Geometry
 from arcade.gl.framebuffer import Framebuffer
 from pyglet.math import Mat4
 from arcade.texture_atlas import TextureAtlas
+from arcade.camera import Projector
+from arcade.camera.default import DefaultProjector
 
 __all__ = ["ArcadeContext"]
 
@@ -57,14 +59,13 @@ class ArcadeContext(Context):
         # Set up a default orthogonal projection for sprites and shapes
         self._window_block: UniformBufferObject = window.ubo
         self.bind_window_block()
+
+        self._default_camera: DefaultProjector = DefaultProjector(context=self)
+        self.current_camera: Projector = self._default_camera
+
         self.viewport = (
-            0,
-            0,
-            self.screen.width,
-            self.screen.height,
+            0, 0, window.width, window.height
         )
-        self.projection_matrix = Mat4.orthogonal_projection(0, self.screen.width, 0, self.screen.height,
-                                                            -1, 1)
 
         # --- Pre-load system shaders here ---
         # FIXME: These pre-created resources needs to be packaged nicely
@@ -253,6 +254,32 @@ class ArcadeContext(Context):
             )
 
         return self._atlas
+
+    @property
+    def viewport(self) -> Tuple[int, int, int, int]:
+        """
+        Get or set the viewport for the currently active framebuffer.
+        The viewport simply describes what pixels of the screen
+        OpenGL should render to. Normally it would be the size of
+        the window's framebuffer::
+
+            # 4:3 screen
+            ctx.viewport = 0, 0, 800, 600
+            # 1080p
+            ctx.viewport = 0, 0, 1920, 1080
+            # Using the current framebuffer size
+            ctx.viewport = 0, 0, *ctx.screen.size
+
+        :type: tuple (x, y, width, height)
+        """
+        return self.active_framebuffer.viewport
+
+    @viewport.setter
+    def viewport(self, value: Tuple[int, int, int, int]):
+        self.active_framebuffer.viewport = value
+        if self._default_camera == self.current_camera:
+            self._default_camera.use()
+
 
     @property
     def projection_matrix(self) -> Mat4:

--- a/tests/unit/camera/test_orthographic_projector.py
+++ b/tests/unit/camera/test_orthographic_projector.py
@@ -7,8 +7,8 @@ def test_orthographic_projector_use(window: Window):
     # Given
     ortho_camera = camera.OrthographicProjector()
 
-    view_matrix = ortho_camera._generate_view_matrix()
-    proj_matrix = ortho_camera._generate_projection_matrix()
+    view_matrix = ortho_camera.generate_view_matrix()
+    proj_matrix = ortho_camera.generate_projection_matrix()
 
     # When
     ortho_camera.use()
@@ -26,8 +26,8 @@ def test_orthographic_projector_activate(window: Window):
     # Given
     ortho_camera: camera.OrthographicProjector = camera.OrthographicProjector()
 
-    view_matrix = ortho_camera._generate_view_matrix()
-    proj_matrix = ortho_camera._generate_projection_matrix()
+    view_matrix = ortho_camera.generate_view_matrix()
+    proj_matrix = ortho_camera.generate_projection_matrix()
 
     # When
     with ortho_camera.activate() as cam:

--- a/tests/unit/camera/test_perspective_projector.py
+++ b/tests/unit/camera/test_perspective_projector.py
@@ -9,8 +9,8 @@ def test_perspective_projector_use(window: Window):
     # Given
     persp_camera = camera.PerspectiveProjector()
 
-    view_matrix = persp_camera._generate_view_matrix()
-    proj_matrix = persp_camera._generate_projection_matrix()
+    view_matrix = persp_camera.generate_view_matrix()
+    proj_matrix = persp_camera.generate_projection_matrix()
 
     # When
     persp_camera.use()
@@ -28,8 +28,8 @@ def test_perspective_projector_activate(window: Window):
     # Given
     persp_camera: camera.PerspectiveProjector = camera.PerspectiveProjector()
 
-    view_matrix = persp_camera._generate_view_matrix()
-    proj_matrix = persp_camera._generate_projection_matrix()
+    view_matrix = persp_camera.generate_view_matrix()
+    proj_matrix = persp_camera.generate_projection_matrix()
 
     # When
     with persp_camera.activate() as cam:


### PR DESCRIPTION
These methods are used to swap between world coordinates and screen coordinates.