### PR TITLE
Fixing the no culling version of the SpriteList shader

### DIFF
--- a/arcade/resources/system/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
+++ b/arcade/resources/system/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
@@ -22,7 +22,7 @@ out vec4 gs_color;
 
 void main() {
     // Get center of the sprite
-    vec2 center = gl_in[0].gl_Position.xy;
+    vec3 center = gl_in[0].gl_Position.xyz;
     vec2 hsize = v_size[0] / 2.0;
     float angle = radians(v_angle[0]);
     mat2 rot = mat2(

--- a/arcade/resources/system/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
+++ b/arcade/resources/system/shaders/sprites/sprite_list_geometry_no_cull_geo.glsl
@@ -20,46 +20,42 @@ in float v_texture[];
 out vec2 gs_uv;
 out vec4 gs_color;
 
-#define VP_CLIP 1.0
-
 void main() {
     // Get center of the sprite
     vec2 center = gl_in[0].gl_Position.xy;
     vec2 hsize = v_size[0] / 2.0;
     float angle = radians(v_angle[0]);
     mat2 rot = mat2(
-        cos(angle), -sin(angle),
-        sin(angle),  cos(angle)
+    cos(angle), -sin(angle),
+    sin(angle), cos(angle)
     );
     mat4 mvp = window.projection * window.view;
     // Emit a quad with the right position, rotation and texture coordinates
-    // Read texture coordinates from UV texture here
-    vec4 uv_data = texelFetch(uv_texture, ivec2(v_texture[0], 0), 0);
-    vec2 tex_offset = uv_data.xy;
-    vec2 tex_size = uv_data.zw;
 
-    // Upper left
-    gl_Position = mvp * vec4(rot * vec2(-hsize.x, hsize.y) + center, 0.0, 1.0);
-    gs_uv =  vec2(0.0, tex_size.y) + tex_offset;
+    // Read texture coordinates from UV texture here
+    vec2 uv0, uv1, uv2, uv3;
+    getSpriteUVs(uv_texture, int(v_texture[0]), uv0, uv1, uv2, uv3);
+
+    // Set the out color for all vertices
     gs_color = v_color[0];
+    // Upper left
+    gl_Position = mvp * vec4(rot * vec2(-hsize.x, hsize.y) + center.xy, center.z, 1.0);
+    gs_uv =  uv0;
     EmitVertex();
 
     // lower left
-    gl_Position = mvp * vec4(rot * vec2(-hsize.x, -hsize.y) + center, 0.0, 1.0);
-    gs_uv = tex_offset;
-    gs_color = v_color[0];
+    gl_Position = mvp * vec4(rot * vec2(-hsize.x, -hsize.y) + center.xy, center.z, 1.0);
+    gs_uv = uv2;
     EmitVertex();
 
     // upper right
-    gl_Position = mvp * vec4(rot * vec2(hsize.x, hsize.y) + center, 0.0, 1.0);
-    gs_uv = tex_size + tex_offset;
-    gs_color = v_color[0];
+    gl_Position = mvp * vec4(rot * vec2(hsize.x, hsize.y) + center.xy, center.z, 1.0);
+    gs_uv = uv1;
     EmitVertex();
 
     // lower right
-    gl_Position = mvp * vec4(rot * vec2(hsize.x, -hsize.y) + center, 0.0, 1.0);
-    gs_uv = vec2(tex_size.x, 0.0) + tex_offset;
-    gs_color = v_color[0];
+    gl_Position = mvp * vec4(rot * vec2(hsize.x, -hsize.y) + center.xy, center.z, 1.0);
+    gs_uv = uv3;
     EmitVertex();
 
     EndPrimitive();


### PR DESCRIPTION
It was never adequately updated to use the new atlas shader lib so it grabs the incorrect parts of the atlas. 

![image](https://github.com/pythonarcade/arcade/assets/86714785/90ad577c-d431-444d-80ce-a6db765e8421)
