### PR TITLE
Fix error running tutorial's script menu_05.py

### DIFF
--- a/doc/tutorials/menu/menu_05.py
+++ b/doc/tutorials/menu/menu_05.py
@@ -208,7 +208,7 @@ class SubMenu(arcade.gui.UIMouseFilterMixin, arcade.gui.UIAnchorLayout):
         dropdown = arcade.gui.UIDropdown(default=dropdown_options[0], options=dropdown_options, height=20, width=250)
 
         slider_label = arcade.gui.UILabel(text=slider_label)
-        pressed_style = arcade.gui.UISlider.UIStyle(filled_bar=arcade.color.GREEN, unfilled_bar=arcade.color.RED)
+        pressed_style = arcade.gui.UISlider.UIStyle(filled_track=arcade.color.GREEN, unfilled_track=arcade.color.RED)
         default_style = arcade.gui.UISlider.UIStyle()
         style_dict = {"press": pressed_style, "normal": default_style, "hover": default_style, "disabled": default_style}
         # Configuring the styles is optional.


### PR DESCRIPTION
## Bug Report
The script `doc/tutorials/menu/menu_05.py` fails because the arguments `filled_bar` and `unfilled_bar` passed to `arcade.gui.UISlider.UIStyle` are not valid.

## System Info

Arcade 3.0.0.dev29
------------------
vendor: Intel
renderer: Mesa Intel(R) HD Graphics 530 (SKL GT2)
version: (4, 6)
python: 3.11.9 (main, Apr 30 2024, 16:43:24) [GCC 13.2.1 20240210]
platform: linux
pyglet version: 2.1.dev2
PIL version: 10.2.0

### Actual behavior:
Run `python menu_05.py`.  
Click the "Pause" button, then click the "Volume" or "Options" button.  
An error is raised: `TypeError: UISliderStyle.__init__() got an unexpected keyword argument 'filled_bar'.`

### Expected behavior:
Run `python menu_05.py`.  
Click the "Pause" button, then click the "Volume" or "Options" button.  
The "Volume" or "Options" sub-menu should appear.
