### PR TITLE
Fix crashing in method _on_player_eos (pythonarcade#2097)

### DIFF
--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -96,10 +96,11 @@ class Sound:
         media.Source._players.append(player)
 
         def _on_player_eos():
-            media.Source._players.remove(player)
+            if player in media.Source._players:
+                media.Source._players.remove(player)
             # There is a closure on player. To get the refcount to 0,
             # we need to delete this function.
-            player.on_player_eos = None  # type: ignore  # pending https://github.com/pyglet/pyglet/issues/845
+            player.on_player_eos = None # type: ignore  # pending https://github.com/pyglet/pyglet/issues/845
 
         player.on_player_eos = _on_player_eos
         return player


### PR DESCRIPTION
**Context:**

**Where:** *arcade/sound.py (method: _on_player_eos())*
As I explain in (#2097) when trying to stop the sound of the footsteps of the character I control, sometimes (randomly) the game crashed, showing the message I attach in the issue.

**Added:**
- Check if "player" exists.

**Testing:**
- When I added this comprobation in my project I didn't have any problems again, and we got rid of a bug that was closing the entire game.