### PR TITLE
Move window.Headless annotation out of comment

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -130,8 +130,8 @@ class Window(pyglet.window.Window):
             gl_version = 3, 1
             gl_api = "gles"
 
-        #: bool: If this is a headless window
-        self.headless = pyglet.options.get("headless") is True
+        #: Whether this is a headless window
+        self.headless: bool = pyglet.options.get("headless") is True
 
         config = None
         # Attempt to make window with antialiasing

--- a/arcade/experimental/clock/clock_window.py
+++ b/arcade/experimental/clock/clock_window.py
@@ -120,8 +120,8 @@ class Window(pyglet.window.Window):
             gl_version = 3, 1
             gl_api = "gles"
 
-        #: bool: If this is a headless window
-        self.headless = pyglet.options.get("headless") is True
+        #: Whether this is a headless window
+        self.headless: bool = pyglet.options.get("headless") is True
 
         config = None
         # Attempt to make window with antialiasing


### PR DESCRIPTION
TL;DR: Tiny drive-by commit while consider ways to move toward 3.0 doc build for Cameras

* Make the change in the normal window
* Mirror the change in the clock_window.py