### PR TITLE
Fix SpriteList.pop exception type on empty

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -591,7 +591,7 @@ class SpriteList(Generic[SpriteType]):
     def pop(self, index: int = -1) -> SpriteType:
         """Attempt to pop a sprite from the list, defaulting to the last.
 
-        This works like :py:method:`list.pop`:
+        This works like :py:meth:`list.pop`:
 
         * If no `index` is specified, this function attempts to pop the
           last :py:class:`Sprite` in the list

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -589,10 +589,17 @@ class SpriteList(Generic[SpriteType]):
             self._init_deferred()
 
     def pop(self, index: int = -1) -> SpriteType:
-        """
-        Pop off the last sprite, or the given index, from the list
+        """Attempt to pop a sprite from the list, defaulting to the last.
 
-        :param index: Index of sprite to remove, defaults to -1 for the last item.
+        This works like :py:method:`list.pop`:
+
+        * If no `index` is specified, this function attempts to pop the
+          last :py:class:`Sprite` in the list
+        * If the list is empty, this function raises an
+          :py:class:`IndexError`
+
+        :param index: Index of sprite to remove (defaults to ``-1`` for
+            the last item.
         """
         if len(self.sprite_list) == 0:
             raise IndexError("pop from empty list")

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -589,17 +589,17 @@ class SpriteList(Generic[SpriteType]):
             self._init_deferred()
 
     def pop(self, index: int = -1) -> SpriteType:
-        """Attempt to pop a sprite from the list, defaulting to the last.
+        """Attempt to pop a sprite from the list.
 
-        This works like :py:meth:`list.pop`:
+        This works like :external:ref:`popping from <tut-morelists>` a
+        standard Python :py:class:`list`:
 
-        * If no `index` is specified, this function attempts to pop the
-          last :py:class:`Sprite` in the list
-        * If the list is empty, this function raises an
-          :py:class:`IndexError`
+        #. If the list is empty, raise an :py:class:`IndexError`
+        #. If no ``index`` is passed, try to pop the last
+           :py:class:`Sprite` in the list
 
         :param index: Index of sprite to remove (defaults to ``-1`` for
-            the last item.
+            the last item)
         """
         if len(self.sprite_list) == 0:
             raise IndexError("pop from empty list")

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -595,7 +595,7 @@ class SpriteList(Generic[SpriteType]):
         :param index: Index of sprite to remove, defaults to -1 for the last item.
         """
         if len(self.sprite_list) == 0:
-            raise (ValueError("pop from empty list"))
+            raise IndexError("pop from empty list")
 
         sprite = self.sprite_list[index]
         self.remove(sprite)

--- a/tests/unit/spritelist/test_spritelist.py
+++ b/tests/unit/spritelist/test_spritelist.py
@@ -113,6 +113,22 @@ def test_it_can_pop_at_a_given_index():
     assert [spritelist.sprite_slot[s] for s in spritelist] == [0, 2]
 
 
+def test_it_raises_indexerror_when_popping_from_empty_spritelist():
+    spritelist = make_named_sprites(0)
+
+    # With default index
+    with pytest.raises(IndexError):
+        spritelist.pop()
+
+    # With positional argument
+    with pytest.raises(IndexError):
+        spritelist.pop(0)
+
+    # With keyword argument
+    with pytest.raises(IndexError):
+        spritelist.pop(index=1)
+
+
 def test_setitem(ctx):
     """Testing __setitem__"""
     num_sprites = 10


### PR DESCRIPTION
* Use `IndexError` instead of `ValueError` as with `list`
* Touch up docstring
* Add test for the exception behavior