### PR TITLE
fix for broken "woman_sprinter" image on docs index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,8 @@
 The Python Arcade Library
 =========================
 
+.. |Go| image:: images/woman_sprinter.svg
+
 ..
    Wrapped in raw html to avoid repeating twice in the PDF, since this blurb is
    repeated in `get_started/introduction.rst`


### PR DESCRIPTION
Fixes an issue in the docs where sphinx wasn't loading the `woman_sprinter.svg` because it was never used in an image directive.