### PR TITLE
More cleanup for update_quick_index.py + helpers

### DIFF
--- a/util/create_resources_listing.py
+++ b/util/create_resources_listing.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.resolve()))
 sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 
 import arcade
-from vfs import Vfs
+from doc_helpers.vfs import Vfs
 
 MODULE_DIR = Path(__file__).parent.resolve()
 ARCADE_ROOT = MODULE_DIR.parent

--- a/util/doc_helpers/__init__.py
+++ b/util/doc_helpers/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .vfs import VirtualFile, Vfs, F
+
+
+__all__ = (
+    'F',
+    'SharedPaths',
+    'VirtualFile',
+    'Vfs'
+)
+
+
+class SharedPaths:
+    """These are often used to set up a Vfs and open files."""
+    REPO_UTILS_DIR = Path(__file__).parent.parent.resolve()
+    REPO_ROOT = REPO_UTILS_DIR.parent
+    ARCADE_ROOT = REPO_ROOT / "arcade"
+    DOC_ROOT = REPO_ROOT / "doc"
+    API_DOC_ROOT = DOC_ROOT / "api_docs"

--- a/util/doc_helpers/__init__.py
+++ b/util/doc_helpers/__init__.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+from typing import Iterable
 
 from .vfs import VirtualFile, Vfs, F
 
 
 __all__ = (
+    'get_module_path',
+    'EMPTY_TUPLE',
     'F',
     'SharedPaths',
+    'NotExcludedBy',
     'VirtualFile',
     'Vfs'
 )
+
+
+EMPTY_TUPLE = tuple()
 
 
 class SharedPaths:
@@ -20,3 +28,60 @@ class SharedPaths:
     ARCADE_ROOT = REPO_ROOT / "arcade"
     DOC_ROOT = REPO_ROOT / "doc"
     API_DOC_ROOT = DOC_ROOT / "api_docs"
+
+
+class NotExcludedBy:
+    """Helper predicate for exclusion.
+
+    This is here because we may eventually define excludes at per-module
+    level in our config below instead of a single list.
+    """
+    def __init__(self, collection: Iterable):
+        self.items = set(collection)
+
+    def __call__(self, item) -> bool:
+        return item not in self.items
+
+
+_VALID_MODULE_SEGMENT = re.compile(r"[_a-zA-Z][_a-z0-9]*")
+
+
+def get_module_path(module: str, root = SharedPaths.REPO_ROOT) -> Path:
+    """Quick-n-dirty module path estimation relative to the repo root.
+
+    :param module: A module path in the project.
+    :raises ValueError: When a can't be computed.
+    :return: A
+    """
+    # Convert module.name.here to module/name/here
+    current = root
+    for index, part in enumerate(module.split('.')):
+        if not _VALID_MODULE_SEGMENT.fullmatch(part):
+            raise ValueError(
+                f'Invalid module segment at index {index}: {part!r}')
+        # else:
+        #   print(current, part)
+        current /= part
+
+    # Account for the two kinds of modules:
+    # 1. arcade/module.py
+    # 2. arcade/module/__init__.py
+    as_package = current / "__init__.py"
+    have_package = as_package.is_file()
+    as_file = current.with_suffix('.py')
+    have_file = as_file.is_file()
+
+    # TODO: When 3.10 becomes our min Python, make this a match-case?
+    if have_package and have_file:
+        raise ValueError(
+            f"Module conflict between {as_package} and {as_file}")
+    elif have_package:
+        current = as_package
+    elif have_file:
+        current = as_file
+    else:
+        raise ValueError(
+            f"No folder package or file module detected for "
+            f"{module}")
+
+    return current

--- a/util/doc_helpers/vfs.py
+++ b/util/doc_helpers/vfs.py
@@ -36,8 +36,15 @@ from typing import Generator, Type, TypeVar, Generic
 
 
 class VirtualFile:
-    """Subclass these to add some magic.
+    """An abstraction over an in-memory stream.
 
+    This might later change to be an abstraction to over a StringIO
+    inside the Vfs class to better reflect file system behavior. What
+    don't change is the write method, which means you can safely do the
+    following:
+
+    1. Subclass this to add helper functions
+    2. Pass it to a Vfs at creation
     """
 
     def __init__(self, path: str):

--- a/util/doc_helpers/vfs.py
+++ b/util/doc_helpers/vfs.py
@@ -56,7 +56,7 @@ class VirtualFile:
         contents = Path(path).read_text()
         return self.write(contents)
 
-    def write(self, str: str):
+    def write(self, str: str) -> int:
         return self._content.write(str)
 
     def close(self):

--- a/util/doc_helpers/vfs.py
+++ b/util/doc_helpers/vfs.py
@@ -156,7 +156,6 @@ class Vfs(Generic[F]):
 
         raise ValueError(f"Unsupported mode {mode!r}")
 
-
     # This is less nasty than dynamically generating a subclass
     # which then attaches instances to a specific Vfs on creation
     # and assigns itself as the .open value for that Vfs

--- a/util/doc_helpers/vfs.py
+++ b/util/doc_helpers/vfs.py
@@ -111,7 +111,7 @@ class Vfs(Generic[F]):
         for p in path.glob(glob):
             self.files_to_delete.add(p)
 
-    def write(self):
+    def write(self) -> None:
         """Sync all files of this Vfs to the real filesystem.
 
         This performs the following actions:

--- a/util/doc_helpers/vfs.py
+++ b/util/doc_helpers/vfs.py
@@ -35,15 +35,6 @@ from pathlib import Path
 from typing import Generator, Type, TypeVar, Generic
 
 
-class SharedPaths:
-    """These are often used to set up a Vfs and open files."""
-    REPO_UTILS_DIR = Path(__file__).parent.resolve()
-    REPO_ROOT = REPO_UTILS_DIR.parent
-    ARCADE_ROOT = REPO_ROOT / "arcade"
-    DOC_ROOT = REPO_ROOT / "doc"
-    API_DOC_ROOT = DOC_ROOT / "api_docs"
-
-
 class VirtualFile:
     """Subclass these to add some magic.
 

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -42,10 +42,11 @@ QUICK_INDEX_FILE_PATH = API_DOC_GENERATION_DIR / "quick_index.rst"
 
 # --- 1. Special rules & excludes ---
 
-SHOW_INHERITANCE = (':show-inheritance:',)
-INHERITED_MEMBERS = (':inherited-members:',)
+RULE_SHOW_INHERITANCE = (':show-inheritance:',)
+RULE_INHERITED_MEMBERS = (':inherited-members:',)
+
 MEMBER_SPECIAL_RULES = {
-    "arcade.ArcadeContext" : SHOW_INHERITANCE + INHERITED_MEMBERS
+    "arcade.ArcadeContext" : RULE_SHOW_INHERITANCE + RULE_INHERITED_MEMBERS
 }
 
 

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -489,7 +489,7 @@ def generate_api_file(api_file_name: str, vfs: Vfs):
 
             # Write the entry to the file
             api_file.write(f".. autoclass:: {full_name}\n")
-            api_file.write("    :members:\n")
+            api_file.write(f"   :members:\n")
             # api_file.write(f"    :member-order: groupwise\n")
 
             # Apply special per-class addenda

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -422,8 +422,8 @@ def generate_api_file(api_file_name: str, vfs: Vfs):
     underline = "-" * len(title)
 
     api_file = vfs.open(full_api_file_name, "w")
-    api_file.write(f".. _{api_file_name[:-4]}_api:")
-    api_file.write(f"\n\n")
+    api_file.write(f".. _{api_file_name[:-4]}_api:\n")
+    api_file.write(f"\n")
     api_file.write(f"{title}\n")
     api_file.write(f"{underline}\n\n")
 

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -407,7 +407,7 @@ def generate_api_file(api_file_name: str, vfs: Vfs):
     try:
         full_api_file_name = API_DOC_GENERATION_DIR / api_file_name
         title = page_config.get('title')
-        use_declarations_in = page_config.get('use_declarations_in', [])
+        use_declarations_in = page_config.get('use_declarations_in', EMPTY_TUPLE)
         print(f"API filename {api_file_name} gets {title=} with {use_declarations_in=}")
 
     except Exception as e:

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -476,14 +476,11 @@ def generate_api_file(api_file_name: str, vfs: Vfs):
                 f"Those belong in the 'tests/' directory!")
             continue
 
+        # TODO: Figure out how to reliably parse & render types?
         module_path = get_module_path(module_name)
         member_lists = get_file_declarations(module_path)
 
-        # TODO: Figure out how to reliably parse & render types?
-        # type_list = member_lists.get('type')
-        class_list = member_lists.get('class')
-        function_list = member_lists.get('function')
-
+        # Skip a file if we got no imports
         if not len(member_lists['*']):
             print(
                 f"WARNING: No members parsed for {module_name!r} with"

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -43,7 +43,11 @@ MEMBER_SPECIAL_RULES = {
 }
 
 class NotExcludedBy:
+    """Helper predicate for exclusion.
 
+    This is here because we may eventually define excludes at per-module
+    level in our config below instead of a single list.
+    """
     def __init__(self, collection: Iterable):
         self.items = set(collection)
 

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -25,7 +25,9 @@ from typing import Iterable, Generator
 # Ensure we get utility & arcade imports first
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 
-from vfs import Vfs, SharedPaths
+from doc_helpers.vfs import Vfs
+from doc_helpers import SharedPaths
+
 
 EMPTY_TUPLE = tuple()
 


### PR DESCRIPTION
**TL;DR:** Organize doc helpers better and things like missing docstrings

### Why?

**TL;DR:** Maintainability

* Keep the quick index script lean by putting helpers elsewhere
* Explain what the helpers are and how to use them

### Changes

* Make `util/doc_helpers` module
* Move vfs-related items into it
* Move misc reusable helpers into it (`get_module_path`, etc)
* Fix docstring for `VirtualFile`
* Consistently use `pathlib.Path` inside vfs-related classes
* Minor style polishing
