### PR TITLE
Bugfix: Spritelist swap doesn't change order

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -650,19 +650,21 @@ class SpriteList(Generic[SpriteType]):
         :param index_1: Item index to swap
         :param index_2: Item index to swap
         """
-        # Swap order in spritelist
+        # Swap order in python spritelist
         sprite_1 = self.sprite_list[index_1]
         sprite_2 = self.sprite_list[index_2]
         self.sprite_list[index_1] = sprite_2
         self.sprite_list[index_2] = sprite_1
 
-        # Swap order in index buffer
+        # Swap order in index buffer to change rendering order
         slot_1 = self.sprite_slot[sprite_1]
         slot_2 = self.sprite_slot[sprite_2]
         i1 = self._sprite_index_data.index(slot_1)
         i2 = self._sprite_index_data.index(slot_2)
         self._sprite_index_data[i1] = slot_2
         self._sprite_index_data[i2] = slot_1
+
+        self._sprite_index_changed = True
 
     def remove(self, sprite: SpriteType) -> None:
         """

--- a/tests/unit/spritelist/test_spritelist.py
+++ b/tests/unit/spritelist/test_spritelist.py
@@ -258,3 +258,28 @@ def test_color():
     # sp.alpha_normalized = -1000
     # assert sp.alpha == 0
     # assert sp.alpha_normalized == 0.0
+
+
+def test_swap(window):
+    """Test swapping sprites including drawing order"""
+    window.clear()
+
+    sprites = [
+        arcade.SpriteSolidColor(10, 10, color=arcade.color.RED),
+        arcade.SpriteSolidColor(10, 10, color=arcade.color.GREEN)
+    ]
+    sl = arcade.SpriteList()
+    sl.extend(sprites)
+
+    # Green sprite is last in list and drawn last
+    sl.draw()
+    assert arcade.get_pixel(x=0, y=0, components=4) == arcade.color.GREEN
+    assert sl.sprite_list == sprites
+
+    # Swap the order
+    sl.swap(0, 1)
+
+    # Red sprite is last in list and drawn last
+    sl.draw()
+    assert arcade.get_pixel(x=0, y=0, components=4) == arcade.color.RED
+    assert sl.sprite_list == sprites[::-1]


### PR DESCRIPTION
The swap method doesn't set the index buffer as dirty, so the order doesn't change until other changes are made to the list.