### PR TITLE
Initial conversion to PEP 585

### DIFF
--- a/.github/workflows/selfhosted_runner.yml
+++ b/.github/workflows/selfhosted_runner.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9.13', '3.10', '3.11', '3.12']
+        python-version: ['3.9.13', '3.10', '3.11', '3.12']
         architecture: ['x64']
 
     steps:

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import List, Tuple, Optional
+from typing import Optional
 
 import pyglet
 
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 
-def get_screens() -> List:
+def get_screens() -> list:
     """
     Return a list of screens. So for a two-monitor setup, this should return
     a list of two screens. Can be used with arcade.Window to select which
@@ -111,7 +111,7 @@ class Window(pyglet.window.Window):
         resizable: bool = False,
         update_rate: float = 1 / 60,
         antialiasing: bool = True,
-        gl_version: Tuple[int, int] = (3, 3),
+        gl_version: tuple[int, int] = (3, 3),
         screen: Optional[pyglet.display.Screen] = None,
         style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
@@ -267,7 +267,7 @@ class Window(pyglet.window.Window):
         self,
         color: Optional[RGBOrA255] = None,
         color_normalized: Optional[RGBANormalized] = None,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
     ) -> None:
         """Clears the window with the configured background color
         set through :py:attr:`arcade.Window.background_color`.
@@ -665,7 +665,7 @@ class Window(pyglet.window.Window):
 
         super().set_size(width, height)
 
-    def get_size(self) -> Tuple[int, int]:
+    def get_size(self) -> tuple[int, int]:
         """
         Get the size of the window.
 
@@ -674,7 +674,7 @@ class Window(pyglet.window.Window):
 
         return super().get_size()
 
-    def get_location(self) -> Tuple[int, int]:
+    def get_location(self) -> tuple[int, int]:
         """
         Return the X/Y coordinates of the window
 
@@ -1052,7 +1052,7 @@ class View:
         self,
         color: Optional[RGBOrA255] = None,
         color_normalized: Optional[RGBANormalized] = None,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
     ) -> None:
         """Clears the window with the configured background color
         set through :py:attr:`arcade.Window.background_color`.

--- a/arcade/cache/__init__.py
+++ b/arcade/cache/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 from .hit_box import HitBoxCache
 from .texture import TextureCache
 from .image_data import ImageDataCache
@@ -22,7 +22,7 @@ def crate_str_from_values(*args, sep: str = "_") -> str:
     return sep.join([str(x) for x in args])
 
 
-def crate_str_from_list(entries: List[Any], sep: str = "_") -> str:
+def crate_str_from_list(entries: list[Any], sep: str = "_") -> str:
     """
     Create a string from a list of parameters.
 

--- a/arcade/cache/image_data.py
+++ b/arcade/cache/image_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from arcade.texture import ImageData
@@ -23,7 +23,7 @@ class ImageDataCache:
     """
 
     def __init__(self):
-        self._entries: Dict[str, "ImageData"] = {}
+        self._entries: dict[str, "ImageData"] = {}
 
     def put(self, name: str, image: "ImageData"):
         """

--- a/arcade/cache/texture.py
+++ b/arcade/cache/texture.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Set, TYPE_CHECKING, Union, Tuple
+from typing import Optional, TYPE_CHECKING, Union
 from pathlib import Path
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ class TextureBucket:
     """
 
     def __init__(self):
-        self._entries: Dict[str, "Texture"] = {}
+        self._entries: dict[str, "Texture"] = {}
 
     def put(self, name: str, texture: "Texture") -> None:
         self._entries[name] = texture
@@ -111,7 +111,7 @@ class TextureCache:
     def get_texture_by_filepath(
         self,
         file_path: Union[str, Path],
-        crop: Tuple[int, int, int, int] = (0, 0, 0, 0),
+        crop: tuple[int, int, int, int] = (0, 0, 0, 0),
     ) -> Optional["Texture"]:
         """
         Get a texture from the cache by file path and crop values.
@@ -155,7 +155,7 @@ class TextureCache:
         self._entries.flush()
         self._file_entries.flush()
 
-    def get_all_textures(self) -> Set["Texture"]:
+    def get_all_textures(self) -> set["Texture"]:
         """Get all textures in the cache"""
         return set(self._entries._entries.values())
 

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional, Tuple, Generator
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Generator
 from math import degrees, radians, atan2, cos, sin
 from contextlib import contextmanager
 
@@ -69,7 +71,7 @@ class Camera2D:
         self,
         viewport: Optional[Rect] = None,
         position: Optional[Point2] = None,
-        up: Tuple[float, float] = (0.0, 1.0),
+        up: tuple[float, float] = (0.0, 1.0),
         zoom: float = 1.0,
         projection: Optional[Rect] = None,
         near: float = -100.0,

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -6,7 +6,7 @@ wide usage throughout Arcade's camera code.
 
 from __future__ import annotations
 from contextlib import contextmanager
-from typing import Protocol, Tuple, Generator
+from typing import Protocol, Generator
 
 from typing_extensions import Self
 from pyglet.math import Vec2, Vec3
@@ -56,15 +56,15 @@ class CameraData:
     ):
 
         #: A 3D vector which describes where the camera is located.
-        self.position: Tuple[float, float, float] = position
+        self.position: tuple[float, float, float] = position
         #: A 3D vector which describes which direction is up (+y).
-        self.up: Tuple[float, float, float] = up
+        self.up: tuple[float, float, float] = up
         #: A scalar which describes which direction the camera is pointing.
         #:
         #: While this affects the projection matrix, it also allows camera
         #: controllers to access zoom functionality without interacting with
         #: projection data.
-        self.forward: Tuple[float, float, float] = forward
+        self.forward: tuple[float, float, float] = forward
 
         # Zoom
         self.zoom: float = zoom

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -1,4 +1,6 @@
-from typing import Optional, Tuple, Generator, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import Optional, Generator, TYPE_CHECKING
 from typing_extensions import Self
 from contextlib import contextmanager
 
@@ -27,7 +29,7 @@ class ViewportProjector:
 
     def __init__(
         self,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
         *,
         context: Optional["ArcadeContext"] = None,
     ):
@@ -38,14 +40,14 @@ class ViewportProjector:
         )
 
     @property
-    def viewport(self) -> Tuple[int, int, int, int]:
+    def viewport(self) -> tuple[int, int, int, int]:
         """
         The viewport use to derive projection and view matrix.
         """
         return self._viewport
 
     @viewport.setter
-    def viewport(self, viewport: Tuple[int, int, int, int]) -> None:
+    def viewport(self, viewport: tuple[int, int, int, int]) -> None:
         self._viewport = viewport
         self._projection_matrix = Mat4.orthogonal_projection(
             0, viewport[2], 0, viewport[3], -100, 100

--- a/arcade/camera/grips/rotate.py
+++ b/arcade/camera/grips/rotate.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from __future__ import annotations
 
 from pyglet.math import Vec3
 
@@ -9,7 +9,7 @@ from arcade.camera.data_types import CameraData
 __all__ = ("rotate_around_forward", "rotate_around_up", "rotate_around_right")
 
 
-def rotate_around_forward(data: CameraData, angle: float) -> Tuple[float, float, float]:
+def rotate_around_forward(data: CameraData, angle: float) -> tuple[float, float, float]:
     """
     Rotate the CameraData up vector around the CameraData forward vector, perfect for rotating the screen.
     This rotation will be around (0.0, 0.0) of the camera projection.
@@ -22,7 +22,7 @@ def rotate_around_forward(data: CameraData, angle: float) -> Tuple[float, float,
     return quaternion_rotation(data.forward, data.up, angle)
 
 
-def rotate_around_up(data: CameraData, angle: float) -> Tuple[float, float, float]:
+def rotate_around_up(data: CameraData, angle: float) -> tuple[float, float, float]:
     """
     Rotate the CameraData forward vector around the CameraData up vector.
     Generally only useful in 3D games.
@@ -36,7 +36,7 @@ def rotate_around_up(data: CameraData, angle: float) -> Tuple[float, float, floa
 
 def rotate_around_right(
     data: CameraData, angle: float
-) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
     """
     Rotate both the CameraData's forward vector and up vector around a calculated right vector.
     Generally only useful in 3D games.
@@ -48,7 +48,7 @@ def rotate_around_right(
     _forward = Vec3(data.forward[0], data.forward[1], data.forward[2])
     _up = Vec3(data.up[0], data.up[1], data.up[2])
     _crossed_vec = _forward.cross(_up)
-    _right: Tuple[float, float, float] = (_crossed_vec.x, _crossed_vec.y, _crossed_vec.z)
+    _right: tuple[float, float, float] = (_crossed_vec.x, _crossed_vec.y, _crossed_vec.z)
     new_forward = quaternion_rotation(_right, data.forward, angle)
     new_up = quaternion_rotation(_right, data.up, angle)
     return new_up, new_forward

--- a/arcade/camera/grips/screen_shake_2d.py
+++ b/arcade/camera/grips/screen_shake_2d.py
@@ -2,6 +2,7 @@
 ScreenShakeController2D:
     Provides an easy way to cause a camera to shake.
 """
+
 from __future__ import annotations
 
 from math import exp, log, pi, sin, floor

--- a/arcade/camera/grips/screen_shake_2d.py
+++ b/arcade/camera/grips/screen_shake_2d.py
@@ -2,8 +2,8 @@
 ScreenShakeController2D:
     Provides an easy way to cause a camera to shake.
 """
+from __future__ import annotations
 
-from typing import Tuple
 from math import exp, log, pi, sin, floor
 from random import uniform
 
@@ -68,7 +68,7 @@ class ScreenShake2D:
         self._length_shaking: float = 0.0
 
         self._current_dir: float = 0.0
-        self._last_vector: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+        self._last_vector: tuple[float, float, float] = (0.0, 0.0, 0.0)
         self._last_update_time: float = 0.0
 
     @property

--- a/arcade/camera/grips/strafe.py
+++ b/arcade/camera/grips/strafe.py
@@ -1,11 +1,11 @@
-from typing import Tuple
+from __future__ import annotations
 
 from pyglet.math import Vec3
 
 from arcade.camera.data_types import CameraData
 
 
-def strafe(data: CameraData, direction: Tuple[float, float]) -> Tuple[float, float, float]:
+def strafe(data: CameraData, direction: tuple[float, float]) -> tuple[float, float, float]:
     """
     Move the CameraData in a 2D direction aligned to the up-right plane of the view.
     A value of [1, 0] will move the camera sideways while a value of [0, 1]

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Generator, TYPE_CHECKING
 from contextlib import contextmanager
 from typing_extensions import Self

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Generator, TYPE_CHECKING
 from typing_extensions import Self
 from contextlib import contextmanager

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from math import tan, pi
-from typing import Tuple
 
 from pyglet.math import Vec2, Vec3, Vec4, Mat4
 from arcade.camera.data_types import (
@@ -118,7 +119,7 @@ def generate_perspective_matrix(
 
 def project_orthographic(
     world_coordinate: Point,
-    viewport: Tuple[int, int, int, int],
+    viewport: tuple[int, int, int, int],
     view_matrix: Mat4,
     projection_matrix: Mat4,
 ) -> Vec2:
@@ -137,7 +138,7 @@ def project_orthographic(
 
 def unproject_orthographic(
     screen_coordinate: Point,
-    viewport: Tuple[int, int, int, int],
+    viewport: tuple[int, int, int, int],
     view_matrix: Mat4,
     projection_matrix: Mat4,
 ) -> Vec3:
@@ -158,7 +159,7 @@ def unproject_orthographic(
 
 def project_perspective(
     world_coordinate: Point,
-    viewport: Tuple[int, int, int, int],
+    viewport: tuple[int, int, int, int],
     view_matrix: Mat4,
     projection_matrix: Mat4,
 ) -> Vec2:
@@ -181,7 +182,7 @@ def project_perspective(
 
 def unproject_perspective(
     screen_coordinate: Point,
-    viewport: Tuple[int, int, int, int],
+    viewport: tuple[int, int, int, int],
     view_matrix: Mat4,
     projection_matrix: Mat4,
 ) -> Vec3:

--- a/arcade/camera/static.py
+++ b/arcade/camera/static.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Generator, Callable, Optional, Tuple, TYPE_CHECKING
+from typing import Generator, Callable, Optional, TYPE_CHECKING
 
 from arcade.camera.data_types import (
     CameraData,
@@ -33,23 +33,23 @@ class _StaticCamera:
         self,
         view_matrix: Mat4,
         projection_matrix: Mat4,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
         *,
         project_method: Optional[
-            Callable[[Point, Tuple[int, int, int, int], Mat4, Mat4], Vec2]
+            Callable[[Point, tuple[int, int, int, int], Mat4, Mat4], Vec2]
         ] = None,
         unproject_method: Optional[
-            Callable[[Point, Tuple[int, int, int, int], Mat4, Mat4], Vec3]
+            Callable[[Point, tuple[int, int, int, int], Mat4, Mat4], Vec3]
         ] = None,
         window: Optional[Window] = None,
     ):
         self._win: Window = window or get_window()
-        self._viewport: Tuple[int, int, int, int] = viewport or self._win.ctx.viewport
+        self._viewport: tuple[int, int, int, int] = viewport or self._win.ctx.viewport
         self._view = view_matrix
         self._projection = projection_matrix
 
-        self._project_method: Optional[Callable[[Point, Tuple, Mat4, Mat4], Vec2]] = project_method
-        self._unproject_method: Optional[Callable[[Point, Tuple, Mat4, Mat4], Vec3]] = (
+        self._project_method: Optional[Callable[[Point, tuple, Mat4, Mat4], Vec2]] = project_method
+        self._unproject_method: Optional[Callable[[Point, tuple, Mat4, Mat4], Vec3]] = (
             unproject_method
         )
 
@@ -104,7 +104,7 @@ class _StaticCamera:
 def static_from_orthographic(
     view: CameraData,
     orthographic: OrthographicProjectionData,
-    viewport: Optional[Tuple[int, int, int, int]] = None,
+    viewport: Optional[tuple[int, int, int, int]] = None,
     *,
     window: Optional[Window] = None,
 ) -> _StaticCamera:
@@ -121,7 +121,7 @@ def static_from_orthographic(
 def static_from_perspective(
     view: CameraData,
     perspective: OrthographicProjectionData,
-    viewport: Optional[Tuple[int, int, int, int]] = None,
+    viewport: Optional[tuple[int, int, int, int]] = None,
     *,
     window: Optional[Window] = None,
 ) -> _StaticCamera:
@@ -136,14 +136,14 @@ def static_from_perspective(
 
 
 def static_from_raw_orthographic(
-    projection: Tuple[float, float, float, float],
+    projection: tuple[float, float, float, float],
     near: float = -100.0,
     far: float = 100.0,
     zoom: float = 1.0,
     position: Point3 = (0.0, 0.0, 0.0),
     up: Point3 = (0.0, 1.0, 0.0),
     forward: Point3 = (0.0, 0.0, -1.0),
-    viewport: Optional[Tuple[int, int, int, int]] = None,
+    viewport: Optional[tuple[int, int, int, int]] = None,
     *,
     window: Optional[Window] = None,
 ) -> _StaticCamera:
@@ -173,7 +173,7 @@ def static_from_raw_perspective(
     position: Point3 = (0.0, 0.0, 0.0),
     up: Point3 = (0.0, 1.0, 0.0),
     forward: Point3 = (0.0, 0.0, -1.0),
-    viewport: Optional[Tuple[int, int, int, int]] = None,
+    viewport: Optional[tuple[int, int, int, int]] = None,
     *,
     window: Optional[Window] = None,
 ) -> _StaticCamera:
@@ -193,12 +193,12 @@ def static_from_raw_perspective(
 def static_from_matrices(
     view: Mat4,
     projection: Mat4,
-    viewport: Optional[Tuple[int, int, int, int]],
+    viewport: Optional[tuple[int, int, int, int]],
     *,
     window: Optional[Window] = None,
-    project_method: Optional[Callable[[Point, Tuple[int, int, int, int], Mat4, Mat4], Vec2]] = None,
+    project_method: Optional[Callable[[Point, tuple[int, int, int, int], Mat4, Mat4], Vec2]] = None,
     unproject_method: Optional[
-        Callable[[Point, Tuple[int, int, int, int], Mat4, Mat4], Vec3]
+        Callable[[Point, tuple[int, int, int, int], Mat4, Mat4], Vec3]
     ] = None,
 ) -> _StaticCamera:
     return _StaticCamera(

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -6,7 +6,7 @@ Contains pre-loaded programs
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable, Dict, Optional, Union, Sequence, Tuple
+from typing import Any, Iterable, Optional, Union, Sequence
 
 import pyglet
 from pyglet import gl
@@ -46,7 +46,7 @@ class ArcadeContext(Context):
                         it's not clear what thread will gc the object.
     """
 
-    atlas_size: Tuple[int, int] = 512, 512
+    atlas_size: tuple[int, int] = 512, 512
 
     def __init__(
         self, window: pyglet.window.Window, gc_mode: str = "context_gc", gl_api: str = "gl"
@@ -190,7 +190,7 @@ class ArcadeContext(Context):
         self._atlas: Optional[TextureAtlas] = None
         # Global labels we modify in `arcade.draw_text`.
         # These multiple labels with different configurations are stored
-        self.label_cache: Dict[str, arcade.Text] = {}
+        self.label_cache: dict[str, arcade.Text] = {}
 
         # self.active_program = None
         self.point_size = 1.0
@@ -250,7 +250,7 @@ class ArcadeContext(Context):
         return self._atlas
 
     @property
-    def viewport(self) -> Tuple[int, int, int, int]:
+    def viewport(self) -> tuple[int, int, int, int]:
         """
         Get or set the viewport for the currently active framebuffer.
         The viewport simply describes what pixels of the screen
@@ -269,7 +269,7 @@ class ArcadeContext(Context):
         return self.active_framebuffer.viewport
 
     @viewport.setter
-    def viewport(self, value: Tuple[int, int, int, int]):
+    def viewport(self, value: tuple[int, int, int, int]):
         self.active_framebuffer.viewport = value
         if self._default_camera == self.current_camera:
             self._default_camera.use()
@@ -321,7 +321,7 @@ class ArcadeContext(Context):
         tess_control_shader: Optional[Union[str, Path]] = None,
         tess_evaluation_shader: Optional[Union[str, Path]] = None,
         common: Iterable[Union[str, Path]] = (),
-        defines: Optional[Dict[str, Any]] = None,
+        defines: Optional[dict[str, Any]] = None,
         varyings: Optional[Sequence[str]] = None,
         varyings_capture_mode: str = "interleaved",
     ) -> Program:

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import array
 import math
-from typing import Optional, Tuple, List
+from typing import Optional
 
 import PIL.Image
 import PIL.ImageOps
@@ -66,7 +66,7 @@ __all__ = [
 
 def get_points_for_thick_line(
     start_x: float, start_y: float, end_x: float, end_y: float, line_width: float
-) -> Tuple[Point2, Point2, Point2, Point2]:
+) -> tuple[Point2, Point2, Point2, Point2]:
     """
     Function used internally for Arcade. OpenGL draws triangles only, so a thick
     line must be two triangles that make up a rectangle. This calculates and returns
@@ -537,7 +537,7 @@ def draw_line_strip(point_list: PointList, color: RGBA255, line_width: float = 1
     if line_width == 1:
         _generic_draw_line_strip(point_list, color, gl.GL_LINE_STRIP)
     else:
-        triangle_point_list: List[Point] = []
+        triangle_point_list: list[Point] = []
         # This needs a lot of improvement
         last_point = None
         for point in point_list:
@@ -1080,7 +1080,7 @@ def draw_rect_filled_kwargs(
 # Get_ functions
 
 
-def get_pixel(x: int, y: int, components: int = 3) -> Tuple[int, ...]:
+def get_pixel(x: int, y: int, components: int = 3) -> tuple[int, ...]:
     """
     Given an x, y, will return a color value of that point.
 

--- a/arcade/earclip.py
+++ b/arcade/earclip.py
@@ -6,12 +6,11 @@ from: https://github.com/linuxlewis/tripy/blob/master/tripy.py
 from __future__ import annotations
 
 from arcade.types import Point, PointList
-from typing import List, Tuple
 
 
 def earclip(
     polygon: PointList,
-) -> List[Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]]:
+) -> list[tuple[tuple[float, float], tuple[float, float], tuple[float, float]]]:
     """
     Simple earclipping algorithm for a given polygon p.
     polygon is expected to be an array of 2-tuples of the cartesian points of the polygon
@@ -72,7 +71,7 @@ def earclip(
     return triangles
 
 
-def _is_clockwise(polygon: List[Point]) -> bool:
+def _is_clockwise(polygon: list[Point]) -> bool:
     s = 0.0
     polygon_count = len(polygon)
     for i in range(polygon_count):
@@ -86,7 +85,7 @@ def _is_convex(prev: Point, point: Point, next_point: Point) -> bool:
     return _triangle_sum(prev[0], prev[1], point[0], point[1], next_point[0], next_point[1]) < 0
 
 
-def _is_ear(p1: Point, p2: Point, p3: Point, polygon: List[Point]) -> bool:
+def _is_ear(p1: Point, p2: Point, p3: Point, polygon: list[Point]) -> bool:
     return (
         _contains_no_points(p1, p2, p3, polygon)
         and _is_convex(p1, p2, p3)
@@ -94,7 +93,7 @@ def _is_ear(p1: Point, p2: Point, p3: Point, polygon: List[Point]) -> bool:
     )
 
 
-def _contains_no_points(p1: Point, p2: Point, p3: Point, polygon: List[Point]) -> bool:
+def _contains_no_points(p1: Point, p2: Point, p3: Point, polygon: list[Point]) -> bool:
     for pn in polygon:
         if pn in (p1, p2, p3):
             continue

--- a/arcade/easing.py
+++ b/arcade/easing.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from math import pi, sin, cos
 from dataclasses import dataclass
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 from .math import get_distance
 
 
@@ -188,7 +188,7 @@ def ease_angle(
     return easing_data
 
 
-def ease_angle_update(easing_data: EasingData, delta_time: float) -> Tuple:
+def ease_angle_update(easing_data: EasingData, delta_time: float) -> tuple[bool, float]:
     """
     Update angle easing.
     """
@@ -237,7 +237,7 @@ def ease_value(
 
 def ease_position(
     start_position, end_position, *, time=None, rate=None, ease_function=linear
-) -> Tuple[EasingData, EasingData]:
+) -> tuple[EasingData, EasingData]:
     """
     Get an easing position
     """
@@ -256,7 +256,7 @@ def ease_position(
     return easing_data_x, easing_data_y
 
 
-def ease_update(easing_data: EasingData, delta_time: float) -> Tuple[bool, float]:
+def ease_update(easing_data: EasingData, delta_time: float) -> tuple[bool, float]:
     """
     Update easing between two values/
     """

--- a/arcade/experimental/actor_map.py
+++ b/arcade/experimental/actor_map.py
@@ -9,7 +9,6 @@ in arcade.
 from __future__ import annotations
 
 import random
-from typing import Tuple
 
 import arcade
 from arcade.gl import geometry
@@ -51,9 +50,9 @@ class Actor:
         map,
         shaders,
         *,
-        position: Tuple[float, float] = (0, 0),
+        position: tuple[float, float] = (0, 0),
         rotation: float = 0.0,
-        area: Tuple[float, float] = (256, 256),
+        area: tuple[float, float] = (256, 256),
         view_distance: float = 120.0,
     ):
         self.ctx = map.ctx
@@ -67,7 +66,7 @@ class Actor:
         self.geometry = geometry.quad_2d_fs()
 
     @property
-    def position(self) -> Tuple[float, float]:
+    def position(self) -> tuple[float, float]:
         """Get or set the position"""
         return self._position
 
@@ -99,7 +98,7 @@ class Map:
     Sprites for out map to keep things less messy
     """
 
-    def __init__(self, ctx, *, size: Tuple[int, int]):
+    def __init__(self, ctx, *, size: tuple[int, int]):
         self.ctx = ctx
         self.size = size
 

--- a/arcade/experimental/background/background.py
+++ b/arcade/experimental/background/background.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Union, Tuple
+from typing import Optional, Union
 
 from arcade.window_commands import get_window
 import arcade.gl as gl
@@ -23,9 +23,9 @@ class Background:
     def __init__(
         self,
         texture: BackgroundTexture,
-        pos: Tuple[float, float],
-        size: Tuple[int, int],
-        color: Union[Tuple[float, float, float], Tuple[int, int, int]],
+        pos: tuple[float, float],
+        size: tuple[int, int],
+        color: Union[tuple[float, float, float], tuple[int, int, int]],
         shader: Optional[gl.Program] = None,
         geometry: Optional[gl.Geometry] = None,
     ):
@@ -80,15 +80,15 @@ class Background:
     @staticmethod
     def from_file(
         tex_src: str,
-        pos: Tuple[float, float] = (0.0, 0.0),
-        size: Optional[Tuple[int, int]] = None,
-        offset: Tuple[float, float] = (0.0, 0.0),
+        pos: tuple[float, float] = (0.0, 0.0),
+        size: Optional[tuple[int, int]] = None,
+        offset: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
         angle: float = 0.0,
         *,
         filters=(gl.NEAREST, gl.NEAREST),
-        color: Optional[Tuple[int, int, int]] = None,
-        color_norm: Optional[Tuple[float, float, float]] = None,
+        color: Optional[tuple[int, int, int]] = None,
+        color_norm: Optional[tuple[float, float, float]] = None,
         shader: Optional[gl.Program] = None,
         geometry: Optional[gl.Geometry] = None,
     ):
@@ -124,19 +124,19 @@ class Background:
         return Background(background_texture, pos, size, _color, shader, geometry)
 
     @property
-    def pos(self) -> Tuple[float, float]:
+    def pos(self) -> tuple[float, float]:
         return self._pos
 
     @pos.setter
-    def pos(self, value: Tuple[float, float]):
+    def pos(self, value: tuple[float, float]):
         self._pos = value
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         return self._size
 
     @size.setter
-    def size(self, value: Tuple[int, int]):
+    def size(self, value: tuple[int, int]):
         self._size = value
         try:
             self.shader["size"] = value
@@ -160,7 +160,7 @@ class Background:
             )
 
     @property
-    def color(self) -> Tuple[int, int, int]:
+    def color(self) -> tuple[int, int, int]:
         """
         Color in the range of 0-255.
         """
@@ -171,7 +171,7 @@ class Background:
         )
 
     @color.setter
-    def color(self, value: Tuple[int, int, int]):
+    def color(self, value: tuple[int, int, int]):
         """
         Color in the range of 0-255.
         """
@@ -184,11 +184,11 @@ class Background:
             )
 
     @property
-    def color_norm(self) -> Tuple[float, float, float]:
+    def color_norm(self) -> tuple[float, float, float]:
         return self._color
 
     @color_norm.setter
-    def color_norm(self, value: Tuple[float, float, float]):
+    def color_norm(self, value: tuple[float, float, float]):
         self._color = value
         try:
             self.shader["color"] = self._color
@@ -197,7 +197,7 @@ class Background:
                 "Attempting to set uniform 'color' when shader does not have uniform with that name."
             )
 
-    def draw(self, shift: Tuple[float, float] = (0.0, 0.0)):
+    def draw(self, shift: tuple[float, float] = (0.0, 0.0)):
         try:
             self.shader["pixelTransform"] = self.texture.pixel_transform
         except KeyError:

--- a/arcade/experimental/background/background_texture.py
+++ b/arcade/experimental/background/background_texture.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, List, Tuple
+from typing import Optional
 
 from PIL import Image
 
@@ -22,7 +22,7 @@ class BackgroundTexture:
     def __init__(
         self,
         texture: gl.Texture2D,
-        offset: Tuple[float, float] = (0.0, 0.0),
+        offset: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
         angle: float = 0.0,
     ):
@@ -60,11 +60,11 @@ class BackgroundTexture:
         self._angle_transform = Mat3().rotate(value)
 
     @property
-    def offset(self) -> Tuple[float, float]:
+    def offset(self) -> tuple[float, float]:
         return self._offset
 
     @offset.setter
-    def offset(self, value: Tuple[float, float]):
+    def offset(self, value: tuple[float, float]):
         self._offset = value
         self._offset_transform = Mat3().translate(-value[0], value[1])
 
@@ -125,7 +125,7 @@ class BackgroundTexture:
     def render_target(
         self,
         context: ArcadeContext,
-        color_attachments: Optional[List[gl.Texture2D]] = None,
+        color_attachments: Optional[list[gl.Texture2D]] = None,
         depth_attachment: Optional[gl.Texture2D] = None,
     ) -> gl.Framebuffer:
         if color_attachments is None:
@@ -138,7 +138,7 @@ class BackgroundTexture:
     @staticmethod
     def from_file(
         tex_src: str,
-        offset: Tuple[float, float] = (0.0, 0.0),
+        offset: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
         angle: float = 0.0,
         filters=(gl.NEAREST, gl.NEAREST),

--- a/arcade/experimental/background/groups.py
+++ b/arcade/experimental/background/groups.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union
 
 import arcade.gl as gl
 from arcade.experimental.background import Background
@@ -13,8 +13,8 @@ class BackgroundGroup:
     The offset of the BackgroundGroup is the same as each background.
     """
 
-    def __init__(self, backgrounds: Optional[List[Background]] = None):
-        self._backgrounds: List[Background] = [] if backgrounds is None else backgrounds
+    def __init__(self, backgrounds: Optional[list[Background]] = None):
+        self._backgrounds: list[Background] = [] if backgrounds is None else backgrounds
 
         self._pos = (0.0, 0.0)
         self._offset = (0.0, 0.0)
@@ -24,7 +24,7 @@ class BackgroundGroup:
         return self._pos
 
     @pos.setter
-    def pos(self, value: Tuple[float, float]):
+    def pos(self, value: tuple[float, float]):
         self._pos = value
 
     @property
@@ -53,7 +53,7 @@ class BackgroundGroup:
         else:
             print("WARNING: Background already in group")
 
-    def extend(self, items: List[Background]):
+    def extend(self, items: list[Background]):
         for item in items:
             self.add(item)
 
@@ -64,15 +64,15 @@ class BackgroundGroup:
     def add_from_file(
         self,
         tex_src: str,
-        pos: Tuple[float, float] = (0.0, 0.0),
-        size: Optional[Tuple[int, int]] = None,
-        offset: Tuple[float, float] = (0.0, 0.0),
+        pos: tuple[float, float] = (0.0, 0.0),
+        size: Optional[tuple[int, int]] = None,
+        offset: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
         angle: float = 0.0,
         *,
         filters=(gl.NEAREST, gl.NEAREST),
-        color: Optional[Tuple[int, int, int]] = None,
-        color_norm: Optional[Tuple[float, float, float]] = None,
+        color: Optional[tuple[int, int, int]] = None,
+        color_norm: Optional[tuple[float, float, float]] = None,
         shader: Optional[gl.Program] = None,
         geometry: Optional[gl.Geometry] = None,
     ):
@@ -103,11 +103,11 @@ class ParallaxGroup:
 
     def __init__(
         self,
-        backgrounds: Optional[List[Background]] = None,
-        depths: Optional[List[float]] = None,
+        backgrounds: Optional[list[Background]] = None,
+        depths: Optional[list[float]] = None,
     ):
-        self._backgrounds: List[Background] = [] if backgrounds is None else backgrounds
-        self._depths: List[float] = [] if depths is None else depths
+        self._backgrounds: list[Background] = [] if backgrounds is None else backgrounds
+        self._depths: list[float] = [] if depths is None else depths
 
         if len(self._backgrounds) != len(self._depths):
             raise ValueError("The number of backgrounds does not equal the number of depth values")
@@ -116,19 +116,19 @@ class ParallaxGroup:
         self._offset = (0.0, 0.0)
 
     @property
-    def pos(self) -> Tuple[float, float]:
+    def pos(self) -> tuple[float, float]:
         return self._pos
 
     @pos.setter
-    def pos(self, value: Tuple[float, float]):
+    def pos(self, value: tuple[float, float]):
         self._pos = value
 
     @property
-    def offset(self) -> Tuple[float, float]:
+    def offset(self) -> tuple[float, float]:
         return self._offset
 
     @offset.setter
-    def offset(self, value: Tuple[float, float]):
+    def offset(self, value: tuple[float, float]):
         self._offset = value
         for index, background in enumerate(self._backgrounds):
             depth = self._depths[index]
@@ -158,7 +158,7 @@ class ParallaxGroup:
     def change_depth(self, item: Background, new_depth: float):
         self._depths[self._backgrounds.index(item)] = new_depth
 
-    def extend(self, items: List[Background], depths: List[float]):
+    def extend(self, items: list[Background], depths: list[float]):
         for index, item in enumerate(items):
             self.add(item, depths[index])
 
@@ -169,16 +169,16 @@ class ParallaxGroup:
     def add_from_file(
         self,
         tex_src: str,
-        pos: Tuple[float, float] = (0.0, 0.0),
-        size: Optional[Tuple[int, int]] = None,
+        pos: tuple[float, float] = (0.0, 0.0),
+        size: Optional[tuple[int, int]] = None,
         depth: float = 1,
-        offset: Tuple[float, float] = (0.0, 0.0),
+        offset: tuple[float, float] = (0.0, 0.0),
         scale: float = 1.0,
         angle: float = 0.0,
         *,
         filters=(gl.NEAREST, gl.NEAREST),
-        color: Optional[Tuple[int, int, int]] = None,
-        color_norm: Optional[Tuple[float, float, float]] = None,
+        color: Optional[tuple[int, int, int]] = None,
+        color_norm: Optional[tuple[float, float, float]] = None,
         shader: Optional[gl.Program] = None,
         geometry: Optional[gl.Geometry] = None,
     ):

--- a/arcade/experimental/clock/clock.py
+++ b/arcade/experimental/clock/clock.py
@@ -1,4 +1,6 @@
-from typing import Optional, Set
+from __future__ import annotations
+
+from typing import Optional
 from arcade.experimental.clock.timer import Timer
 
 
@@ -41,8 +43,8 @@ class Clock:
 
         self._parent: Optional[Clock] = parent
 
-        self._children: Set[Clock] = set()
-        self._timers: Set[Timer] = set()
+        self._children: set[Clock] = set()
+        self._timers: set[Timer] = set()
 
         self._delta_time_raw: float = 0.0
 

--- a/arcade/experimental/clock/clock_window.py
+++ b/arcade/experimental/clock/clock_window.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Tuple, Optional
+from typing import Optional
 
 import pyglet
 
@@ -93,7 +93,7 @@ class Window(pyglet.window.Window):
         resizable: bool = False,
         update_rate: float = 1 / 60,
         antialiasing: bool = True,
-        gl_version: Tuple[int, int] = (3, 3),
+        gl_version: tuple[int, int] = (3, 3),
         screen: Optional[pyglet.display.Screen] = None,
         style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
@@ -264,7 +264,7 @@ class Window(pyglet.window.Window):
         self,
         color: Optional[RGBOrA255] = None,
         color_normalized: Optional[RGBOrANormalized] = None,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
     ):
         """Clears the window with the configured background color
         set through :py:attr:`arcade.Window.background_color`.
@@ -695,7 +695,7 @@ class Window(pyglet.window.Window):
 
         super().set_size(width, height)
 
-    def get_size(self) -> Tuple[int, int]:
+    def get_size(self) -> tuple[int, int]:
         """
         Get the size of the window.
 
@@ -704,7 +704,7 @@ class Window(pyglet.window.Window):
 
         return super().get_size()
 
-    def get_location(self) -> Tuple[int, int]:
+    def get_location(self) -> tuple[int, int]:
         """
         Return the X/Y coordinates of the window
 
@@ -737,7 +737,7 @@ class Window(pyglet.window.Window):
         set_viewport(left, right, bottom, top)
 
     # noinspection PyMethodMayBeStatic
-    def get_viewport(self) -> Tuple[float, float, float, float]:
+    def get_viewport(self) -> tuple[float, float, float, float]:
         """Get the viewport. (What coordinates we can see.)"""
         return self.ctx.projection_2d
 
@@ -1013,7 +1013,7 @@ class View:
         self,
         color: Optional[RGBOrA255] = None,
         color_normalized: Optional[RGBOrANormalized] = None,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
     ):
         """Clears the window with the configured background color
         set through :py:attr:`arcade.Window.background_color`.

--- a/arcade/experimental/clock/timer.py
+++ b/arcade/experimental/clock/timer.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import weakref
-from typing import Callable, List, Dict, Any, Optional, TYPE_CHECKING
+from typing import Callable, Any, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from arcade.experimental.clock.clock import Clock
@@ -56,8 +58,8 @@ class Timer:
         self._complete: bool = False
 
         self._callback: Optional[Callable] = weakref.proxy(callback)
-        self._args: List[Any] = list(args)
-        self._kwargs: Dict[str, Any] = kwargs or dict()
+        self._args: list[Any] = list(args)
+        self._kwargs: dict[str, Any] = kwargs or dict()
 
         self.reusable: bool = reusable
 

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -19,6 +19,7 @@ both easier and more performant than more accurate blur approaches.
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.experimental.examples.array_backed_grid
 """
+
 from __future__ import annotations
 
 from typing import Optional, cast

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -19,8 +19,9 @@ both easier and more performant than more accurate blur approaches.
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.experimental.examples.array_backed_grid
 """
+from __future__ import annotations
 
-from typing import Tuple, Optional, cast
+from typing import Optional, cast
 from textwrap import dedent
 from math import cos, pi
 from random import uniform, randint
@@ -45,13 +46,13 @@ class DepthOfField:
 
     def __init__(
         self,
-        size: Optional[Tuple[int, int]] = None,
+        size: Optional[tuple[int, int]] = None,
         clear_color: RGBA255 = (155, 155, 155, 255),
     ):
         self._geo = geometry.quad_2d_fs()
         self._win: Window = get_window()
 
-        size = cast(Tuple[int, int], size or self._win.size)
+        size = cast(tuple[int, int], size or self._win.size)
         self._clear_color: Color = Color.from_iterable(clear_color)
 
         self.stale = True

--- a/arcade/experimental/input/manager.py
+++ b/arcade/experimental/input/manager.py
@@ -312,7 +312,7 @@ class InputManager:
 
     def register_action_handler(
         self,
-        handler: Union[Callable[[str, ActionState], Any], List[Callable[[str, ActionState], Any]]],
+        handler: Union[Callable[[str, ActionState], Any], list[Callable[[str, ActionState], Any]]],
     ):
         if isinstance(handler, list):
             self.on_action_listeners.extend(handler)

--- a/arcade/experimental/input/manager.py
+++ b/arcade/experimental/input/manager.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Optional, Union
 
 import pyglet
 from pyglet.input.base import Controller
@@ -25,12 +25,12 @@ from .mapping import (
 
 
 class RawInputManager(TypedDict):
-    actions: List[RawAction]
-    axes: List[RawAxis]
+    actions: list[RawAction]
+    axes: list[RawAxis]
     controller_deadzone: float
 
 
-def _set_discard(set: Set, element: Any) -> Set:
+def _set_discard(set: set, element: Any) -> set:
     set.discard(element)
     return set
 
@@ -52,23 +52,23 @@ class InputManager:
         controller: Optional[Controller] = None,
         allow_keyboard: bool = True,
         action_handlers: Union[
-            Callable[[str, ActionState], Any], List[Callable[[str, ActionState], Any]]
+            Callable[[str, ActionState], Any], list[Callable[[str, ActionState], Any]]
         ] = [],
         controller_deadzone: float = 0.1,
     ):
-        self.actions: Dict[str, Action] = {}
-        self.keys_to_actions: Dict[int, Set[str]] = {}
-        self.controller_buttons_to_actions: Dict[str, Set[str]] = {}
-        self.controller_axes_to_actions: Dict[str, Set[str]] = {}
-        self.mouse_buttons_to_actions: Dict[int, Set[str]] = {}
-        self.on_action_listeners: List[Callable[[str, ActionState], Any]] = []
-        self.action_subscribers: Dict[str, Set[Callable[[ActionState], Any]]] = {}
+        self.actions: dict[str, Action] = {}
+        self.keys_to_actions: dict[int, set[str]] = {}
+        self.controller_buttons_to_actions: dict[str, set[str]] = {}
+        self.controller_axes_to_actions: dict[str, set[str]] = {}
+        self.mouse_buttons_to_actions: dict[int, set[str]] = {}
+        self.on_action_listeners: list[Callable[[str, ActionState], Any]] = []
+        self.action_subscribers: dict[str, set[Callable[[ActionState], Any]]] = {}
 
-        self.axes: Dict[str, Axis] = {}
-        self.axes_state: Dict[str, float] = {}
-        self.keys_to_axes: Dict[int, Set[str]] = {}
-        self.controller_buttons_to_axes: Dict[str, Set[str]] = {}
-        self.controller_analog_to_axes: Dict[str, Set[str]] = {}
+        self.axes: dict[str, Axis] = {}
+        self.axes_state: dict[str, float] = {}
+        self.keys_to_axes: dict[int, set[str]] = {}
+        self.controller_buttons_to_axes: dict[str, set[str]] = {}
+        self.controller_analog_to_axes: dict[str, set[str]] = {}
 
         self.window = arcade.get_window()
 

--- a/arcade/experimental/input/mapping.py
+++ b/arcade/experimental/input/mapping.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Set, Union
+from typing import Union
 
 from typing_extensions import TypedDict
 
@@ -25,19 +25,19 @@ class RawAxisMapping(TypedDict):
 
 class RawAction(TypedDict):
     name: str
-    mappings: List[RawActionMapping]
+    mappings: list[RawActionMapping]
 
 
 class RawAxis(TypedDict):
     name: str
-    mappings: List[RawAxisMapping]
+    mappings: list[RawAxisMapping]
 
 
 class Action:
 
     def __init__(self, name: str) -> None:
         self.name = name
-        self._mappings: Set[ActionMapping] = set()
+        self._mappings: set[ActionMapping] = set()
 
     def add_mapping(self, mapping: ActionMapping) -> None:
         self._mappings.add(mapping)
@@ -53,7 +53,7 @@ class Axis:
 
     def __init__(self, name: str) -> None:
         self.name = name
-        self._mappings: Set[AxisMapping] = set()
+        self._mappings: set[AxisMapping] = set()
 
     def add_mapping(self, mapping: AxisMapping) -> None:
         self._mappings.add(mapping)
@@ -103,7 +103,7 @@ class AxisMapping(Mapping):
 
 
 def serialize_action(action: Action) -> RawAction:
-    raw_mappings: List[RawActionMapping] = []
+    raw_mappings: list[RawActionMapping] = []
     for mapping in action._mappings:
         raw_mappings.append(
             {
@@ -135,7 +135,7 @@ def parse_raw_axis(raw_axis: RawAxis) -> Axis:
 
 
 def serialize_axis(axis: Axis) -> RawAxis:
-    raw_mappings: List[RawAxisMapping] = []
+    raw_mappings: list[RawAxisMapping] = []
     for mapping in axis._mappings:
         raw_mappings.append(
             {

--- a/arcade/experimental/input_manager_example.py
+++ b/arcade/experimental/input_manager_example.py
@@ -1,7 +1,8 @@
 #  type: ignore
+from __future__ import annotations
 
 import random
-from typing import List, Optional
+from typing import Optional
 
 import pyglet
 
@@ -88,7 +89,7 @@ class Game(arcade.Window):
             wall.center_y = 32
             self.wall_list.append(wall)
 
-        self.players: List[Player] = []
+        self.players: list[Player] = []
 
         self.controller_manager = pyglet.input.ControllerManager()
         self.controller_manager.set_handlers(self.on_connect, self.on_disconnect)

--- a/arcade/experimental/lights.py
+++ b/arcade/experimental/lights.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from array import array
-from typing import Iterable, Tuple, Sequence, List, Optional
+from typing import Iterable, Sequence, Optional
 
 from arcade import gl
 from arcade.experimental.texture_render_target import RenderTargetTexture
@@ -54,7 +54,7 @@ class Light:
             )
 
     @property
-    def position(self) -> Tuple[float, float]:
+    def position(self) -> tuple[float, float]:
         """Get or set the light position"""
         return self._center_x, self._center_y
 
@@ -88,7 +88,7 @@ class LightLayer(RenderTargetTexture):
         """
         super().__init__(width, height)
 
-        self._lights: List[Light] = []
+        self._lights: list[Light] = []
         self._prev_target = None
         self._rebuild = False
         self._stride = 28
@@ -172,7 +172,7 @@ class LightLayer(RenderTargetTexture):
 
     def draw(
         self,
-        position: Tuple[float, float] = (0, 0),
+        position: tuple[float, float] = (0, 0),
         target=None,
         ambient_color: RGBOrA255 = (64, 64, 64),
     ):
@@ -186,7 +186,7 @@ class LightLayer(RenderTargetTexture):
 
         # Re-build light data if needed
         if self._rebuild and len(self._lights) > 0:
-            data: List[float] = []
+            data: list[float] = []
             for light in self._lights:
                 data.extend(light.position)
                 data.append(light.radius)

--- a/arcade/experimental/postprocessing.py
+++ b/arcade/experimental/postprocessing.py
@@ -4,7 +4,6 @@ Post-processing shaders.
 
 from __future__ import annotations
 
-from typing import Tuple
 from arcade.context import ArcadeContext
 from arcade.gl.texture import Texture2D
 from arcade import get_window
@@ -15,7 +14,7 @@ from arcade.experimental.gaussian_kernel import gaussian_kernel
 class PostProcessing:
     """Base class"""
 
-    def __init__(self, size: Tuple[int, int], *args, **kwargs):
+    def __init__(self, size: tuple[int, int], *args, **kwargs):
         self._size = size
         window = get_window()
         if not window:
@@ -46,7 +45,7 @@ class PostProcessing:
     #     """ Render. Should be over-loaded by the child class. """
     #     pass
 
-    def resize(self, size: Tuple[int, int]):
+    def resize(self, size: tuple[int, int]):
         """
         Resize post processing buffers.
         This is often needed of the screen since changes.
@@ -83,7 +82,7 @@ class GaussianBlurPass(PostProcessing):
 class GaussianBlurHorizontal(GaussianBlurPass):
     """Blur the buffer horizontally."""
 
-    def __init__(self, size: Tuple[int, int], kernel_size=5, sigma=2, multiplier=1, step=1):
+    def __init__(self, size: tuple[int, int], kernel_size=5, sigma=2, multiplier=1, step=1):
         super().__init__(size, kernel_size=5, sigma=2, multiplier=1, step=1)
         color_attachment = self.ctx.texture(
             size, components=3, wrap_x=self.ctx.CLAMP_TO_EDGE, wrap_y=self.ctx.CLAMP_TO_EDGE
@@ -108,7 +107,7 @@ class GaussianBlurHorizontal(GaussianBlurPass):
 class GaussianBlurVertical(GaussianBlurPass):
     """Blur the buffer vertically."""
 
-    def __init__(self, size: Tuple[int, int], kernel_size=5, sigma=2, multiplier=1, step=1):
+    def __init__(self, size: tuple[int, int], kernel_size=5, sigma=2, multiplier=1, step=1):
         super().__init__(
             size, kernel_size=kernel_size, sigma=sigma, multiplier=multiplier, step=step
         )

--- a/arcade/experimental/pygame_interaction.py
+++ b/arcade/experimental/pygame_interaction.py
@@ -16,7 +16,6 @@ but should work with any recent version of Pygame.
 from __future__ import annotations
 
 import math
-from typing import Tuple
 
 import pygame  # type: ignore
 
@@ -30,7 +29,7 @@ class SurfaceTexture:
     making it simple to synchronize the data.
     """
 
-    def __init__(self, ctx: arcade.ArcadeContext, size: Tuple[int, int]):
+    def __init__(self, ctx: arcade.ArcadeContext, size: tuple[int, int]):
         self._ctx = ctx
         self._size = size
         self._surface = pygame.Surface(size, flags=pygame.SRCALPHA)
@@ -66,7 +65,7 @@ class SurfaceTexture:
         )
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         return self._size
 
     @property

--- a/arcade/experimental/shadertoy.py
+++ b/arcade/experimental/shadertoy.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import string
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple, Optional, Union
+from typing import Optional, Union
 
 from arcade import get_window
 import arcade
@@ -55,7 +55,7 @@ class ShadertoyBase:
     :param source: The mainImage shader source
     """
 
-    def __init__(self, size: Tuple[int, int], source: str):
+    def __init__(self, size: tuple[int, int], source: str):
         self._ctx = get_window().ctx
         self._size = size
         self._source = source
@@ -78,7 +78,7 @@ class ShadertoyBase:
         self._quad = geometry.quad_2d_fs()
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         Get or set the size in pixels.
 
@@ -157,7 +157,7 @@ class ShadertoyBase:
         self._frame_rate = value
 
     @property
-    def mouse_position(self) -> Tuple[float, float]:
+    def mouse_position(self) -> tuple[float, float]:
         """
         Get or set the current mouse position.
 
@@ -170,7 +170,7 @@ class ShadertoyBase:
         self._mouse_pos = value
 
     @property
-    def mouse_buttons(self) -> Tuple[float, float]:
+    def mouse_buttons(self) -> tuple[float, float]:
         """
         Get or set the mouse button states.
         Depending on the use case these can contain
@@ -182,11 +182,11 @@ class ShadertoyBase:
         return self._mouse_buttons
 
     @mouse_buttons.setter
-    def mouse_buttons(self, value: Tuple[float, float]):
+    def mouse_buttons(self, value: tuple[float, float]):
         self._mouse_buttons = value
 
     @property
-    def channel_time(self) -> List[float]:
+    def channel_time(self) -> list[float]:
         return self._channel_time
 
     @property
@@ -247,7 +247,7 @@ class ShadertoyBase:
         """The context"""
         return self._ctx
 
-    def resize(self, size: Tuple[int, int]) -> None:
+    def resize(self, size: tuple[int, int]) -> None:
         """Resize of this shadertoy or buffer"""
         raise NotImplementedError
 
@@ -256,8 +256,8 @@ class ShadertoyBase:
         *,
         time: Optional[float] = None,
         time_delta: Optional[float] = None,
-        mouse_position: Optional[Tuple[float, float]] = None,
-        size: Optional[Tuple[int, int]] = None,
+        mouse_position: Optional[tuple[float, float]] = None,
+        size: Optional[tuple[int, int]] = None,
         frame: Optional[int] = None,
         frame_rate: Optional[float] = None,
     ):
@@ -312,7 +312,7 @@ class ShadertoyBase:
         self._program.set_uniform_safe("iFrameRate", self._frame_rate)
         self._program.set_uniform_safe("iDate", self._get_date())
 
-    def _get_date(self) -> Tuple[float, float, float, float]:
+    def _get_date(self) -> tuple[float, float, float, float]:
         """Create year, month, day, seconds data for iDate"""
         now = datetime.now()
         seconds = now.hour * 60 * 60 + now.minute * 60 + now.second + now.microsecond / 1_000_000
@@ -355,7 +355,7 @@ class ShadertoyBuffer(ShadertoyBase):
     :param repeat: Repeat/wrap mode for the underlying texture
     """
 
-    def __init__(self, size: Tuple[int, int], source: str, repeat: bool = False):
+    def __init__(self, size: tuple[int, int], source: str, repeat: bool = False):
         super().__init__(size, source)
         self._texture = self.ctx.texture(self._size, components=4)
         self._fbo = self.ctx.framebuffer(color_attachments=[self._texture])
@@ -405,7 +405,7 @@ class ShadertoyBuffer(ShadertoyBase):
         with self._fbo.activate():
             self._quad.render(self._program)
 
-    def resize(self, size: Tuple[int, int]):
+    def resize(self, size: tuple[int, int]):
         """
         Change the internal buffer size.
 
@@ -430,7 +430,7 @@ class Shadertoy(ShadertoyBase):
         }
     """
 
-    def __init__(self, size: Tuple[int, int], main_source: str):
+    def __init__(self, size: tuple[int, int], main_source: str):
         """
         :param [int, int] size: pixel size if the output
         :param main_source: The main glsl source with mainImage function
@@ -479,7 +479,7 @@ class Shadertoy(ShadertoyBase):
         self._buffer_d = value
 
     @classmethod
-    def create_from_file(cls, size: Tuple[int, int], path: Union[str, Path]) -> "Shadertoy":
+    def create_from_file(cls, size: tuple[int, int], path: Union[str, Path]) -> "Shadertoy":
         """
         Create a Shadertoy from a mainImage shader file.
 
@@ -512,7 +512,7 @@ class Shadertoy(ShadertoyBase):
             source = fd.read()
         return ShadertoyBuffer(self._size, source)
 
-    def resize(self, size: Tuple[int, int]):
+    def resize(self, size: tuple[int, int]):
         """
         Resize the internal buffers
 

--- a/arcade/experimental/video_player.py
+++ b/arcade/experimental/video_player.py
@@ -8,7 +8,7 @@ and you might need to tell pyglet where it's located.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 # import sys
 import pyglet
@@ -34,7 +34,7 @@ class VideoPlayer:
         self._width = arcade.get_window().width
         self._height = arcade.get_window().height
 
-    def draw(self, left: int = 0, bottom: int = 0, size: Optional[Tuple[int, int]] = None) -> None:
+    def draw(self, left: int = 0, bottom: int = 0, size: Optional[tuple[int, int]] = None) -> None:
         """
         Call this in `on_draw`.
 
@@ -64,7 +64,7 @@ class VideoPlayer:
         """Video height."""
         return self._height
 
-    def get_video_size(self) -> Tuple[int, int]:
+    def get_video_size(self) -> tuple[int, int]:
         if not self.player.source or not self.player.source.video_format:
             return 0, 0
         video_format = self.player.source.video_format

--- a/arcade/gl/compute_shader.py
+++ b/arcade/gl/compute_shader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Union
 from ctypes import (
     c_char,
     cast,
@@ -29,7 +29,7 @@ class ComputeShader:
     def __init__(self, ctx: "Context", glsl_source: str) -> None:
         self._ctx = ctx
         self._source = glsl_source
-        self._uniforms: Dict[str, Union[UniformBlock, Uniform]] = dict()
+        self._uniforms: dict[str, Union[UniformBlock, Uniform]] = dict()
 
         from arcade.gl import ShaderException
 
@@ -218,7 +218,7 @@ class ComputeShader:
             block = UniformBlock(self._glo, index, size, name)
             self._uniforms[name] = block
 
-    def _query_uniform(self, location: int) -> Tuple[str, int, int]:
+    def _query_uniform(self, location: int) -> tuple[str, int, int]:
         """Retrieve Uniform information at given location.
 
         Returns the name, the type as a GLenum (GL_FLOAT, ...) and the size. Size is
@@ -240,7 +240,7 @@ class ComputeShader:
         )
         return u_name.value.decode(), u_type.value, u_size.value
 
-    def _query_uniform_block(self, location: int) -> Tuple[int, int, str]:
+    def _query_uniform_block(self, location: int) -> tuple[int, int, str]:
         """Query active uniform block by retrieving the name and index and size"""
         # Query name
         u_size = gl.GLint()

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ctypes import c_int, string_at
 from contextlib import contextmanager
-from typing import Generator, Optional, Tuple, List, TYPE_CHECKING
+from typing import Generator, Optional, TYPE_CHECKING
 import weakref
 
 
@@ -91,7 +91,7 @@ class Framebuffer:
         # but let's keep this simple with high compatibility.
         self._width, self._height = self._detect_size()
         self._viewport = 0, 0, self._width, self._height
-        self._scissor: Optional[Tuple[int, int, int, int]] = None
+        self._scissor: Optional[tuple[int, int, int, int]] = None
 
         # Attach textures to it
         for i, tex in enumerate(self._color_attachments):
@@ -145,7 +145,7 @@ class Framebuffer:
         """
         return self._glo
 
-    def _get_viewport(self) -> Tuple[int, int, int, int]:
+    def _get_viewport(self) -> tuple[int, int, int, int]:
         """
         Get or set the framebuffer's viewport.
         The viewport parameter are ``(x, y, width, height)``.
@@ -162,7 +162,7 @@ class Framebuffer:
         """
         return self._viewport
 
-    def _set_viewport(self, value: Tuple[int, int, int, int]):
+    def _set_viewport(self, value: tuple[int, int, int, int]):
         if not isinstance(value, tuple) or len(value) != 4:
             raise ValueError("viewport should be a 4-component tuple")
 
@@ -179,7 +179,7 @@ class Framebuffer:
 
     viewport = property(_get_viewport, _set_viewport)
 
-    def _get_scissor(self) -> Optional[Tuple[int, int, int, int]]:
+    def _get_scissor(self) -> Optional[tuple[int, int, int, int]]:
         """
         Get or set the scissor box for this framebuffer.
 
@@ -239,7 +239,7 @@ class Framebuffer:
         return self._height
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         Size as a ``(w, h)`` tuple
 
@@ -257,7 +257,7 @@ class Framebuffer:
         return self._samples
 
     @property
-    def color_attachments(self) -> List[Texture2D]:
+    def color_attachments(self) -> list[Texture2D]:
         """
         A list of color attachments
 
@@ -352,7 +352,7 @@ class Framebuffer:
         color: Optional[RGBOrA255] = None,
         color_normalized: Optional[RGBOrANormalized] = None,
         depth: float = 1.0,
-        viewport: Optional[Tuple[int, int, int, int]] = None,
+        viewport: Optional[tuple[int, int, int, int]] = None,
     ):
         """
         Clears the framebuffer::
@@ -476,7 +476,7 @@ class Framebuffer:
         gl.glDeleteFramebuffers(1, framebuffer_id)
         ctx.stats.decr("framebuffer")
 
-    def _detect_size(self) -> Tuple[int, int]:
+    def _detect_size(self) -> tuple[int, int]:
         """Detect the size of the framebuffer based on the attachments"""
         expected_size = (
             self._color_attachments[0] if self._color_attachments else self._depth_attachment
@@ -572,7 +572,7 @@ class DefaultFrameBuffer(Framebuffer):
         self._depth_attachment = True  # type: ignore
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         Size as a ``(w, h)`` tuple
 
@@ -598,11 +598,11 @@ class DefaultFrameBuffer(Framebuffer):
         """
         return self.size[1]
 
-    def _get_framebuffer_size(self) -> Tuple[int, int]:
+    def _get_framebuffer_size(self) -> tuple[int, int]:
         """Get the framebuffer size of the window"""
         return self._ctx.window.get_framebuffer_size()
 
-    def _get_viewport(self) -> Tuple[int, int, int, int]:
+    def _get_viewport(self) -> tuple[int, int, int, int]:
         """
         Get or set the framebuffer's viewport.
         The viewport parameter are ``(x, y, width, height)``.
@@ -625,7 +625,7 @@ class DefaultFrameBuffer(Framebuffer):
             int(self._viewport[3] / ratio),
         )
 
-    def _set_viewport(self, value: Tuple[int, int, int, int]):
+    def _set_viewport(self, value: tuple[int, int, int, int]):
         if not isinstance(value, tuple) or len(value) != 4:
             raise ValueError("viewport should be a 4-component tuple")
 
@@ -649,7 +649,7 @@ class DefaultFrameBuffer(Framebuffer):
 
     viewport = property(_get_viewport, _set_viewport)
 
-    def _get_scissor(self) -> Optional[Tuple[int, int, int, int]]:
+    def _get_scissor(self) -> Optional[tuple[int, int, int, int]]:
         """
         Get or set the scissor box for this framebuffer.
 

--- a/arcade/gl/geometry.py
+++ b/arcade/gl/geometry.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import math
 from array import array
-from typing import Tuple
 
 from arcade.gl import Context, BufferDescription
 from arcade.gl.vertex_array import Geometry
@@ -25,7 +24,7 @@ def quad_2d_fs() -> Geometry:
 
 
 def quad_2d(
-    size: Tuple[float, float] = (1.0, 1.0), pos: Tuple[float, float] = (0.0, 0.0)
+    size: tuple[float, float] = (1.0, 1.0), pos: tuple[float, float] = (0.0, 0.0)
 ) -> Geometry:
     """
     Creates 2D quad Geometry using 2 triangle strip with texture coordinates.
@@ -91,8 +90,8 @@ def screen_rectangle(
 
 
 def cube(
-    size: Tuple[float, float, float] = (1.0, 1.0, 1.0),
-    center: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    size: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    center: tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> Geometry:
     """Creates a cube with normals and texture coordinates.
 

--- a/arcade/gl/glsl.py
+++ b/arcade/gl/glsl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 import re
 
 from pyglet import gl
@@ -43,7 +43,7 @@ class ShaderSource:
         self._source = source.strip()
         self._type = source_type
         self._lines = self._source.split("\n") if source else []
-        self._out_attributes = []  # type: List[str]
+        self._out_attributes = []  # type: list[str]
 
         if not self._lines:
             raise ValueError("Shader source is empty")
@@ -75,7 +75,7 @@ class ShaderSource:
         return self._version
 
     @property
-    def out_attributes(self) -> List[str]:
+    def out_attributes(self) -> list[str]:
         """The out attributes for this program"""
         return self._out_attributes
 
@@ -96,7 +96,7 @@ class ShaderSource:
             lines = source.split("\n")
             self._lines = self._lines[:line_number] + lines + self._lines[line_number:]
 
-    def get_source(self, *, defines: Optional[Dict[str, str]] = None) -> str:
+    def get_source(self, *, defines: Optional[dict[str, str]] = None) -> str:
         """Return the shader source
 
         :param defines: Defines to replace in the source.
@@ -126,7 +126,7 @@ class ShaderSource:
         )
 
     @staticmethod
-    def apply_defines(lines: List[str], defines: Dict[str, str]) -> List[str]:
+    def apply_defines(lines: list[str], defines: dict[str, str]) -> list[str]:
         """Locate and apply #define values
 
         :param lines: List of source lines

--- a/arcade/gl/program.py
+++ b/arcade/gl/program.py
@@ -11,7 +11,7 @@ from ctypes import (
     byref,
     create_string_buffer,
 )
-from typing import Any, Dict, Iterable, Tuple, List, TYPE_CHECKING, Union, Optional
+from typing import Any, Iterable, TYPE_CHECKING, Union, Optional
 import typing
 import weakref
 
@@ -77,7 +77,7 @@ class Program:
         geometry_shader: Optional[str] = None,
         tess_control_shader: Optional[str] = None,
         tess_evaluation_shader: Optional[str] = None,
-        varyings: Optional[List[str]] = None,
+        varyings: Optional[list[str]] = None,
         varyings_capture_mode: str = "interleaved",
     ):
         self._ctx = ctx
@@ -85,10 +85,10 @@ class Program:
         self._varyings = varyings or []
         self._varyings_capture_mode = varyings_capture_mode.strip().lower()
         self._geometry_info = (0, 0, 0)
-        self._attributes = []  # type: List[AttribFormat]
+        self._attributes = []  # type: list[AttribFormat]
         #: Internal cache key used with vertex arrays
         self.attribute_key = "INVALID"  # type: str
-        self._uniforms: Dict[str, Union[Uniform, UniformBlock]] = {}
+        self._uniforms: dict[str, Union[Uniform, UniformBlock]] = {}
 
         if self._varyings_capture_mode not in self._valid_capture_modes:
             raise ValueError(
@@ -96,7 +96,7 @@ class Program:
                 f"Valid modes are: {self._valid_capture_modes}."
             )
 
-        shaders: List[Tuple[str, int]] = [(vertex_shader, gl.GL_VERTEX_SHADER)]
+        shaders: list[tuple[str, int]] = [(vertex_shader, gl.GL_VERTEX_SHADER)]
         if fragment_shader:
             shaders.append((fragment_shader, gl.GL_FRAGMENT_SHADER))
         if geometry_shader:
@@ -187,7 +187,7 @@ class Program:
         return self._attributes
 
     @property
-    def varyings(self) -> List[str]:
+    def varyings(self) -> list[str]:
         """
         Out attributes names used in transform feedback
 
@@ -196,7 +196,7 @@ class Program:
         return self._varyings
 
     @property
-    def out_attributes(self) -> List[str]:
+    def out_attributes(self) -> list[str]:
         """
         Out attributes names used in transform feedback.
 
@@ -307,7 +307,7 @@ class Program:
         except KeyError:
             pass
 
-    def set_uniform_array_safe(self, name: str, value: List[Any]):
+    def set_uniform_array_safe(self, name: str, value: list[Any]):
         """
         Safely set a uniform array. Arrays can be shortened
         by the glsl compiler not all elements are determined
@@ -442,7 +442,7 @@ class Program:
             block = UniformBlock(self._glo, index, size, name)
             self._uniforms[name] = block
 
-    def _query_uniform(self, location: int) -> Tuple[str, int, int]:
+    def _query_uniform(self, location: int) -> tuple[str, int, int]:
         """Retrieve Uniform information at given location.
 
         Returns the name, the type as a GLenum (GL_FLOAT, ...) and the size. Size is
@@ -464,7 +464,7 @@ class Program:
         )
         return u_name.value.decode(), u_type.value, u_size.value
 
-    def _query_uniform_block(self, location: int) -> Tuple[int, int, str]:
+    def _query_uniform_block(self, location: int) -> tuple[int, int, str]:
         """Query active uniform block by retrieving the name and index and size"""
         # Query name
         u_size = gl.GLint()

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ctypes import byref, string_at
 import weakref
-from typing import Optional, Tuple, Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 from pyglet import gl
 
@@ -114,12 +114,12 @@ class Texture2D:
     def __init__(
         self,
         ctx: "Context",
-        size: Tuple[int, int],
+        size: tuple[int, int],
         *,
         components: int = 4,
         dtype: str = "f1",
         data: Optional[BufferProtocol] = None,
-        filter: Optional[Tuple[PyGLuint, PyGLuint]] = None,
+        filter: Optional[tuple[PyGLuint, PyGLuint]] = None,
         wrap_x: Optional[PyGLuint] = None,
         wrap_y: Optional[PyGLuint] = None,
         target=gl.GL_TEXTURE_2D,
@@ -187,7 +187,7 @@ class Texture2D:
 
         self.ctx.stats.incr("texture")
 
-    def resize(self, size: Tuple[int, int]):
+    def resize(self, size: tuple[int, int]):
         """
         Resize the texture. This will re-allocate the internal
         memory and all pixel data will be lost.
@@ -362,7 +362,7 @@ class Texture2D:
         return self._dtype
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         The size of the texture as a tuple
 
@@ -493,7 +493,7 @@ class Texture2D:
         gl.glTexParameteri(self._target, gl.GL_TEXTURE_SWIZZLE_A, swizzle_enums[3])
 
     @property
-    def filter(self) -> Tuple[int, int]:
+    def filter(self) -> tuple[int, int]:
         """Get or set the ``(min, mag)`` filter for this texture.
         These are rules for how a texture interpolates.
         The filter is specified for minification and magnification.
@@ -524,7 +524,7 @@ class Texture2D:
         return self._filter
 
     @filter.setter
-    def filter(self, value: Tuple[int, int]):
+    def filter(self, value: tuple[int, int]):
         if not isinstance(value, tuple) or not len(value) == 2:
             raise ValueError("Texture filter must be a 2 component tuple (min, mag)")
 

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Optional, Iterable, List, Sequence, Tuple, Union, Set
+from typing import Optional, Iterable, Sequence, Union
 from typing_extensions import TypeAlias
 
 from pyglet import gl
@@ -18,9 +18,9 @@ GLuintLike = Union[gl.GLuint, int]
 PyGLuint = int
 
 
-OpenGlFilter: TypeAlias = Tuple[PyGLenum, PyGLenum]
+OpenGlFilter: TypeAlias = tuple[PyGLenum, PyGLenum]
 BlendFunction: TypeAlias = Union[
-    Tuple[PyGLenum, PyGLenum], Tuple[PyGLenum, PyGLenum, PyGLenum, PyGLenum]
+    tuple[PyGLenum, PyGLenum], tuple[PyGLenum, PyGLenum, PyGLenum, PyGLenum]
 ]
 
 _float_base_format = (0, gl.GL_RED, gl.GL_RG, gl.GL_RGB, gl.GL_RGBA)
@@ -211,7 +211,7 @@ class BufferDescription:
 
     # Describe all variants of a format string to simplify parsing (single component)
     # format: gl_type, byte_size
-    _formats: Dict[str, Tuple[Optional[PyGLenum], int]] = {
+    _formats: dict[str, tuple[Optional[PyGLenum], int]] = {
         # (gl enum, byte size)
         # Floats
         "f": (gl.GL_FLOAT, 4),
@@ -260,11 +260,11 @@ class BufferDescription:
         #: List of string attributes
         self.attributes = attributes
         #: List of normalized attributes
-        self.normalized: Set[str] = set() if normalized is None else set(normalized)
+        self.normalized: set[str] = set() if normalized is None else set(normalized)
         #: Instanced flag (bool)
         self.instanced: bool = instanced
         #: Formats of each attribute
-        self.formats: List[AttribFormat] = []
+        self.formats: list[AttribFormat] = []
         #: The byte stride of the buffer
         self.stride: int = -1
         #: Number of vertices in the buffer
@@ -288,7 +288,7 @@ class BufferDescription:
                 f"attributes ({len(self.attributes)})"
             )
 
-        def zip_attrs(formats: List[str], attributes: Sequence[str]):
+        def zip_attrs(formats: list[str], attributes: Sequence[str]):
             """Join together formats and attribute names taking padding into account"""
             attr_index = 0
             for f in formats:

--- a/arcade/gl/utils.py
+++ b/arcade/gl/utils.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from array import array
-from typing import Any, Tuple
+from typing import Any
 from ctypes import c_byte
 
 
-def data_to_ctypes(data: Any) -> Tuple[int, Any]:
+def data_to_ctypes(data: Any) -> tuple[int, Any]:
     """
     Attempts to convert the data to ctypes if needed by using the buffer protocol.
 

--- a/arcade/gl/vertex_array.py
+++ b/arcade/gl/vertex_array.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ctypes import c_void_p, byref
-from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Optional, Sequence, TYPE_CHECKING, Union
 import weakref
 
 from pyglet import gl
@@ -366,7 +366,7 @@ class VertexArray:
 
     def transform_separate(
         self,
-        buffers: List[Buffer],
+        buffers: list[Buffer],
         mode: GLenumLike,
         output_mode: GLenumLike,
         first: int = 0,
@@ -461,7 +461,7 @@ class Geometry:
         self._index_buffer = index_buffer
         self._index_element_size = index_element_size
         self._mode = mode if mode is not None else ctx.TRIANGLES
-        self._vao_cache: Dict[str, VertexArray] = {}
+        self._vao_cache: dict[str, VertexArray] = {}
         self._num_vertices: int = -1
         """
         :param ctx: The context this object belongs to
@@ -669,7 +669,7 @@ class Geometry:
     def transform(
         self,
         program: Program,
-        buffer: Union[Buffer, List[Buffer]],
+        buffer: Union[Buffer, list[Buffer]],
         *,
         first: int = 0,
         vertices: Optional[int] = None,

--- a/arcade/gui/nine_patch.py
+++ b/arcade/gui/nine_patch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import arcade
 import arcade.gl as gl
@@ -189,7 +189,7 @@ class NinePatchTexture:
         self._top = top
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """The size of texture as a width, height tuple in pixels."""
         return self.texture.size
 
@@ -206,8 +206,8 @@ class NinePatchTexture:
     def draw_sized(
         self,
         *,
-        position: Tuple[float, float] = (0.0, 0.0),
-        size: Tuple[float, float],
+        position: tuple[float, float] = (0.0, 0.0),
+        size: tuple[float, float],
         pixelated: bool = False,
         **kwargs,
     ):

--- a/arcade/gui/property.py
+++ b/arcade/gui/property.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 import traceback
-from typing import Any, Callable, Generic, Optional, Set, TypeVar, cast
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
 from weakref import WeakKeyDictionary, ref
 
 P = TypeVar("P")
@@ -18,7 +18,7 @@ class _Obs(Generic[P]):
     def __init__(self, value: P):
         self.value = value
         # This will keep any added listener even if it is not referenced anymore and would be garbage collected
-        self.listeners: Set[Callable[[Any, P], Any]] = set()
+        self.listeners: set[Callable[[Any, P], Any]] = set()
 
 
 class Property(Generic[P]):

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Tuple, Union, Optional
+from typing import Union, Optional
 
 import arcade
 from arcade import Texture
@@ -23,8 +23,8 @@ class Surface:
     def __init__(
         self,
         *,
-        size: Tuple[int, int],
-        position: Tuple[int, int] = (0, 0),
+        size: tuple[int, int],
+        position: tuple[int, int] = (0, 0),
         pixel_ratio: float = 1.0,
     ):
         self.ctx = arcade.get_window().ctx
@@ -202,7 +202,7 @@ class Surface:
         # Restore blend function
         self.ctx.blend_func = blend_func
 
-    def resize(self, *, size: Tuple[int, int], pixel_ratio: float) -> None:
+    def resize(self, *, size: tuple[int, int], pixel_ratio: float) -> None:
         """
         Resize the internal texture by re-allocating a new one
 

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -12,7 +12,7 @@ The better gui for arcade
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, Iterable, List, Optional, Type, TypeVar, Union, Tuple
+from typing import Iterable, Optional, Type, TypeVar, Union
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED, EventDispatcher
 from typing_extensions import TypeGuard
@@ -90,8 +90,8 @@ class UIManager(EventDispatcher):
     def __init__(self, window: Optional[arcade.Window] = None):
         super().__init__()
         self.window = window or arcade.get_window()
-        self._surfaces: Dict[int, Surface] = {}
-        self.children: Dict[int, List[UIWidget]] = defaultdict(list)
+        self._surfaces: dict[int, Surface] = {}
+        self.children: dict[int, list[UIWidget]] = defaultdict(list)
         self._requires_render = True
         self.register_event_type("on_event")
 
@@ -336,7 +336,7 @@ class UIManager(EventDispatcher):
             for layer in layers:
                 self._get_surface(layer).draw()
 
-    def adjust_mouse_coordinates(self, x: float, y: float) -> Tuple[float, float]:
+    def adjust_mouse_coordinates(self, x: float, y: float) -> tuple[float, float]:
         """
         This method is used, to translate mouse coordinates to coordinates
         respecting the viewport and projection of cameras.

--- a/arcade/gui/widgets/buttons.py
+++ b/arcade/gui/widgets/buttons.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Dict, Union
+from typing import Optional, Union
 
 import arcade
 from arcade import Texture
@@ -53,7 +53,7 @@ class UITextureButton(UIInteractiveWidget, UIStyledWidget[UITextureButtonStyle],
     :param size_hint_max: max width and height in pixel
     """
 
-    _textures: Dict[str, Union[Texture, NinePatchTexture]] = DictProperty()  # type: ignore
+    _textures: dict[str, Union[Texture, NinePatchTexture]] = DictProperty()  # type: ignore
 
     UIStyle = UITextureButtonStyle
 
@@ -93,7 +93,7 @@ class UITextureButton(UIInteractiveWidget, UIStyledWidget[UITextureButtonStyle],
         text: str = "",
         multiline: bool = False,
         scale: Optional[float] = None,
-        style: Optional[Dict[str, UIStyleBase]] = None,
+        style: Optional[dict[str, UIStyleBase]] = None,
         size_hint=None,
         size_hint_min=None,
         size_hint_max=None,

--- a/arcade/gui/widgets/dropdown.py
+++ b/arcade/gui/widgets/dropdown.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from pyglet.event import EVENT_HANDLED
 
@@ -72,7 +72,7 @@ class UIDropdown(UILayout):
         width: float = 100,
         height: float = 20,
         default: Optional[str] = None,
-        options: Optional[List[Union[str, None]]] = None,
+        options: Optional[list[Union[str, None]]] = None,
         style=None,
         **kwargs,
     ):

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, List, TypeVar, Optional, cast
+from typing import Iterable, TypeVar, Optional, cast
 
 from arcade.gui.property import bind, unbind
 from arcade.gui.widgets import UIWidget, UILayout
@@ -643,7 +643,7 @@ class UIGridLayout(UILayout):
             return
 
         child_sorted_row_wise = cast(
-            List[List[UIWidget]],
+            list[list[UIWidget]],
             [[None for _ in range(self.column_count)] for _ in range(self.row_count)],
         )
 
@@ -701,7 +701,7 @@ class UIGridLayout(UILayout):
             sum(principal_width_ratio_list) + self.column_count * self._horizontal_spacing
         )
 
-        def ratio(dimensions: List) -> List:
+        def ratio(dimensions: list) -> list:
             """
             Used to calculate ratio of the elements based on the minimum value in the parameter.
             :param dimension: List containing max height or width of the cells.

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import cos, radians, sin
-from typing import Any, Tuple
+from typing import Any
 from typing_extensions import Self
 
 from PIL.Image import Image
@@ -103,7 +103,7 @@ class HitBox:
         self,
         points: Point2List,
         position: Point2 = (0.0, 0.0),
-        scale: Tuple[float, float] = (1.0, 1.0),
+        scale: tuple[float, float] = (1.0, 1.0),
     ):
         self._points = points
         self._position = position
@@ -178,7 +178,7 @@ class HitBox:
         return min(y_points)
 
     @property
-    def scale(self) -> Tuple[float, float]:
+    def scale(self) -> tuple[float, float]:
         """
         The X & Y scaling factors for the points in this hit box.
 
@@ -187,7 +187,7 @@ class HitBox:
         return self._scale
 
     @scale.setter
-    def scale(self, scale: Tuple[float, float]):
+    def scale(self, scale: tuple[float, float]):
         self._scale = scale
         self._adjusted_cache_dirty = True
 
@@ -247,9 +247,9 @@ class RotatableHitBox(HitBox):
         self,
         points: Point2List,
         *,
-        position: Tuple[float, float] = (0.0, 0.0),
+        position: tuple[float, float] = (0.0, 0.0),
         angle: float = 0.0,
-        scale: Tuple[float, float] = (1.0, 1.0),
+        scale: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(points, position=position, scale=scale)
         self._angle: float = angle

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 from PIL.Image import Image
 import pymunk
 from pymunk.autogeometry import (
@@ -62,7 +62,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
 
         return self.to_points_list(image, line_set)
 
-    def to_points_list(self, image: Image, line_set: List[Vec2d]) -> Point2List:
+    def to_points_list(self, image: Image, line_set: list[Vec2d]) -> Point2List:
         """
         Convert a line set to a list of points.
 
@@ -148,7 +148,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
         # or the line set might just be a hole in the sprite.
         return march_soft(logo_bb, horizontal_samples, vertical_samples, 99, sample_func)
 
-    def select_largest_line_set(self, line_sets: PolylineSet) -> List[Vec2d]:
+    def select_largest_line_set(self, line_sets: PolylineSet) -> list[Vec2d]:
         """
         Given a list of line sets, return the one that covers the most of the image.
 

--- a/arcade/hitbox/simple.py
+++ b/arcade/hitbox/simple.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
 from PIL.Image import Image
 from arcade.types import Point, Point2List
 from .base import HitBoxAlgorithm
@@ -57,7 +56,7 @@ class SimpleHitBoxAlgorithm(HitBoxAlgorithm):
             # print(f"offset: {offset}")
             return offset
 
-        def _r(point: Tuple[float, float], height: int, width: int) -> Point:
+        def _r(point: tuple[float, float], height: int, width: int) -> Point:
             return point[0] - width / 2, (height - point[1]) - height / 2
 
         top_left_corner_offset = _check_corner_offset(left_border, top_border, 1, 1)

--- a/arcade/isometric.py
+++ b/arcade/isometric.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from arcade.shape_list import ShapeElementList, create_line
-from typing import Tuple
 from arcade.types import RGBA255
 
 
 def isometric_grid_to_screen(
     tile_x: int, tile_y: int, width: int, height: int, tile_width: int, tile_height: int
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     screen_x = tile_width * tile_x // 2 + height * tile_width // 2 - tile_y * tile_width // 2
     screen_y = (
         (height - tile_y - 1) * tile_height // 2
@@ -19,7 +18,7 @@ def isometric_grid_to_screen(
 
 def screen_to_isometric_grid(
     screen_x: int, screen_y: int, width: int, height: int, tile_width: int, tile_height: int
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     x2 = (1 / tile_width * screen_x / 2 - 1 / tile_height * screen_y / 2 + width / 2) * 2 - (
         width / 2 + 0.5
     )

--- a/arcade/joysticks.py
+++ b/arcade/joysticks.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import pyglet.input
-from typing import List
 from pyglet.input import Joystick
 
 __all__ = ["get_joysticks", "get_game_controllers"]
 
 
-def get_joysticks() -> List[Joystick]:
+def get_joysticks() -> list[Joystick]:
     """
     Get a list of all the game controllers
 
@@ -18,7 +17,7 @@ def get_joysticks() -> List[Joystick]:
     return pyglet.input.get_joysticks()  # type: ignore  # pending https://github.com/pyglet/pyglet/issues/842
 
 
-def get_game_controllers() -> List[Joystick]:
+def get_game_controllers() -> list[Joystick]:
     """
     Get a list of all the game controllers
 

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import random
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Union
 from arcade.types import AsFloat, Point, Point2
 
 
@@ -63,8 +63,8 @@ def clamp(a, low: float, high: float) -> float:
     return high if a > high else max(a, low)
 
 
-V_2D = Union[Tuple[AsFloat, AsFloat], Sequence[AsFloat]]
-V_3D = Union[Tuple[AsFloat, AsFloat, AsFloat], Sequence[AsFloat]]
+V_2D = Union[tuple[AsFloat, AsFloat], Sequence[AsFloat]]
+V_3D = Union[tuple[AsFloat, AsFloat, AsFloat], Sequence[AsFloat]]
 
 
 def lerp(v1: AsFloat, v2: AsFloat, u: float) -> float:
@@ -72,11 +72,11 @@ def lerp(v1: AsFloat, v2: AsFloat, u: float) -> float:
     return v1 + ((v2 - v1) * u)
 
 
-def lerp_2d(v1: V_2D, v2: V_2D, u: float) -> Tuple[float, float]:
+def lerp_2d(v1: V_2D, v2: V_2D, u: float) -> tuple[float, float]:
     return (lerp(v1[0], v2[0], u), lerp(v1[1], v2[1], u))
 
 
-def lerp_3d(v1: V_3D, v2: V_3D, u: float) -> Tuple[float, float, float]:
+def lerp_3d(v1: V_3D, v2: V_3D, u: float) -> tuple[float, float, float]:
     return (lerp(v1[0], v2[0], u), lerp(v1[1], v2[1], u), lerp(v1[2], v2[2], u))
 
 
@@ -356,8 +356,8 @@ def get_angle_radians(x1: float, y1: float, x2: float, y2: float) -> float:
 
 
 def quaternion_rotation(
-    axis: Tuple[float, float, float], vector: Tuple[float, float, float], angle: float
-) -> Tuple[float, float, float]:
+    axis: tuple[float, float, float], vector: tuple[float, float, float], angle: float
+) -> tuple[float, float, float]:
     """
     Rotate a 3-dimensional vector of any length clockwise around a 3-dimensional unit length vector.
 

--- a/arcade/particles/particle.py
+++ b/arcade/particles/particle.py
@@ -3,7 +3,7 @@ Particle - Object produced by an Emitter.  Often used in large quantity to produ
 """
 
 from __future__ import annotations
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional
 
 from arcade.sprite import Sprite
 from arcade.math import lerp, clamp
@@ -16,7 +16,7 @@ class Particle(Sprite):
     def __init__(
         self,
         path_or_texture: Optional[PathOrTexture],
-        change_xy: Tuple[float, float],
+        change_xy: tuple[float, float],
         center_xy: Point = (0.0, 0.0),
         angle: float = 0.0,
         change_angle: float = 0.0,

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -5,7 +5,7 @@ Classic A-star algorithm for path finding.
 from __future__ import annotations
 
 import math
-from typing import cast, List, Optional, Set, Tuple, Union, Dict
+from typing import cast, Optional, Union
 
 from arcade import Sprite, SpriteList, check_for_collision_with_list, get_sprites_at_point
 from arcade.math import get_distance, lerp_2d
@@ -62,7 +62,7 @@ class _AStarGraph(object):
 
     def __init__(
         self,
-        barriers: Union[List, Tuple, Set],
+        barriers: Union[list, tuple, set],
         left: int,
         right: int,
         bottom: int,
@@ -89,7 +89,7 @@ class _AStarGraph(object):
         else:
             self.movement_directions = (1, 0), (-1, 0), (0, 1), (0, -1)  # type: ignore
 
-    def get_vertex_neighbours(self, pos: Point) -> List[Tuple[float, float]]:
+    def get_vertex_neighbours(self, pos: Point) -> list[tuple[float, float]]:
         """
         Return neighbors for this point according to ``self.movement_directions``
 
@@ -131,7 +131,7 @@ class _AStarGraph(object):
             return 1.42
 
 
-def _AStarSearch(start: Point2, end: Point2, graph: _AStarGraph) -> Optional[List[Point2]]:
+def _AStarSearch(start: Point2, end: Point2, graph: _AStarGraph) -> Optional[list[Point2]]:
     """
     Returns a path from start to end using the AStarSearch Algorithm
 
@@ -142,8 +142,8 @@ def _AStarSearch(start: Point2, end: Point2, graph: _AStarGraph) -> Optional[Lis
 
     :return: The path from start to end. Returns None if is path is not found
     """
-    G: Dict[Point2, float] = dict()  # Actual movement cost to each position from the start position
-    F: Dict[Point2, float] = (
+    G: dict[Point2, float] = dict()  # Actual movement cost to each position from the start position
+    F: dict[Point2, float] = (
         dict()
     )  # Estimated movement cost of start to end going via this position
 
@@ -290,7 +290,7 @@ def astar_calculate_path(
     end_point: Point,
     astar_barrier_list: AStarBarrierList,
     diagonal_movement: bool = True,
-) -> Optional[List[Point]]:
+) -> Optional[list[Point]]:
     """
     Calculates the path using AStarSearch Algorithm and returns the path
 
@@ -323,7 +323,7 @@ def astar_calculate_path(
     # Currently 'result' is in grid locations. We need to convert them to pixel
     # locations.
     revised_result = [_expand(p, grid_size) for p in result]
-    return cast(List[Point], revised_result)
+    return cast(list[Point], revised_result)
 
 
 def has_line_of_sight(

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import random
-from typing import List
 
 import pyglet.clock
 from pyglet.shapes import Line
@@ -87,7 +86,7 @@ class PerfGraph(arcade.Sprite):
 
         # Variables for rendering the data line
         self.graph_data = graph_data
-        self._data_to_graph: List[float] = []
+        self._data_to_graph: list[float] = []
         self._view_max_value = 0.0  # We'll calculate this once we have data
         self._view_y_scale_step = view_y_scale_step
         self._view_height = self._texture.height - self._bottom_y  # type: ignore
@@ -98,9 +97,9 @@ class PerfGraph(arcade.Sprite):
         self._pyglet_batch = Batch()  # Used to draw graph elements
 
         # Convenient storage for iteration during color updates
-        self._vertical_axis_text_objects: List[arcade.Text] = []
-        self._all_text_objects: List[arcade.Text] = []
-        self._grid_lines: List[Line] = []
+        self._vertical_axis_text_objects: list[arcade.Text] = []
+        self._all_text_objects: list[arcade.Text] = []
+        self._grid_lines: list[Line] = []
 
         # Create the bottom label text object
         self._bottom_label = arcade.Text(

--- a/arcade/perf_info.py
+++ b/arcade/perf_info.py
@@ -5,13 +5,12 @@ Utility functions to keep performance information
 from __future__ import annotations
 
 import collections
-from typing import Dict
 
 import pyglet
 import time
 
 # Evil globals
-_timings: Dict = {}
+_timings: dict = {}
 _pyglets_dispatch_event = None
 _frame_times: collections.deque = collections.deque()
 _max_history: int = 100
@@ -115,7 +114,7 @@ def clear_timings() -> None:
     _timings = {}
 
 
-def get_timings() -> Dict:
+def get_timings() -> dict:
     """
     Get a dict of the current dispatch event timings.
 

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 # pylint: disable=too-many-arguments, too-many-locals, too-few-public-methods
 import math
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, Optional, Union
 
 from arcade import (
     Sprite,
@@ -22,7 +22,7 @@ __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 from arcade.utils import copy_dunders_unimplemented
 
 
-def _circular_check(player: Sprite, walls: List[SpriteList]) -> None:
+def _circular_check(player: Sprite, walls: list[SpriteList]) -> None:
     """
     This is a horrible kludge to 'guess' our way out of a collision
     """
@@ -55,8 +55,8 @@ def _circular_check(player: Sprite, walls: List[SpriteList]) -> None:
 
 
 def _move_sprite(
-    moving_sprite: Sprite, walls: List[SpriteList[SpriteType]], ramp_up: bool
-) -> List[SpriteType]:
+    moving_sprite: Sprite, walls: list[SpriteList[SpriteType]], ramp_up: bool
+) -> list[SpriteType]:
 
     # See if we are starting this turn with a sprite already colliding with us.
     if len(check_for_collision_with_lists(moving_sprite, walls)) > 0:
@@ -245,7 +245,7 @@ class PhysicsEngineSimple:
         walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
     ) -> None:
         self.player_sprite: Sprite = player_sprite
-        self._walls: List[SpriteList]
+        self._walls: list[SpriteList]
 
         if walls:
             self._walls = [walls] if isinstance(walls, SpriteList) else list(walls)
@@ -308,9 +308,9 @@ class PhysicsEnginePlatformer:
         ladders: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
         walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
     ) -> None:
-        self._ladders: Optional[List[SpriteList]]
-        self._platforms: List[SpriteList]
-        self._walls: List[SpriteList]
+        self._ladders: Optional[list[SpriteList]]
+        self._platforms: list[SpriteList]
+        self._walls: list[SpriteList]
 
         if ladders:
             self._ladders = [ladders] if isinstance(ladders, SpriteList) else list(ladders)

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import pymunk
 from pyglet.math import Vec2
@@ -59,9 +59,9 @@ class PymunkPhysicsEngine:
         self.space = pymunk.Space()
         self.space.gravity = gravity
         self.space.damping = damping
-        self.collision_types: List[str] = []
-        self.sprites: Dict[Sprite, PymunkPhysicsObject] = {}
-        self.non_static_sprite_list: List = []
+        self.collision_types: list[str] = []
+        self.sprites: dict[Sprite, PymunkPhysicsObject] = {}
+        self.non_static_sprite_list: list = []
         self.maximum_incline_on_ground = maximum_incline_on_ground
 
     def add_sprite(
@@ -73,7 +73,7 @@ class PymunkPhysicsEngine:
         moment_of_inertia: Optional[float] = None,  # correct spelling
         body_type: int = DYNAMIC,
         damping: Optional[float] = None,
-        gravity: Optional[Union[pymunk.Vec2d, Tuple[float, float], Vec2]] = None,
+        gravity: Optional[Union[pymunk.Vec2d, tuple[float, float], Vec2]] = None,
         max_velocity: Optional[int] = None,
         max_horizontal_velocity: Optional[int] = None,
         max_vertical_velocity: Optional[int] = None,
@@ -142,7 +142,7 @@ class PymunkPhysicsEngine:
 
         # Callback used if we need custom gravity, damping, velocity, etc.
         def velocity_callback(
-            my_body: pymunk.Body, my_gravity: Tuple[float, float], my_damping: float, dt: float
+            my_body: pymunk.Body, my_gravity: tuple[float, float], my_damping: float, dt: float
         ):
             """Used for custom damping, gravity, and max_velocity."""
 
@@ -259,7 +259,7 @@ class PymunkPhysicsEngine:
 
     def get_sprites_from_arbiter(
         self, arbiter: pymunk.Arbiter
-    ) -> Tuple[Optional[Sprite], Optional[Sprite]]:
+    ) -> tuple[Optional[Sprite], Optional[Sprite]]:
         """Given a collision arbiter, return the sprites associated with the collision."""
         shape1, shape2 = arbiter.shapes
         sprite1 = self.get_sprite_for_shape(shape1)
@@ -271,7 +271,7 @@ class PymunkPhysicsEngine:
         grounding = self.check_grounding(sprite)
         return grounding["body"] is not None
 
-    def apply_impulse(self, sprite: Sprite, impulse: Tuple[float, float]):
+    def apply_impulse(self, sprite: Sprite, impulse: tuple[float, float]):
         """Apply an impulse force on a sprite"""
         physics_object = self.get_physics_object(sprite)
         if physics_object.body is None:
@@ -280,7 +280,7 @@ class PymunkPhysicsEngine:
             )
         physics_object.body.apply_impulse_at_local_point(impulse)
 
-    def set_position(self, sprite: Sprite, position: Union[pymunk.Vec2d, Tuple[float, float]]):
+    def set_position(self, sprite: Sprite, position: Union[pymunk.Vec2d, tuple[float, float]]):
         """Apply an impulse force on a sprite"""
         physics_object = self.get_physics_object(sprite)
         if physics_object.body is None:
@@ -297,7 +297,7 @@ class PymunkPhysicsEngine:
             )
         physics_object.body.angle = math.radians(rotation)
 
-    def set_velocity(self, sprite: Sprite, velocity: Tuple[float, float]):
+    def set_velocity(self, sprite: Sprite, velocity: tuple[float, float]):
         """Apply an impulse force on a sprite"""
         physics_object = self.get_physics_object(sprite)
         if physics_object.body is None:
@@ -419,7 +419,7 @@ class PymunkPhysicsEngine:
         """Get the shape/body for a sprite."""
         return self.sprites[sprite]
 
-    def apply_force(self, sprite: Sprite, force: Tuple[float, float]):
+    def apply_force(self, sprite: Sprite, force: tuple[float, float]):
         """Apply force to a Sprite."""
         physics_object = self.sprites[sprite]
         if physics_object.body is None:

--- a/arcade/resources/__init__.py
+++ b/arcade/resources/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Union
 from arcade.utils import warning, ReplacementWarning
 
 #: The absolute path to this directory
@@ -9,7 +9,7 @@ RESOURCE_DIR = Path(__file__).parent.resolve()
 SYSTEM_PATH = RESOURCE_DIR / "system"
 ASSET_PATH = RESOURCE_DIR / "assets"
 
-handles: Dict[str, List[Path]] = {
+handles: dict[str, list[Path]] = {
     "resources": [SYSTEM_PATH, ASSET_PATH],
     "assets": [ASSET_PATH],
     "system": [SYSTEM_PATH],
@@ -149,7 +149,7 @@ def add_resource_handle(handle: str, path: Union[str, Path]) -> None:
         paths.append(path)
 
 
-def get_resource_handle_paths(handle: str) -> List[Path]:
+def get_resource_handle_paths(handle: str) -> list[Path]:
     """
     Returns the paths for a resource handle.
 

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -12,7 +12,7 @@ It allows you to do the following:
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union, Iterable
+from typing import Optional, Union, Iterable
 
 from arcade import Sprite, SpriteList
 from arcade.types import Color, RGBA255
@@ -69,8 +69,8 @@ class Scene:
     """
 
     def __init__(self) -> None:
-        self._sprite_lists: List[SpriteList] = []
-        self._name_mapping: Dict[str, SpriteList] = {}
+        self._sprite_lists: list[SpriteList] = []
+        self._name_mapping: dict[str, SpriteList] = {}
 
     def __len__(self) -> int:
         """

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, List, Iterable, Union, Set, Generator
+from typing import TYPE_CHECKING, Optional, Iterable, Union, Generator
 import math
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
@@ -336,17 +336,17 @@ class SectionManager:
 
         # store sections in update/event order and in draw order
         # a list of the current sections for this in update/event order
-        self._sections: List[Section] = []
+        self._sections: list[Section] = []
 
         # the list of current sections in draw order
-        self._sections_draw: List[Section] = []
+        self._sections_draw: list[Section] = []
 
         # generic camera to reset after a custom camera is use
         # this camera is set to the whole viewport
         self.camera: DefaultProjector = DefaultProjector()
 
         # Holds the section the mouse is currently on top
-        self.mouse_over_sections: List[Section] = []
+        self.mouse_over_sections: list[Section] = []
 
         # True will call view.on_draw before sections on_draw, False after, None will not call view on_draw
         self.view_draw_first: Optional[bool] = True
@@ -356,7 +356,7 @@ class SectionManager:
         self.view_resize_first: Optional[bool] = True
 
         # Events that the section manager should handle (instead of the View) if sections are present in a View
-        self.managed_events: Set = {
+        self.managed_events: set = {
             "on_mouse_motion",
             "on_mouse_drag",
             "on_mouse_press",
@@ -372,7 +372,7 @@ class SectionManager:
         }
 
     @property
-    def sections(self) -> List[Section]:
+    def sections(self) -> list[Section]:
         """Property that returns the list of sections"""
         return self._sections
 

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -13,10 +13,6 @@ from collections import OrderedDict
 import itertools
 import math
 from typing import (
-    Dict,
-    Set,
-    List,
-    Tuple,
     Iterable,
     Optional,
     Sequence,
@@ -206,8 +202,8 @@ def create_line_strip(point_list: PointList, color: RGBA255, line_width: float =
     if line_width == 1:
         return create_line_generic(point_list, color, gl.GL_LINE_STRIP)
 
-    triangle_point_list: List[Point] = []
-    new_color_list: List[RGBA255] = []
+    triangle_point_list: list[Point] = []
+    new_color_list: list[RGBA255] = []
     for i in range(1, len(point_list)):
         start_x = point_list[i - 1][0]
         start_y = point_list[i - 1][1]
@@ -272,8 +268,8 @@ def create_lines_with_colors(
     if line_width == 1:
         return create_line_generic_with_colors(point_list, color_list, gl.GL_LINES)
 
-    triangle_point_list: List[Point] = []
-    new_color_list: List[RGBA255] = []
+    triangle_point_list: list[Point] = []
+    new_color_list: list[RGBA255] = []
     for i in range(1, len(point_list), 2):
         start_x = point_list[i - 1][0]
         start_y = point_list[i - 1][1]
@@ -461,8 +457,8 @@ def create_rectangle(
     :param tilt_angle: Angle to tilt the rectangle in degrees
     :param filled: If True, the rectangle is filled. If False, it is an outline.
     """
-    data: List[Point] = cast(
-        List[Point], get_rectangle_points(center_x, center_y, width, height, tilt_angle)
+    data: list[Point] = cast(
+        list[Point], get_rectangle_points(center_x, center_y, width, height, tilt_angle)
     )
 
     if filled:
@@ -506,7 +502,7 @@ def create_rectangle(
         data = [o_lt, i_lt, o_rt, i_rt, o_rb, i_rb, o_lb, i_lb, o_lt, i_lt]
 
         if tilt_angle != 0:
-            point_list_2: List[Point] = []
+            point_list_2: list[Point] = []
             for point in data:
                 new_point = rotate_point(point[0], point[1], center_x, center_y, tilt_angle)
                 point_list_2.append(new_point)
@@ -552,8 +548,8 @@ def create_rectangles_filled_with_colors(point_list, color_list: Sequence[RGBA25
     as one.
     """
     shape_mode = gl.GL_TRIANGLES
-    new_point_list: List[Point] = []
-    new_color_list: List[RGBA255] = []
+    new_point_list: list[Point] = []
+    new_color_list: list[RGBA255] = []
     for i in range(0, len(point_list), 4):
         new_point_list += [point_list[0 + i], point_list[1 + i], point_list[3 + i]]
         new_point_list += [point_list[1 + i], point_list[3 + i], point_list[2 + i]]
@@ -816,15 +812,15 @@ class ShapeElementList(Generic[TShape]):
         # The context this shape list belongs to
         self.ctx = get_window().ctx
         # List of sprites in the sprite list
-        self.shape_list: List[TShape] = []
+        self.shape_list: list[TShape] = []
         self.change_x = 0.0
         self.change_y = 0.0
         self._center_x = 0.0
         self._center_y = 0.0
         self._angle = 0.0
         self.program = self.ctx.shape_element_list_program
-        self.batches: Dict[int, _Batch] = OrderedDict()
-        self.dirties: Set[_Batch] = set()
+        self.batches: dict[int, _Batch] = OrderedDict()
+        self.dirties: set[_Batch] = set()
 
         self._blend = blend
 
@@ -914,7 +910,7 @@ class ShapeElementList(Generic[TShape]):
         self.center_y += change_y
 
     @property
-    def position(self) -> Tuple[float, float]:
+    def position(self) -> tuple[float, float]:
         """
         Get or set the position of the ShapeElementList.
 
@@ -923,7 +919,7 @@ class ShapeElementList(Generic[TShape]):
         return self._center_x, self._center_y
 
     @position.setter
-    def position(self, value: Tuple[float, float]) -> None:
+    def position(self, value: tuple[float, float]) -> None:
         self._center_x, self._center_y = value
 
     @property
@@ -1003,8 +999,8 @@ class _Batch(Generic[TShape]):
             index_buffer=self.ibo,
         )
 
-        self.items: List[TShape] = []
-        self.new_items: List[TShape] = []
+        self.items: list[TShape] = []
+        self.new_items: list[TShape] = []
         self.vertices = 0  # Total vertices in the batch
         self.elements = 0  # Total elements in the batch
         self.FLAGS = 0  # Flags to indicate changes

--- a/arcade/sprite/animated.py
+++ b/arcade/sprite/animated.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import bisect
 import math
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from .sprite import Sprite
 from arcade import Texture
@@ -46,13 +46,13 @@ class TextureAnimation:
 
     __slots__ = ("_keyframes", "_duration_ms", "_timeline")
 
-    def __init__(self, keyframes: List[TextureKeyframe]):
+    def __init__(self, keyframes: list[TextureKeyframe]):
         self._keyframes = keyframes
         self._duration_ms = 0
-        self._timeline: List[int] = self._create_timeline(self._keyframes)
+        self._timeline: list[int] = self._create_timeline(self._keyframes)
 
     @property
-    def keyframes(self) -> Tuple[TextureKeyframe, ...]:
+    def keyframes(self) -> tuple[TextureKeyframe, ...]:
         """
         A tuple of keyframes in the animation.
         Keyframes should not be modified directly.
@@ -80,12 +80,12 @@ class TextureAnimation:
         """
         return len(self._keyframes)
 
-    def _create_timeline(self, keyframes: List[TextureKeyframe]) -> List[int]:
+    def _create_timeline(self, keyframes: list[TextureKeyframe]) -> list[int]:
         """
         Create a timeline of the animation.
         This is a list of timestamps for each frame in seconds.
         """
-        timeline: List[int] = []
+        timeline: list[int] = []
         current_time_ms = 0
         for frame in keyframes:
             timeline.append(current_time_ms)
@@ -94,7 +94,7 @@ class TextureAnimation:
         self._duration_ms = current_time_ms
         return timeline
 
-    def get_keyframe(self, time: float, loop: bool = True) -> Tuple[int, TextureKeyframe]:
+    def get_keyframe(self, time: float, loop: bool = True) -> tuple[int, TextureKeyframe]:
         """
         Get the frame at a given time.
 
@@ -226,12 +226,12 @@ class AnimatedWalkingSprite(Sprite):
             center_y=center_y,
         )
         self.state = FACE_RIGHT
-        self.stand_right_textures: List[Texture] = []
-        self.stand_left_textures: List[Texture] = []
-        self.walk_left_textures: List[Texture] = []
-        self.walk_right_textures: List[Texture] = []
-        self.walk_up_textures: List[Texture] = []
-        self.walk_down_textures: List[Texture] = []
+        self.stand_right_textures: list[Texture] = []
+        self.stand_left_textures: list[Texture] = []
+        self.walk_left_textures: list[Texture] = []
+        self.walk_right_textures: list[Texture] = []
+        self.walk_up_textures: list[Texture] = []
+        self.walk_down_textures: list[Texture] = []
         self.cur_texture_index = 0
         self.texture_change_distance = 20
         self.last_texture_change_center_x: float = 0.0
@@ -248,7 +248,7 @@ class AnimatedWalkingSprite(Sprite):
         y1 = self.center_y
         y2 = self.last_texture_change_center_y
         distance = math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
-        texture_list: List[Texture] = []
+        texture_list: list[Texture] = []
 
         change_direction = False
         if (

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, List, TypeVar, Any, Tuple
+from typing import TYPE_CHECKING, Iterable, TypeVar, Any
 
 import arcade
 from arcade.types import Point, Point2, Color, RGBA255, RGBOrA255, PointList, Rect, LRBT
@@ -65,7 +65,7 @@ class BasicSprite:
         self._scale = Vec2(scale, scale)
         self._visible = bool(visible)
         self._color: Color = WHITE
-        self.sprite_lists: List["SpriteList"] = []
+        self.sprite_lists: list["SpriteList"] = []
 
         # Core properties we don't use, but spritelist expects it
         self._angle = 0.0
@@ -349,7 +349,7 @@ class BasicSprite:
             sprite_list._update_color(self)
 
     @property
-    def rgb(self) -> Tuple[int, int, int]:
+    def rgb(self) -> tuple[int, int, int]:
         """Get or set only the sprite's RGB color components.
 
         If a 4-color RGBA tuple is passed:
@@ -678,7 +678,7 @@ class BasicSprite:
 
         return check_for_collision(self, other)
 
-    def collides_with_list(self: SpriteType, sprite_list: "SpriteList") -> List[SpriteType]:
+    def collides_with_list(self: SpriteType, sprite_list: "SpriteList") -> list[SpriteType]:
         """Check if current sprite is overlapping with any other sprite in a list
 
         :param sprite_list: SpriteList to check against

--- a/arcade/sprite/colored.py
+++ b/arcade/sprite/colored.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Tuple
+from typing import Optional
 from weakref import WeakValueDictionary
 
 import PIL
@@ -47,7 +47,7 @@ class SpriteSolidColor(Sprite):
     # we cache them here weakly. Making a 100 x 100 grid of white sprites
     # only create 1 texture instead of 1000. This saves memory and processing
     # time for the default texture atlas.
-    _texture_cache: WeakValueDictionary[Tuple[int, int], Texture] = WeakValueDictionary()
+    _texture_cache: WeakValueDictionary[tuple[int, int], Texture] = WeakValueDictionary()
 
     def __init__(
         self,
@@ -121,7 +121,7 @@ class SpriteCircle(Sprite):
     """
 
     # Local weak cache for textures to avoid creating multiple instances with the same configuration
-    _texture_cache: WeakValueDictionary[Tuple[int, RGBA255, bool], Texture] = WeakValueDictionary()
+    _texture_cache: WeakValueDictionary[tuple[int, RGBA255, bool], Texture] = WeakValueDictionary()
 
     def __init__(self, radius: int, color: RGBA255, soft: bool = False, **kwargs):
         radius = int(radius)

--- a/arcade/sprite/mixins.py
+++ b/arcade/sprite/mixins.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Tuple
+from typing import Optional
 
 
 class PyMunk:
@@ -15,7 +15,7 @@ class PyMunk:
 
     def __init__(self):
         self.damping: Optional[float] = None
-        self.gravity: Optional[Tuple[float, float]] = None
+        self.gravity: Optional[tuple[float, float]] = None
         self.max_velocity: Optional[float] = None
         self.max_horizontal_velocity: Optional[float] = None
         self.max_vertical_velocity: Optional[float] = None

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import arcade
 from arcade import Texture
@@ -99,7 +99,7 @@ class Sprite(BasicSprite, PymunkMixin):
         self.change_angle: float = 0.0
 
         # Custom sprite properties
-        self._properties: Optional[Dict[str, Any]] = None
+        self._properties: Optional[dict[str, Any]] = None
 
         # Boundaries for moving platforms in tilemaps
         self.boundary_left: Optional[float] = None
@@ -108,9 +108,9 @@ class Sprite(BasicSprite, PymunkMixin):
         self.boundary_bottom: Optional[float] = None
 
         self.cur_texture_index: int = 0
-        self.textures: List[Texture] = _textures
+        self.textures: list[Texture] = _textures
 
-        self.physics_engines: List[Any] = []
+        self.physics_engines: list[Any] = []
 
         self._sprite_list: Optional[SpriteList] = None
         # Debug properties
@@ -246,7 +246,7 @@ class Sprite(BasicSprite, PymunkMixin):
             sprite_list._update_texture(self)
 
     @property
-    def properties(self) -> Dict[str, Any]:
+    def properties(self) -> dict[str, Any]:
         """
         Get or set custom sprite properties.
 
@@ -256,7 +256,7 @@ class Sprite(BasicSprite, PymunkMixin):
         return self._properties
 
     @properties.setter
-    def properties(self, value: Dict[str, Any]) -> None:
+    def properties(self, value: dict[str, Any]) -> None:
         self._properties = value
 
     # --- Movement methods -----

--- a/arcade/sprite_list/spatial_hash.py
+++ b/arcade/sprite_list/spatial_hash.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
 from math import trunc
-from typing import (
-    List,
-    Set,
-    Dict,
-    Generic,
-)
+from typing import Generic
 from arcade.sprite.base import BasicSprite
 from arcade.types import Point, IPoint
 from arcade.sprite import SpriteType
@@ -31,10 +26,10 @@ class SpatialHash(Generic[SpriteType]):
 
         self.cell_size = cell_size
         # Buckets of sprites per cell
-        self.contents: Dict[IPoint, Set[SpriteType]] = {}
+        self.contents: dict[IPoint, set[SpriteType]] = {}
         # All the buckets a sprite is in.
         # This is used to remove a sprite from the spatial hash.
-        self.buckets_for_sprite: Dict[SpriteType, List[Set[SpriteType]]] = {}
+        self.buckets_for_sprite: dict[SpriteType, list[set[SpriteType]]] = {}
 
     def hash(self, point: IPoint) -> IPoint:
         """Convert world coordinates to cell coordinates"""
@@ -61,7 +56,7 @@ class SpatialHash(Generic[SpriteType]):
 
         # hash the minimum and maximum points
         min_point, max_point = self.hash(min_point), self.hash(max_point)
-        buckets: List[Set[SpriteType]] = []
+        buckets: list[set[SpriteType]] = []
 
         # Iterate over the rectangular region adding the sprite to each cell
         for i in range(min_point[0], max_point[0] + 1):
@@ -97,7 +92,7 @@ class SpatialHash(Generic[SpriteType]):
         # Delete the sprite from the bucket tracker
         del self.buckets_for_sprite[sprite]
 
-    def get_sprites_near_sprite(self, sprite: BasicSprite) -> Set[SpriteType]:
+    def get_sprites_near_sprite(self, sprite: BasicSprite) -> set[SpriteType]:
         """
         Get all the sprites that are in the same buckets as the given sprite.
 
@@ -109,7 +104,7 @@ class SpatialHash(Generic[SpriteType]):
 
         # hash the minimum and maximum points
         min_point, max_point = self.hash(min_point), self.hash(max_point)
-        close_by_sprites: Set[SpriteType] = set()
+        close_by_sprites: set[SpriteType] = set()
 
         # Iterate over the all the covered cells and collect the sprites
         for i in range(min_point[0], max_point[0] + 1):
@@ -119,7 +114,7 @@ class SpatialHash(Generic[SpriteType]):
 
         return close_by_sprites
 
-    def get_sprites_near_point(self, point: Point) -> Set[SpriteType]:
+    def get_sprites_near_point(self, point: Point) -> set[SpriteType]:
         """
         Return sprites in the same bucket as the given point.
 
@@ -131,7 +126,7 @@ class SpatialHash(Generic[SpriteType]):
         # Return a copy of the set.
         return set(self.contents.setdefault(hash_point, set()))
 
-    def get_sprites_near_rect(self, rect: Rect) -> Set[SpriteType]:
+    def get_sprites_near_rect(self, rect: Rect) -> set[SpriteType]:
         """
         Return sprites in the same buckets as the given rectangle.
 
@@ -144,7 +139,7 @@ class SpatialHash(Generic[SpriteType]):
 
         # hash the minimum and maximum points
         min_point, max_point = self.hash(min_point), self.hash(max_point)
-        close_by_sprites: Set[SpriteType] = set()
+        close_by_sprites: set[SpriteType] = set()
 
         # Iterate over the all the covered cells and collect the sprites
         for i in range(min_point[0], max_point[0] + 1):

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -15,12 +15,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Deque,
-    Dict,
     Iterable,
     Iterator,
-    List,
     Optional,
-    Tuple,
     Union,
     Generic,
     Callable,
@@ -115,7 +112,7 @@ class SpriteList(Generic[SpriteType]):
         self._lazy = lazy
         self._visible = visible
         self._blend = blend
-        self._color: Tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+        self._color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
 
         # The initial capacity of the spritelist buffers (internal)
         self._buf_capacity = abs(capacity) or _DEFAULT_CAPACITY
@@ -129,10 +126,10 @@ class SpriteList(Generic[SpriteType]):
         self._sprite_buffer_free_slots: Deque[int] = deque()
 
         # List of sprites in the sprite list
-        self.sprite_list: List[SpriteType] = []
+        self.sprite_list: list[SpriteType] = []
         # Buffer slots for the sprites (excluding index buffer)
         # This has nothing to do with the index in the spritelist itself
-        self.sprite_slot: Dict[SpriteType, int] = dict()
+        self.sprite_slot: dict[SpriteType, int] = dict()
 
         # Python representation of buffer data
         self._sprite_pos_data = array("f", [0] * self._buf_capacity * 3)
@@ -171,7 +168,7 @@ class SpriteList(Generic[SpriteType]):
         if use_spatial_hash:
             self.spatial_hash = SpatialHash(cell_size=self._spatial_hash_cell_size)
 
-        self.properties: Optional[Dict[str, Any]] = None
+        self.properties: Optional[dict[str, Any]] = None
 
         # LOG.debug(
         #     "[%s] Creating SpriteList use_spatial_hash=%s capacity=%s",
@@ -776,7 +773,7 @@ class SpriteList(Generic[SpriteType]):
         random.shuffle(pairs)
 
         # Reconstruct the lists again from pairs
-        sprites, indices = cast(Tuple[List[SpriteType], List[int]], zip(*pairs))
+        sprites, indices = cast(tuple[list[SpriteType], list[int]], zip(*pairs))
         self.sprite_list = list(sprites)
         self._sprite_index_data = array("I", indices)
 
@@ -870,7 +867,7 @@ class SpriteList(Generic[SpriteType]):
         for sprite in self.sprite_list:
             sprite.update_animation(delta_time)
 
-    def _get_center(self) -> Tuple[float, float]:
+    def _get_center(self) -> tuple[float, float]:
         """Get the mean center coordinates of all sprites in the list."""
         x = sum((sprite.center_x for sprite in self.sprite_list)) / len(self.sprite_list)
         y = sum((sprite.center_y for sprite in self.sprite_list)) / len(self.sprite_list)

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -5,7 +5,7 @@ Drawing text with pyglet label
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import pyglet
 
@@ -41,7 +41,7 @@ def load_font(path: Union[str, Path]) -> None:
     pyglet.font.add_file(str(file_path))
 
 
-FontNameOrNames = Union[str, Tuple[str, ...]]
+FontNameOrNames = Union[str, tuple[str, ...]]
 
 
 def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames:
@@ -56,14 +56,14 @@ def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames
     argument for pyglet to attempt to resolve. This is consistent with
     the original behavior of this code before it was encapsulated.
 
-    :param Union[str, Tuple[str, ...]] font_name:
+    :param Union[str, tuple[str, ...]] font_name:
     :return: Either a resolved path or the original tuple
     """
     if font_name:
 
         # ensure
         if isinstance(font_name, str):
-            font_list: Tuple[str, ...] = (font_name,)
+            font_list: tuple[str, ...] = (font_name,)
         elif isinstance(font_name, tuple):
             font_list = font_name
         else:
@@ -130,7 +130,7 @@ class Text:
     :param font_size: Size of the text in points
     :param width: A width limit in pixels
     :param align: Horizontal alignment; values other than "left" require width to be set
-    :param Union[str, Tuple[str, ...]] font_name: A font name, path to a font file, or list of names
+    :param Union[str, tuple[str, ...]] font_name: A font name, path to a font file, or list of names
     :param bold: Whether to draw the text as bold
     :param italic: Whether to draw the text as italic
     :param anchor_x: How to calculate the anchor point's x coordinate.
@@ -465,7 +465,7 @@ class Text:
         return self._label.bottom
 
     @property
-    def content_size(self) -> Tuple[int, int]:
+    def content_size(self) -> tuple[int, int]:
         """
         Get the pixel width and height of the text contents.
         """
@@ -710,7 +710,7 @@ def draw_text(
     :param font_size: Size of the text in points
     :param width: A width limit in pixels
     :param align: Horizontal alignment; values other than "left" require width to be set
-    :param Union[str, Tuple[str, ...]] font_name: A font name, path to a font file, or list of names
+    :param Union[str, tuple[str, ...]] font_name: A font name, path to a font file, or list of names
     :param bold: Whether to draw the text as bold
     :param italic: Whether to draw the text as italic
     :param anchor_x: How to calculate the anchor point's x coordinate

--- a/arcade/texture/manager.py
+++ b/arcade/texture/manager.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Union, Optional, Tuple
+from typing import Union, Optional
 
 import PIL.Image
 import PIL.ImageOps
@@ -26,7 +26,7 @@ class TextureCacheManager:
     """
 
     def __init__(self):
-        self._sprite_sheets: Dict[str, SpriteSheet] = {}
+        self._sprite_sheets: dict[str, SpriteSheet] = {}
         self._hit_box_cache = HitBoxCache()
         self._image_data_cache = ImageDataCache()
         self._texture_cache = TextureCache()
@@ -195,7 +195,7 @@ class TextureCacheManager:
         self,
         file_path: Path,
         hit_box_algorithm: Optional[hitbox.HitBoxAlgorithm] = None,
-        crop: Tuple[int, int, int, int] = (0, 0, 0, 0),
+        crop: tuple[int, int, int, int] = (0, 0, 0, 0),
         hash: Optional[str] = None,
     ) -> Texture:
         """Load a texture, or return a cached version if it's already loaded."""
@@ -243,7 +243,7 @@ class TextureCacheManager:
         file_path: Path,
         hash: Optional[str] = None,
         mode: str = "RGBA",
-    ) -> Tuple[ImageData, bool]:
+    ) -> tuple[ImageData, bool]:
         """
         Load an image, or return a cached version
 

--- a/arcade/texture/spritesheet.py
+++ b/arcade/texture/spritesheet.py
@@ -1,6 +1,6 @@
 from PIL import Image
 from pathlib import Path
-from typing import Union, Tuple, Optional, List, Literal, TYPE_CHECKING
+from typing import Union, Optional, Literal, TYPE_CHECKING
 
 # from arcade import Texture
 from arcade.texture import Texture
@@ -72,7 +72,7 @@ class SpriteSheet:
         return self._path
 
     @property
-    def flip_flags(self) -> Tuple[bool, bool]:
+    def flip_flags(self) -> tuple[bool, bool]:
         """
         Query the orientation of the sprite sheet.
         This can be used to determine if the sprite sheet needs to be flipped.
@@ -146,11 +146,11 @@ class SpriteSheet:
 
     def get_image_grid(
         self,
-        size: Tuple[int, int],
+        size: tuple[int, int],
         columns: int,
         count: int,
-        margin: Tuple[int, int, int, int] = (0, 0, 0, 0),
-    ) -> List[Image.Image]:
+        margin: tuple[int, int, int, int] = (0, 0, 0, 0),
+    ) -> list[Image.Image]:
         """
         Slice a grid of textures from the sprite sheet.
 
@@ -176,12 +176,12 @@ class SpriteSheet:
 
     def get_texture_grid(
         self,
-        size: Tuple[int, int],
+        size: tuple[int, int],
         columns: int,
         count: int,
-        margin: Tuple[int, int, int, int] = (0, 0, 0, 0),
+        margin: tuple[int, int, int, int] = (0, 0, 0, 0),
         hit_box_algorithm: Optional["HitBoxAlgorithm"] = None,
-    ) -> List[Texture]:
+    ) -> list[Texture]:
         """
         Slice a grid of textures from the sprite sheet.
 

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any, Dict, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import Any, Optional, Type, Union, TYPE_CHECKING
 from pathlib import Path
 
 import PIL.Image
@@ -84,7 +84,7 @@ class ImageData:
         return self.image.height
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         The size of the image
         """
@@ -190,11 +190,11 @@ class Texture:
 
         # Optional filename for debugging
         self._file_path: Optional[Path] = None
-        self._crop_values: Optional[Tuple[int, int, int, int]] = None
-        self._properties: Dict[str, Any] = {}
+        self._crop_values: Optional[tuple[int, int, int, int]] = None
+        self._properties: dict[str, Any] = {}
 
     @property
-    def properties(self) -> Dict[str, Any]:
+    def properties(self) -> dict[str, Any]:
         """
         A dictionary of properties for this texture.
         This can be used to store any data you want.
@@ -232,7 +232,7 @@ class Texture:
         *,
         hash: str,
         hit_box_algorithm: HitBoxAlgorithm,
-        vertex_order: Tuple[int, int, int, int] = (0, 1, 2, 3),
+        vertex_order: tuple[int, int, int, int] = (0, 1, 2, 3),
     ) -> str:
         """
         Create a cache name for the texture.
@@ -251,7 +251,7 @@ class Texture:
         return f"{hash}|{vertex_order}|{hit_box_algorithm.cache_name}|"
 
     @classmethod
-    def create_atlas_name(cls, hash: str, vertex_order: Tuple[int, int, int, int] = (0, 1, 2, 3)):
+    def create_atlas_name(cls, hash: str, vertex_order: tuple[int, int, int, int] = (0, 1, 2, 3)):
         return f"{hash}|{vertex_order}"
 
     def _update_cache_names(self):
@@ -270,7 +270,7 @@ class Texture:
 
     @classmethod
     def create_image_cache_name(
-        cls, path: Union[str, Path], crop: Tuple[int, int, int, int] = (0, 0, 0, 0)
+        cls, path: Union[str, Path], crop: tuple[int, int, int, int] = (0, 0, 0, 0)
     ):
         return f"{str(path)}|{crop}"
 
@@ -297,7 +297,7 @@ class Texture:
         self._file_path = path
 
     @property
-    def crop_values(self) -> Optional[Tuple[int, int, int, int]]:
+    def crop_values(self) -> Optional[tuple[int, int, int, int]]:
         """
         The crop values used to create this texture in the referenced file
 
@@ -306,7 +306,7 @@ class Texture:
         return self._crop_values
 
     @crop_values.setter
-    def crop_values(self, crop: Optional[Tuple[int, int, int, int]]):
+    def crop_values(self, crop: Optional[tuple[int, int, int, int]]):
         self._crop_values = crop
 
     @property
@@ -378,7 +378,7 @@ class Texture:
         self._size = (self._size[0], value)
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """
         The virtual size of the texture in pixels.
 
@@ -390,7 +390,7 @@ class Texture:
         return self._size
 
     @size.setter
-    def size(self, value: Tuple[int, int]):
+    def size(self, value: tuple[int, int]):
         self._size = value
 
     @property
@@ -413,7 +413,7 @@ class Texture:
         return self._hit_box_algorithm
 
     @classmethod
-    def create_filled(cls, name: str, size: Tuple[int, int], color: RGBA255) -> "Texture":
+    def create_filled(cls, name: str, size: tuple[int, int], color: RGBA255) -> "Texture":
         """
         Create a filled texture. This is an alias for :py:meth:`create_empty`.
 
@@ -428,7 +428,7 @@ class Texture:
     def create_empty(
         cls,
         name: str,
-        size: Tuple[int, int],
+        size: tuple[int, int],
         color: RGBA255 = TRANSPARENT_BLACK,
     ) -> "Texture":
         """

--- a/arcade/texture/transforms.py
+++ b/arcade/texture/transforms.py
@@ -8,7 +8,6 @@ transform the texture coordinates and hit box points.
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
 from enum import Enum
 from arcade.math import rotate_point
 from arcade.types import Point2List
@@ -51,7 +50,7 @@ class Transform:
         return points
 
     @classmethod
-    def transform_vertex_order(cls, order: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
+    def transform_vertex_order(cls, order: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
         """
         Transforms and exiting vertex order with this transform.
         This gives us important metadata on how to quickly transform
@@ -67,9 +66,9 @@ class Transform:
     @classmethod
     def transform_texture_coordinates_order(
         cls,
-        texture_coordinates: Tuple[float, float, float, float, float, float, float, float],
-        order: Tuple[int, int, int, int],
-    ) -> Tuple[float, float, float, float, float, float, float, float]:
+        texture_coordinates: tuple[float, float, float, float, float, float, float, float],
+        order: tuple[int, int, int, int],
+    ) -> tuple[float, float, float, float, float, float, float, float]:
         """
         Change texture coordinates order.
 
@@ -230,7 +229,7 @@ class TransverseTransform(Transform):
 # but it's faster to just pre-calculate it.
 # Key is the vertex order
 # Value is the orientation (flip_left_right, flip_top_down, rotation)
-ORIENTATIONS: Dict[Tuple[int, int, int, int], Tuple[int, bool, bool]] = {
+ORIENTATIONS: dict[tuple[int, int, int, int], tuple[int, bool, bool]] = {
     (0, 1, 2, 3): (0, False, False),  # Default
     (2, 0, 3, 1): (90, False, False),  # Rotate 90
     (3, 2, 1, 0): (180, False, False),  # Rotate 180

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -14,7 +14,7 @@ import math
 import os
 from collections import OrderedDict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import pytiled_parser
 import pytiled_parser.tiled_object
@@ -49,7 +49,7 @@ __all__ = ["TileMap", "load_tilemap", "read_tmx"]
 prop_to_float = cast(Callable[[pytiled_parser.Property], float], float)
 
 
-def _get_image_info_from_tileset(tile: pytiled_parser.Tile) -> Tuple[int, int, int, int]:
+def _get_image_info_from_tileset(tile: pytiled_parser.Tile) -> tuple[int, int, int, int]:
     image_x = 0
     image_y = 0
     if tile.tileset.image is not None:
@@ -187,10 +187,10 @@ class TileMap:
     "The background color of the map."
     scaling: float
     "A global scaling value to be applied to all Sprites in the map."
-    sprite_lists: Dict[str, SpriteList]
+    sprite_lists: dict[str, SpriteList]
     """A dictionary mapping SpriteLists to their layer names. This is used
                     for all tile layers of the map."""
-    object_lists: Dict[str, List[TiledObject]]
+    object_lists: dict[str, list[TiledObject]]
     """
     A dictionary mapping TiledObjects to their layer names. This is used
     for all object layers of the map.
@@ -202,7 +202,7 @@ class TileMap:
         self,
         map_file: Union[str, Path] = "",
         scaling: float = 1.0,
-        layer_options: Optional[Dict[str, Dict[str, Any]]] = None,
+        layer_options: Optional[dict[str, dict[str, Any]]] = None,
         use_spatial_hash: bool = False,
         hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
         tiled_map: Optional[pytiled_parser.TiledMap] = None,
@@ -254,8 +254,8 @@ class TileMap:
         self.offset = offset
 
         # Dictionaries to store the SpriteLists for processed layers
-        self.sprite_lists: Dict[str, SpriteList] = OrderedDict()
-        self.object_lists: Dict[str, List[TiledObject]] = OrderedDict()
+        self.sprite_lists: dict[str, SpriteList] = OrderedDict()
+        self.object_lists: dict[str, list[TiledObject]] = OrderedDict()
         self.properties = self.tiled_map.properties
 
         global_options = {  # type: ignore
@@ -279,10 +279,10 @@ class TileMap:
     def _process_layer(
         self,
         layer: pytiled_parser.Layer,
-        global_options: Dict[str, Any],
-        layer_options: Optional[Dict[str, Dict[str, Any]]] = None,
+        global_options: dict[str, Any],
+        layer_options: Optional[dict[str, dict[str, Any]]] = None,
     ) -> None:
-        processed: Union[SpriteList, Tuple[Optional[SpriteList], Optional[List[TiledObject]]]]
+        processed: Union[SpriteList, tuple[Optional[SpriteList], Optional[list[TiledObject]]]]
 
         options = global_options
 
@@ -318,7 +318,7 @@ class TileMap:
         self,
         x: float,
         y: float,
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Given a set of coordinates in pixel units, this returns the cartesian coordinates.
 
@@ -429,7 +429,7 @@ class TileMap:
         scaling: float = 1.0,
         hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
         custom_class: Optional[type] = None,
-        custom_class_args: Dict[str, Any] = {},
+        custom_class_args: dict[str, Any] = {},
     ) -> Sprite:
         """Given a tile from the parser, try and create a Sprite from it."""
 
@@ -504,7 +504,7 @@ class TileMap:
                     print("Warning, only one hit box supported for tile.")
 
             for hitbox in tile.objects.tiled_objects:
-                points: List[Point2] = []
+                points: list[Point2] = []
                 if isinstance(hitbox, pytiled_parser.tiled_object.Rectangle):
                     if hitbox.size is None:
                         print(
@@ -571,7 +571,7 @@ class TileMap:
                     points = [(point[1], point[0]) for point in points]
 
                 my_sprite.hit_box = RotatableHitBox(
-                    cast(List[Point2], points),
+                    cast(list[Point2], points),
                     position=my_sprite.position,
                     angle=my_sprite.angle,
                     scale=my_sprite.scale_xy,
@@ -634,7 +634,7 @@ class TileMap:
         hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
         offset: Vec2 = Vec2(0, 0),
         custom_class: Optional[type] = None,
-        custom_class_args: Dict[str, Any] = {},
+        custom_class_args: dict[str, Any] = {},
     ) -> SpriteList:
         sprite_list: SpriteList = SpriteList(
             use_spatial_hash=use_spatial_hash,
@@ -719,7 +719,7 @@ class TileMap:
         hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
         offset: Vec2 = Vec2(0, 0),
         custom_class: Optional[type] = None,
-        custom_class_args: Dict[str, Any] = {},
+        custom_class_args: dict[str, Any] = {},
     ) -> SpriteList:
         sprite_list: SpriteList = SpriteList(
             use_spatial_hash=use_spatial_hash,
@@ -796,15 +796,15 @@ class TileMap:
         hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
         offset: Vec2 = Vec2(0, 0),
         custom_class: Optional[type] = None,
-        custom_class_args: Dict[str, Any] = {},
-    ) -> Tuple[Optional[SpriteList], Optional[List[TiledObject]]]:
+        custom_class_args: dict[str, Any] = {},
+    ) -> tuple[Optional[SpriteList], Optional[list[TiledObject]]]:
         if not scaling:
             scaling = self.scaling
 
         sprite_list: Optional[SpriteList] = None
-        objects_list: Optional[List[TiledObject]] = []
+        objects_list: Optional[list[TiledObject]] = []
 
-        shape: Union[List[Point2], Tuple[int, int, int, int], Point2, None] = None
+        shape: Union[list[Point2], tuple[int, int, int, int], Point2, None] = None
 
         for cur_object in layer.tiled_objects:
             # shape: Optional[Union[Point, PointList, Rect]] = None
@@ -934,7 +934,7 @@ class TileMap:
             elif isinstance(cur_object, pytiled_parser.tiled_object.Polygon) or isinstance(
                 cur_object, pytiled_parser.tiled_object.Polyline
             ):
-                points: List[Point2] = []
+                points: list[Point2] = []
                 shape = points
                 for point in cur_object.points:
                     x = point.x + cur_object.coordinates.x
@@ -981,7 +981,7 @@ class TileMap:
 def load_tilemap(
     map_file: Union[str, Path],
     scaling: float = 1.0,
-    layer_options: Optional[Dict[str, Dict[str, Any]]] = None,
+    layer_options: Optional[dict[str, dict[str, Any]]] = None,
     use_spatial_hash: bool = False,
     hit_box_algorithm: Optional[HitBoxAlgorithm] = None,
     offset: Vec2 = Vec2(0, 0),

--- a/arcade/types/__init__.py
+++ b/arcade/types/__init__.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 # flake8: noqa: E402
 import sys
 from pathlib import Path
-from typing import NamedTuple, Optional, Tuple, Union, TYPE_CHECKING, TypeVar
+from typing import NamedTuple, Optional, Union, TYPE_CHECKING, TypeVar
 
 from pytiled_parser import Properties
 
@@ -151,14 +151,14 @@ _T = TypeVar("_T")
 #:       """
 #:       ...  # No function definition
 #:
-Size2D = Tuple[_T, _T]
+Size2D = tuple[_T, _T]
 
 #: Used in :py:class:`~arcade.sprite_list.spatial_hash.SpatialHash`.
-IPoint = Tuple[int, int]
+IPoint = tuple[int, int]
 
 
 # We won't keep this forever. It's a temp stub for particles we'll replace.
-Velocity = Tuple[AsFloat, AsFloat]
+Velocity = tuple[AsFloat, AsFloat]
 
 # --- End potentially obsolete annotations ---
 
@@ -178,7 +178,7 @@ PathOrTexture = PathOr["Texture"]
 
 
 class TiledObject(NamedTuple):
-    shape: Union[Point, PointList, Tuple[int, int, int, int]]
+    shape: Union[Point, PointList, tuple[int, int, int, int]]
     properties: Optional[Properties] = None
     name: Optional[str] = None
     type: Optional[str] = None

--- a/arcade/types/color.py
+++ b/arcade/types/color.py
@@ -21,7 +21,7 @@ named color values, please see the following:
 from __future__ import annotations
 
 import random
-from typing import Tuple, Iterable, Optional, Union, TypeVar
+from typing import Iterable, Optional, Union, TypeVar
 
 from typing_extensions import Self, Final
 
@@ -67,8 +67,8 @@ MASK_RGB_B: Final[int] = 0x0000FF
 ChannelType = TypeVar("ChannelType")
 
 # Generic color aliases
-RGB = Tuple[ChannelType, ChannelType, ChannelType]
-RGBA = Tuple[ChannelType, ChannelType, ChannelType, ChannelType]
+RGB = tuple[ChannelType, ChannelType, ChannelType]
+RGBA = tuple[ChannelType, ChannelType, ChannelType, ChannelType]
 RGBOrA = Union[RGB[ChannelType], RGBA[ChannelType]]
 
 # Specific color aliases
@@ -182,7 +182,7 @@ class Color(RGBA255):
         return self[3]
 
     @property
-    def rgb(self) -> Tuple[int, int, int]:
+    def rgb(self) -> tuple[int, int, int]:
         """Return only a color's RGB components.
 
         This is syntactic sugar for slice indexing as below:
@@ -503,7 +503,7 @@ class Color(RGBA255):
 
         return cls(r, g, b, a)
 
-    def swizzle(self, order: str) -> Tuple[int, ...]:
+    def swizzle(self, order: str) -> tuple[int, ...]:
         """Get a :py:class:`tuple` of channel values in the given ``order``.
 
         .. _GLSL's swizzling: https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)#Swizzling

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import math
-from typing import NamedTuple, Optional, TypedDict, Tuple
+from typing import NamedTuple, Optional, TypedDict
 
 from pyglet.math import Vec2
 
@@ -11,8 +11,8 @@ from arcade.types.vector_like import AnchorPoint, Point2
 
 from arcade.utils import ReplacementWarning, warning
 
-RectParams = Tuple[AsFloat, AsFloat, AsFloat, AsFloat]
-ViewportParams = Tuple[int, int, int, int]
+RectParams = tuple[AsFloat, AsFloat, AsFloat, AsFloat]
+ViewportParams = tuple[int, int, int, int]
 
 
 class RectKwargs(TypedDict):

--- a/arcade/types/vector_like.py
+++ b/arcade/types/vector_like.py
@@ -9,17 +9,17 @@ This is a submodule of :py:mod:`arcade.types` to avoid issues with:
 
 from __future__ import annotations
 
-from typing import Union, Tuple, Sequence
+from typing import Union, Sequence
 
 from pyglet.math import Vec2, Vec3
 
 from arcade.types.numbers import AsFloat
 
 #: Matches both :py:class:`~pyglet.math.Vec2` and tuples of two numbers.
-Point2 = Union[Tuple[AsFloat, AsFloat], Vec2]
+Point2 = Union[tuple[AsFloat, AsFloat], Vec2]
 
 #: Matches both :py:class:`~pyglet.math.Vec3` and tuples of three numbers.
-Point3 = Union[Tuple[AsFloat, AsFloat, AsFloat], Vec3]
+Point3 = Union[tuple[AsFloat, AsFloat, AsFloat], Vec3]
 
 
 #: Matches any 2D or 3D point, including:

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -10,7 +10,7 @@ import functools
 import platform
 import sys
 import warnings
-from typing import Tuple, Type, TypeVar
+from typing import Type, TypeVar
 from pathlib import Path
 
 
@@ -208,7 +208,7 @@ def is_raspberry_pi() -> bool:
     return get_raspberry_pi_info()[0]
 
 
-def get_raspberry_pi_info() -> Tuple[bool, str, str]:
+def get_raspberry_pi_info() -> tuple[bool, str, str]:
     """
     Determine if the host is a raspberry pi with additional info.
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -10,7 +10,7 @@ import os
 
 import pyglet
 
-from typing import Callable, Optional, Tuple, TYPE_CHECKING
+from typing import Callable, Optional, TYPE_CHECKING
 from arcade.types import RGBA255, Color
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ __all__ = [
 ]
 
 
-def get_display_size(screen_id: int = 0) -> Tuple[int, int]:
+def get_display_size(screen_id: int = 0) -> tuple[int, int]:
     """
     Return the width and height of a monitor.
 

--- a/make.py
+++ b/make.py
@@ -11,13 +11,14 @@ For help, see the following:
 * CONTRIBUTING.md
 * The output of python make.py --help
 """
+from __future__ import annotations
 
 import os
 from contextlib import contextmanager
 from shutil import which, rmtree
 import subprocess
 from pathlib import Path
-from typing import Union, List, Generator, Optional
+from typing import Union, Generator, Optional
 
 PathLike = Union[Path, str, bytes]
 
@@ -137,7 +138,7 @@ def cd_context(directory: PathLike) -> Generator[Path, None, None]:
         os.chdir(_original_dir)
 
 
-def run(args: Union[str, List[str]], cd: Optional[PathLike] = None) -> None:
+def run(args: Union[str, list[str]], cd: Optional[PathLike] = None) -> None:
     """
     Try to run `args` with subprocess, switching into & out of `cd` if provided.
 
@@ -158,7 +159,7 @@ def run(args: Union[str, List[str]], cd: Optional[PathLike] = None) -> None:
         exit(result.returncode)
 
 
-def run_doc(args: Union[str, List[str]]) -> None:
+def run_doc(args: Union[str, list[str]]) -> None:
     run(args, cd=FULL_DOC_DIR)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Arcade Game Development Library"
 readme = "README.md"
 authors = [{ name = "Paul Vincent Craven", email = "paul@cravenfamily.com" }]
 license = { file = "license.rst" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,13 @@ description = "Arcade Game Development Library"
 readme = "README.md"
 authors = [{ name = "Paul Vincent Craven", email = "paul@cravenfamily.com" }]
 license = { file = "license.rst" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Arcade Game Development Library"
 readme = "README.md"
 authors = [{ name = "Paul Vincent Craven", email = "paul@cravenfamily.com" }]
 license = { file = "license.rst" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Does an initial conversion of types to be in line with [PEP 585](https://peps.python.org/pep-0585/)

This is a full sweep of the library, places where `from __future__ import annotations` was not present, it was added in order for this to still work on Python 3.8.

After support for 3.8 is dropped, if the `__future__` import is not needed for other reasons, it could be dropped.