### PR TITLE
Optimize & document collision circular check in physics engines

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -39,6 +39,7 @@ def _wiggle_until_free(colliding: Sprite, walls: list[SpriteList]) -> None:
 
     # Original x & y of the moving object
     o_x, o_y = colliding.position
+    # fmt: off
     # Allocate once so we don't recreate or gc
     try_list = array(
         'f', (
@@ -50,7 +51,6 @@ def _wiggle_until_free(colliding: Sprite, walls: list[SpriteList]) -> None:
     )
     wiggle_distance = 1
 
-    # fmt: off
     while True:
         # Cache our variant dimensions
         o_x_plus  = o_x + wiggle_distance

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 # pylint: disable=too-many-arguments, too-many-locals, too-few-public-methods
 import math
 
-from array import array
 from typing import Iterable, Optional, Union
 
 from arcade import (

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -22,12 +22,14 @@ __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 from arcade.utils import copy_dunders_unimplemented
 
 
-def _circular_check(player: Sprite, walls: list[SpriteList]) -> None:
+def _circular_check(moving: Sprite, walls: list[SpriteList]) -> None:
+    """A kludge to 'guess' our way out a collision for a moving sprite.
+
+    :param moving: A sprite to move out of the given list of SpriteLists.
+    :param walls: A list of walls to guess our way out of.
     """
-    This is a horrible kludge to 'guess' our way out of a collision
-    """
-    original_x = player.center_x
-    original_y = player.center_y
+    original_x = moving.center_x
+    original_y = moving.center_y
 
     vary = 1
     while True:
@@ -44,10 +46,10 @@ def _circular_check(player: Sprite, walls: list[SpriteList]) -> None:
 
         for my_item in try_list:
             x, y = my_item
-            player.center_x = x
-            player.center_y = y
-            check_hit_list = check_for_collision_with_lists(player, walls)
-            # print(f"Vary {vary} ({self.player_sprite.center_x} {self.player_sprite.center_y}) "
+            moving.center_x = x
+            moving.center_y = y
+            check_hit_list = check_for_collision_with_lists(moving, walls)
+            # print(f"Vary {vary} ({self.moving_sprite.center_x} {self.moving_sprite.center_y}) "
             #       f"= {len(check_hit_list)}")
             if len(check_hit_list) == 0:
                 return

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -28,8 +28,7 @@ def _circular_check(moving: Sprite, walls: list[SpriteList]) -> None:
     :param moving: A sprite to move out of the given list of SpriteLists.
     :param walls: A list of walls to guess our way out of.
     """
-    original_x = moving.center_x
-    original_y = moving.center_y
+    original_x, original_y = moving.position
 
     vary = 1
     while True:
@@ -46,8 +45,7 @@ def _circular_check(moving: Sprite, walls: list[SpriteList]) -> None:
 
         for my_item in try_list:
             x, y = my_item
-            moving.center_x = x
-            moving.center_y = y
+            moving.position = x, y
             check_hit_list = check_for_collision_with_lists(moving, walls)
             # print(f"Vary {vary} ({self.moving_sprite.center_x} {self.moving_sprite.center_y}) "
             #       f"= {len(check_hit_list)}")

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -39,18 +39,16 @@ def _wiggle_until_free(colliding: Sprite, walls: list[SpriteList]) -> None:
 
     # Original x & y of the moving object
     o_x, o_y = colliding.position
-    # fmt: off
-    # Allocate once so we don't recreate or gc
-    try_list = array(
-        'f', (
-            0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0,
-        )
-    )
-    wiggle_distance = 1
 
+    # fmt: off
+    try_list = [  # Allocate once so we don't recreate or gc
+        0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0,
+    ]
+
+    wiggle_distance = 1
     while True:
         # Cache our variant dimensions
         o_x_plus  = o_x + wiggle_distance


### PR DESCRIPTION
**TL;DR:** Optimize, rename, and document egregious kludge a little

* Stop GCing in the middle of collision resolution
* Explain how and why it works
* Rename it

#### Tests Steps Taken

- [x] Run CI
- [x] Run some examples for:
   - [x] `PhysicsEngineSimple`
   - [x] `PhysicsEnginePlatformer`

#### Why?

* Test out black & PR flow before salvaging #1981
* Fix some of the paper cuts inside physics engines