### PR TITLE
Fix unneeded copies and `SpriteList` updates in physics engines

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -345,6 +345,7 @@ class PhysicsEnginePlatformer:
         self._ladders: list[SpriteList] = []
         self._platforms: list[SpriteList] = []
         self._walls: list[SpriteList] = []
+        self._all_obstacles = ListChain(self._walls, self._platforms)
 
         _add_to_list(self._ladders, ladders)
         _add_to_list(self._platforms, platforms)
@@ -427,8 +428,7 @@ class PhysicsEnginePlatformer:
         self.player_sprite.center_y -= y_distance
 
         # Check for wall hit
-        hit_list = check_for_collision_with_lists(
-            self.player_sprite, ListChain(self._walls, self._platforms))
+        hit_list = check_for_collision_with_lists(self.player_sprite, self._all_obstacles)
 
         self.player_sprite.center_y += y_distance
 
@@ -532,7 +532,7 @@ class PhysicsEnginePlatformer:
                     platform.center_y += platform.change_y
 
         complete_hit_list = _move_sprite(
-            self.player_sprite, ListChain(self._walls, self._platforms), ramp_up=True
+            self.player_sprite, self._all_obstacles, ramp_up=True
         )
 
         # print(f"Spot Z ({self.player_sprite.center_x}, {self.player_sprite.center_y})")

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -21,7 +21,7 @@ from arcade.math import get_distance
 
 __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 
-from arcade.utils import copy_dunders_unimplemented
+from arcade.utils import copy_dunders_unimplemented, ListChain
 
 
 def _wiggle_until_free(colliding: Sprite, walls: Iterable[SpriteList]) -> None:
@@ -431,7 +431,7 @@ class PhysicsEnginePlatformer:
 
         # Check for wall hit
         hit_list = check_for_collision_with_lists(
-            self.player_sprite, chain(self.walls, self.platforms))
+            self.player_sprite, ListChain(self._walls, self._platforms))
 
         self.player_sprite.center_y += y_distance
 
@@ -535,7 +535,7 @@ class PhysicsEnginePlatformer:
                     platform.center_y += platform.change_y
 
         complete_hit_list = _move_sprite(
-            self.player_sprite, chain(self.walls, self.platforms), ramp_up=True
+            self.player_sprite, ListChain(self._walls, self._platforms), ramp_up=True
         )
 
         # print(f"Spot Z ({self.player_sprite.center_x}, {self.player_sprite.center_y})")

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -530,9 +530,7 @@ class PhysicsEnginePlatformer:
 
                     platform.center_y += platform.change_y
 
-        complete_hit_list = _move_sprite(
-            self.player_sprite, self._all_obstacles, ramp_up=True
-        )
+        complete_hit_list = _move_sprite(self.player_sprite, self._all_obstacles, ramp_up=True)
 
         # print(f"Spot Z ({self.player_sprite.center_x}, {self.player_sprite.center_y})")
         # Return list of encountered sprites

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -292,13 +292,13 @@ class PhysicsEngineSimple:
     @walls.setter
     def walls(self, walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None):
         if walls:
-            self._walls = [walls] if isinstance(walls, SpriteList) else list(walls)
+            _add_to_list(self._walls, walls)
         else:
-            self._walls = []
+            self._walls.clear()
 
     @walls.deleter
     def walls(self):
-        self._walls = []
+        self._walls.clear()
 
     def update(self):
         """
@@ -365,13 +365,13 @@ class PhysicsEnginePlatformer:
     @ladders.setter
     def ladders(self, ladders: Optional[Union[SpriteList, Iterable[SpriteList]]] = None):
         if ladders:
-            self._ladders = [ladders] if isinstance(ladders, SpriteList) else list(ladders)
+            _add_to_list(self._ladders, ladders)
         else:
-            self._ladders = []
+            self._ladders.clear()
 
     @ladders.deleter
     def ladders(self):
-        self._ladders = []
+        self._ladders.clear()
 
     @property
     def platforms(self):
@@ -381,9 +381,9 @@ class PhysicsEnginePlatformer:
     @platforms.setter
     def platforms(self, platforms: Optional[Union[SpriteList, Iterable[SpriteList]]] = None):
         if platforms:
-            self._platforms = [platforms] if isinstance(platforms, SpriteList) else list(platforms)
+            _add_to_list(self._platforms, platforms)
         else:
-            self._platforms = []
+            self._platforms.clear()
 
     @platforms.deleter
     def platforms(self):
@@ -397,13 +397,13 @@ class PhysicsEnginePlatformer:
     @walls.setter
     def walls(self, walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None):
         if walls:
-            self._walls = [walls] if isinstance(walls, SpriteList) else list(walls)
+            _add_to_list(self._walls, walls)
         else:
-            self._walls = []
+            self._walls.clear()
 
     @walls.deleter
     def walls(self):
-        self._walls = []
+        self._walls.clear()
 
     def is_on_ladder(self) -> bool:
         """Return 'true' if the player is in contact with a sprite in the ladder list."""

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -253,6 +253,15 @@ def _move_sprite(
     return complete_hit_list
 
 
+def _add_to_list(dest: list[SpriteList], source: Optional[SpriteList | Iterable[SpriteList]]):
+    if source is None:
+        return
+    elif isinstance(source, SpriteList):
+        dest.append(source)
+    else:
+        dest.extend(source)
+
+
 @copy_dunders_unimplemented
 class PhysicsEngineSimple:
     """
@@ -271,12 +280,10 @@ class PhysicsEngineSimple:
         walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
     ) -> None:
         self.player_sprite: Sprite = player_sprite
-        self._walls: list[SpriteList]
+        self._walls: list[SpriteList] = []
 
         if walls:
-            self._walls = [walls] if isinstance(walls, SpriteList) else list(walls)
-        else:
-            self._walls = []
+            _add_to_list(self._walls, walls)
 
     @property
     def walls(self):
@@ -334,24 +341,14 @@ class PhysicsEnginePlatformer:
         ladders: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
         walls: Optional[Union[SpriteList, Iterable[SpriteList]]] = None,
     ) -> None:
-        self._ladders: Optional[list[SpriteList]]
-        self._platforms: list[SpriteList]
-        self._walls: list[SpriteList]
 
-        if ladders:
-            self._ladders = [ladders] if isinstance(ladders, SpriteList) else list(ladders)
-        else:
-            self._ladders = []
+        self._ladders: list[SpriteList] = []
+        self._platforms: list[SpriteList] = []
+        self._walls: list[SpriteList] = []
 
-        if platforms:
-            self._platforms = [platforms] if isinstance(platforms, SpriteList) else list(platforms)
-        else:
-            self._platforms = []
-
-        if walls:
-            self._walls = [walls] if isinstance(walls, SpriteList) else list(walls)
-        else:
-            self._walls = []
+        _add_to_list(self._ladders, ladders)
+        _add_to_list(self._platforms, platforms)
+        _add_to_list(self._walls, walls)
 
         self.player_sprite: Sprite = player_sprite
         self.gravity_constant: float = gravity_constant

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -88,8 +88,7 @@ def _move_sprite(
     if len(check_for_collision_with_lists(moving_sprite, walls)) > 0:
         _wiggle_until_free(moving_sprite, walls)
 
-    original_x = moving_sprite.center_x
-    original_y = moving_sprite.center_y
+    original_x, original_y = moving_sprite.position
     original_angle = moving_sprite.angle
 
     # --- Rotate
@@ -113,8 +112,7 @@ def _move_sprite(
                 > max_distance
             ):
                 # Ok, glitched trying to rotate. Reset.
-                moving_sprite.center_x = original_x
-                moving_sprite.center_y = original_y
+                moving_sprite.position = original_x, original_y
                 moving_sprite.angle = original_angle
 
     # --- Move in the y direction
@@ -238,8 +236,9 @@ def _move_sprite(
                     ) % 2
 
         # print(cur_x_change * direction, cur_y_change)
-        moving_sprite.center_x = original_x + cur_x_change * direction
-        moving_sprite.center_y = almost_original_y + cur_y_change
+        moved_x = original_x + cur_x_change * direction
+        moved_y = almost_original_y + cur_y_change
+        moving_sprite.position = moved_x, moved_y
         # print(f"({moving_sprite.center_x}, {moving_sprite.center_y}) {cur_x_change * direction}, {cur_y_change}")
 
     # Add in rotating hit list

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 # pylint: disable=too-many-arguments, too-many-locals, too-few-public-methods
 import math
+from itertools import chain
 
 from typing import Iterable, Optional, Union
 
@@ -23,7 +24,7 @@ __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 from arcade.utils import copy_dunders_unimplemented
 
 
-def _wiggle_until_free(colliding: Sprite, walls: list[SpriteList]) -> None:
+def _wiggle_until_free(colliding: Sprite, walls: Iterable[SpriteList]) -> None:
     """Kludge to 'guess' a colliding sprite out of a collision.
 
     It works by iterating over increasing wiggle sizes of 8 points
@@ -81,7 +82,7 @@ def _wiggle_until_free(colliding: Sprite, walls: list[SpriteList]) -> None:
 
 
 def _move_sprite(
-    moving_sprite: Sprite, walls: list[SpriteList[SpriteType]], ramp_up: bool
+    moving_sprite: Sprite, walls: Iterable[SpriteList[SpriteType]], ramp_up: bool
 ) -> list[SpriteType]:
 
     # See if we are starting this turn with a sprite already colliding with us.
@@ -429,7 +430,8 @@ class PhysicsEnginePlatformer:
         self.player_sprite.center_y -= y_distance
 
         # Check for wall hit
-        hit_list = check_for_collision_with_lists(self.player_sprite, self.walls + self.platforms)
+        hit_list = check_for_collision_with_lists(
+            self.player_sprite, chain(self.walls, self.platforms))
 
         self.player_sprite.center_y += y_distance
 
@@ -533,7 +535,7 @@ class PhysicsEnginePlatformer:
                     platform.center_y += platform.change_y
 
         complete_hit_list = _move_sprite(
-            self.player_sprite, self.walls + self.platforms, ramp_up=True
+            self.player_sprite, chain(self.walls, self.platforms), ramp_up=True
         )
 
         # print(f"Spot Z ({self.player_sprite.center_x}, {self.player_sprite.center_y})")

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 # pylint: disable=too-many-arguments, too-many-locals, too-few-public-methods
 import math
-from itertools import chain
 
 from typing import Iterable, Optional, Union
 

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -20,7 +20,7 @@ from arcade.math import get_distance
 
 __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 
-from arcade.utils import copy_dunders_unimplemented, ListChain
+from arcade.utils import copy_dunders_unimplemented, Chain
 
 
 def _wiggle_until_free(colliding: Sprite, walls: Iterable[SpriteList]) -> None:
@@ -344,7 +344,7 @@ class PhysicsEnginePlatformer:
         self._ladders: list[SpriteList] = []
         self._platforms: list[SpriteList] = []
         self._walls: list[SpriteList] = []
-        self._all_obstacles = ListChain(self._walls, self._platforms)
+        self._all_obstacles = Chain(self._walls, self._platforms)
 
         _add_to_list(self._ladders, ladders)
         _add_to_list(self._platforms, platforms)

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -11,7 +11,7 @@ import platform
 import sys
 import warnings
 from itertools import chain
-from typing import Type, TypeVar, Generator, Generic
+from typing import Type, TypeVar, Generator, Generic, Sequence
 from pathlib import Path
 
 
@@ -119,18 +119,21 @@ _T = TypeVar('_T')
 _TType = TypeVar('_TType', bound=Type)
 
 
-class ListChain(Generic[_T]):
+class Chain(Generic[_T]):
     """A reusable OOP version of :py:class:`itertools.chain`.
 
     In some cases (physics engines), we need to iterate over multiple
-    lists repeatedly. This class provides a way to do so without copying
-    all of them into a joined list.
+    sequences of objects repeatedly. This class provides a way to do so
+    which:
+
+    * Is non-exhausting
+    * Avoids copying all items into one joined list
 
     Arguments:
-        components: The lists of items to join.
+        components: The sequences of items to join.
     """
-    def __init__(self, *components: list[_T]):
-        self.components: list[list[_T]] = list(components)
+    def __init__(self, *components: Sequence[_T]):
+        self.components: list[Sequence[_T]] = list(components)
 
     def __iter__(self) -> Generator[_T, None, None]:
         for item in chain.from_iterable(self.components):

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -11,10 +11,9 @@ import platform
 import sys
 import warnings
 from itertools import chain
-from typing import Type, TypeVar, Sequence, Generator
+from typing import Type, TypeVar, Generator, Generic
 from pathlib import Path
 
-from typing_extensions import Generic
 
 _CT = TypeVar('_CT')  # Comparable type, ie supports the <= operator
 

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -1,5 +1,5 @@
 """
-# Various utility functions.
+Various utility functions.
 
 IMPORTANT:
 These  should be standalone and not rely on any arcade imports

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -1,5 +1,5 @@
 """
-Various utility functions.
+# Various utility functions.
 
 IMPORTANT:
 These  should be standalone and not rely on any arcade imports
@@ -125,6 +125,9 @@ class ListChain(Generic[_T]):
     In some cases (physics engines), we need to iterate over multiple
     lists repeatedly. This class provides a way to do so without copying
     all of them into a joined list.
+
+    Arguments:
+        components: The lists of items to join.
     """
     def __init__(self, *components: list[_T]):
         self.components: list[list[_T]] = list(components)


### PR DESCRIPTION
**TL;DR:** Clean up internal behavior ahead of reviving #1867

Closes #2163

### Changes

* Make component lists have identical behavior
  * All other lists are empty instead of None (`._walls`, `_platforms`
  * Therefore, `_ladders` is no longer `Optional` and will be empty instead of `None`
* Use `.position` instead of `.center_x` and `.center_y` in `_move_to`
* Generalize some annotations to allow using a non-exhausting OOP `itertools.chain` wrapper
* Stop re-creating lists and use clearing instead
  * Add `_add_to_list` helper
  * Use `list.clear` instead of re-creating lists to avoid GC thrash  