### PR TITLE
Fix platforms.deleter + add tests for physics behavior properties

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -387,7 +387,7 @@ class PhysicsEnginePlatformer:
 
     @platforms.deleter
     def platforms(self):
-        self._platforms = []
+        self._platforms.clear()
 
     @property
     def walls(self):


### PR DESCRIPTION
**TL;DR:** Make sure we aren't actually replacing instance lists unintentionally

* Make platforms.deleter use `list.clear` like the rest
* Add tests for this behavior for both `PhysicsEngineSimple` and `PhysicsEnginePlatformer`
* Explain the behavior in the tests