### PR TITLE
Fix error when resizing the minimap in minimap_camera example

### DIFF
--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -10,6 +10,7 @@ python -m arcade.examples.minimap_camera
 import random
 
 import arcade
+from arcade import LBWH
 
 SPRITE_SCALING = 0.5
 
@@ -153,11 +154,14 @@ class MyGame(arcade.Window):
             if (self.selected_camera.zoom - 0.1) > 0:
                 self.selected_camera.zoom -= 0.1
         elif key == arcade.key.I:
-            l, b, w, h = self.camera_minimap.viewport
-            self.camera_minimap.viewport = l + 100, b + 100, w - 100, h - 100
+            viewport = self.camera_minimap.viewport
+            self.camera_minimap.viewport = LBWH(viewport.left + 100, viewport.bottom + 100,
+                                                viewport.width - 100, viewport.height - 100)
         elif key == arcade.key.K:
-            l, b, w, h = self.camera_minimap.viewport
-            self.camera_minimap.viewport = l - 100, b - 100, w + 100, h + 100
+            viewport = self.camera_minimap.viewport
+            self.camera_minimap.viewport = LBWH(viewport.left - 100, viewport.bottom - 100,
+                                                viewport.width + 100, viewport.height + 100)
+
 
     def on_key_release(self, key, modifiers):
         """Called when the user releases a key. """

--- a/arcade/examples/minimap_camera.py
+++ b/arcade/examples/minimap_camera.py
@@ -10,12 +10,11 @@ python -m arcade.examples.minimap_camera
 import random
 
 import arcade
-from arcade import LBWH
 
 SPRITE_SCALING = 0.5
 
-DEFAULT_SCREEN_WIDTH = 800
-DEFAULT_SCREEN_HEIGHT = 600
+DEFAULT_SCREEN_WIDTH = 1280
+DEFAULT_SCREEN_HEIGHT = 720
 SCREEN_TITLE = "Minimap Example"
 
 # How many pixels to keep as a minimum margin between the character
@@ -155,11 +154,11 @@ class MyGame(arcade.Window):
                 self.selected_camera.zoom -= 0.1
         elif key == arcade.key.I:
             viewport = self.camera_minimap.viewport
-            self.camera_minimap.viewport = LBWH(viewport.left + 100, viewport.bottom + 100,
+            self.camera_minimap.viewport = arcade.LBWH(viewport.left + 100, viewport.bottom + 100,
                                                 viewport.width - 100, viewport.height - 100)
         elif key == arcade.key.K:
             viewport = self.camera_minimap.viewport
-            self.camera_minimap.viewport = LBWH(viewport.left - 100, viewport.bottom - 100,
+            self.camera_minimap.viewport = arcade.LBWH(viewport.left - 100, viewport.bottom - 100,
                                                 viewport.width + 100, viewport.height + 100)
 
 


### PR DESCRIPTION
The `minimap_camera.py` example was broken when the viewport was switched to use RECTs. Before this change, pressing 'i' or 'k' to resize the minimap would throw an error.

Thus, this PR updates the `minimap_camera.py` example to resize the minimap using LBWH when pressing 'i' or 'k'.

This PR addresses one example in #2116 