### PR TITLE
Initial Import Sorting with Ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,10 @@ the formatting is correct.
 python make.py format
 ```
 
+In addition to Black, this will sort the imports using [Ruff](https://docs.astral.sh/ruff/). If you want to setup
+your editor to run this, please see [this link](https://docs.astral.sh/ruff/integrations/) for more information on
+Ruff integration for your specific editor.
+
 ### Use pre-commit hooks to automatically run formatting
 
 You can use `pre-commit <https://pre-commit.com/>`_ to automatically run lint, formatting and type checks against 

--- a/arcade/__main__.py
+++ b/arcade/__main__.py
@@ -2,6 +2,5 @@ from __future__ import annotations
 
 from arcade.management import show_info
 
-
 if __name__ == "__main__":
     show_info()

--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import arcade
 import pymunk
 from PyInstaller.compat import is_darwin, is_unix, is_win
+
+import arcade
 
 pymunk_path = Path(pymunk.__file__).parent
 arcade_path = Path(arcade.__file__).parent

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -11,19 +11,16 @@ import time
 from typing import Optional
 
 import pyglet
-
 import pyglet.gl as gl
 import pyglet.window.mouse
 from pyglet.display.base import ScreenMode
 from pyglet.window import MouseCursor
 
 import arcade
-from arcade import get_display_size
-from arcade import set_window
+from arcade import SectionManager, get_display_size, set_window
 from arcade.color import TRANSPARENT_BLACK
 from arcade.context import ArcadeContext
-from arcade.types import Color, RGBOrA255, RGBANormalized
-from arcade import SectionManager
+from arcade.types import Color, RGBANormalized, RGBOrA255
 from arcade.types.rect import LBWH, Rect
 from arcade.utils import is_raspberry_pi
 

--- a/arcade/cache/hit_box.py
+++ b/arcade/cache/hit_box.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 
 import gzip
 import json
-from pathlib import Path
-from typing import Optional, Union, TYPE_CHECKING
 from collections import OrderedDict
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
 
-from arcade.types import Point2List
 from arcade.resources import resolve
+from arcade.types import Point2List
 
 if TYPE_CHECKING:
     from arcade import Texture

--- a/arcade/cache/image_data.py
+++ b/arcade/cache/image_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from arcade.texture import ImageData

--- a/arcade/cache/texture.py
+++ b/arcade/cache/texture.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING, Union
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from arcade import Texture

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Generator
-from math import degrees, radians, atan2, cos, sin
 from contextlib import contextmanager
+from math import atan2, cos, degrees, radians, sin
+from typing import TYPE_CHECKING, Generator, Optional
 
+from pyglet.math import Vec2, Vec3
 from typing_extensions import Self
 
 from arcade.camera.data_types import (
@@ -12,15 +13,13 @@ from arcade.camera.data_types import (
     ZeroProjectionDimension,
 )
 from arcade.camera.projection_functions import (
-    generate_view_matrix,
     generate_orthographic_matrix,
+    generate_view_matrix,
     project_orthographic,
     unproject_orthographic,
 )
 from arcade.gl import Framebuffer
-from pyglet.math import Vec2, Vec3
-
-from arcade.types import Point, Rect, LBWH, LRBT
+from arcade.types import LBWH, LRBT, Point, Rect
 from arcade.types.vector_like import Point2
 from arcade.window_commands import get_window
 

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -5,13 +5,14 @@ wide usage throughout Arcade's camera code.
 """
 
 from __future__ import annotations
+
 from contextlib import contextmanager
-from typing import Protocol, Generator
+from typing import Generator, Protocol
 
-from typing_extensions import Self
 from pyglet.math import Vec2, Vec3
+from typing_extensions import Self
 
-from arcade.types import AsFloat, Point, Point3, Rect, LRBT
+from arcade.types import LRBT, AsFloat, Point, Point3, Rect
 
 __all__ = [
     "CameraData",

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Optional, Generator, TYPE_CHECKING
-from typing_extensions import Self
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Generator, Optional
 
 from pyglet.math import Mat4, Vec2, Vec3
+from typing_extensions import Self
 
 from arcade.types import Point
 from arcade.window_commands import get_window

--- a/arcade/camera/grips/constrain.py
+++ b/arcade/camera/grips/constrain.py
@@ -5,9 +5,9 @@ can have large impacts on the behaviour of the camera, so try and keep the numbe
 The methods don't update the camera data directly incase you want to smoothly interpolate towards the target position
 """
 
-from arcade.types import Rect, Point2, Box, Point3
-from arcade.math import clamp
 from arcade.camera.data_types import CameraData
+from arcade.math import clamp
+from arcade.types import Box, Point2, Point3, Rect
 
 
 def constrain_x(data: CameraData, minimum: float, maximum: float) -> Point3:

--- a/arcade/camera/grips/rotate.py
+++ b/arcade/camera/grips/rotate.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from pyglet.math import Vec3
 
-from arcade.math import quaternion_rotation
 from arcade.camera.data_types import CameraData
-
+from arcade.math import quaternion_rotation
 
 __all__ = ("rotate_around_forward", "rotate_around_up", "rotate_around_right")
 

--- a/arcade/camera/grips/screen_shake_2d.py
+++ b/arcade/camera/grips/screen_shake_2d.py
@@ -5,12 +5,11 @@ ScreenShakeController2D:
 
 from __future__ import annotations
 
-from math import exp, log, pi, sin, floor
+from math import exp, floor, log, pi, sin
 from random import uniform
 
 from arcade.camera.data_types import CameraData
 from arcade.math import quaternion_rotation
-
 
 __all__ = ("ScreenShake2D",)
 

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
-from typing import Optional, Generator, TYPE_CHECKING
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Generator, Optional
+
+from pyglet.math import Mat4, Vec2, Vec3
 from typing_extensions import Self
 
-from pyglet.math import Mat4, Vec3, Vec2
-
-from arcade.camera.data_types import Projector, CameraData, OrthographicProjectionData
+from arcade.camera.data_types import CameraData, OrthographicProjectionData, Projector
 from arcade.camera.projection_functions import (
-    generate_view_matrix,
     generate_orthographic_matrix,
+    generate_view_matrix,
     project_orthographic,
     unproject_orthographic,
 )
-
-from arcade.types import Point, Rect, LBWH
+from arcade.types import LBWH, Point, Rect
 from arcade.window_commands import get_window
 
 if TYPE_CHECKING:

--- a/arcade/camera/perspective.py
+++ b/arcade/camera/perspective.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-from typing import Optional, Generator, TYPE_CHECKING
-from typing_extensions import Self
 from contextlib import contextmanager
+from math import radians, tan
+from typing import TYPE_CHECKING, Generator, Optional
 
-from math import tan, radians
-from pyglet.math import Mat4, Vec3, Vec2
+from pyglet.math import Mat4, Vec2, Vec3
+from typing_extensions import Self
 
-from arcade.camera.data_types import Projector, CameraData, PerspectiveProjectionData
+from arcade.camera.data_types import CameraData, PerspectiveProjectionData, Projector
 from arcade.camera.projection_functions import (
-    generate_view_matrix,
     generate_perspective_matrix,
+    generate_view_matrix,
     project_perspective,
     unproject_perspective,
 )
-
-from arcade.types import Point, Rect, LBWH
+from arcade.types import LBWH, Point, Rect
 from arcade.window_commands import get_window
 
 if TYPE_CHECKING:

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from math import tan, pi
+from math import pi, tan
 
-from pyglet.math import Vec2, Vec3, Vec4, Mat4
+from pyglet.math import Mat4, Vec2, Vec3, Vec4
+
 from arcade.camera.data_types import (
     CameraData,
-    PerspectiveProjectionData,
     OrthographicProjectionData,
+    PerspectiveProjectionData,
 )
 from arcade.types import Point
 

--- a/arcade/camera/static.py
+++ b/arcade/camera/static.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Generator, Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Generator, Optional
+
+from pyglet.math import Mat4, Vec2, Vec3
 
 from arcade.camera.data_types import (
     CameraData,
@@ -9,19 +11,16 @@ from arcade.camera.data_types import (
     PerspectiveProjectionData,
 )
 from arcade.camera.projection_functions import (
-    generate_view_matrix,
     generate_orthographic_matrix,
     generate_perspective_matrix,
+    generate_view_matrix,
     project_orthographic,
     project_perspective,
     unproject_orthographic,
     unproject_perspective,
 )
-
 from arcade.types import Point, Point3
 from arcade.window_commands import get_window
-
-from pyglet.math import Mat4, Vec3, Vec2
 
 if TYPE_CHECKING:
     from arcade.application import Window

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -6,24 +6,24 @@ Contains pre-loaded programs
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable, Optional, Union, Sequence
+from typing import Any, Iterable, Optional, Sequence, Union
 
 import pyglet
+from PIL import Image
 from pyglet import gl
 from pyglet.graphics.shader import UniformBufferObject
-from PIL import Image
+from pyglet.math import Mat4
 
 import arcade
+from arcade.camera import Projector
+from arcade.camera.default import DefaultProjector
 from arcade.gl import BufferDescription, Context
 from arcade.gl.compute_shader import ComputeShader
+from arcade.gl.framebuffer import Framebuffer
 from arcade.gl.program import Program
 from arcade.gl.texture import Texture2D
 from arcade.gl.vertex_array import Geometry
-from arcade.gl.framebuffer import Framebuffer
-from pyglet.math import Mat4
 from arcade.texture_atlas import DefaultTextureAtlas, TextureAtlasBase
-from arcade.camera import Projector
-from arcade.camera.default import DefaultProjector
 
 __all__ = ["ArcadeContext"]
 

--- a/arcade/draw/arc.py
+++ b/arcade/draw/arc.py
@@ -1,8 +1,9 @@
 import math
 
 from arcade import gl
-from arcade.types import RGBA255
 from arcade.math import rotate_point
+from arcade.types import RGBA255
+
 from .helpers import _generic_draw_line_strip
 
 

--- a/arcade/draw/circle.py
+++ b/arcade/draw/circle.py
@@ -1,8 +1,7 @@
 import array
 
 from arcade import gl
-
-from arcade.types import Color, RGBA255
+from arcade.types import RGBA255, Color
 from arcade.window_commands import get_window
 
 

--- a/arcade/draw/helpers.py
+++ b/arcade/draw/helpers.py
@@ -2,7 +2,7 @@ import array
 import math
 
 from arcade import gl
-from arcade.types import Point2, PointList, RGBA255, Color
+from arcade.types import RGBA255, Color, Point2, PointList
 from arcade.window_commands import get_window
 
 

--- a/arcade/draw/line.py
+++ b/arcade/draw/line.py
@@ -1,9 +1,9 @@
 import array
 
 from arcade import gl
-
-from arcade.types import Color, RGBA255, PointList, Point
+from arcade.types import RGBA255, Color, Point, PointList
 from arcade.window_commands import get_window
+
 from .helpers import _generic_draw_line_strip, get_points_for_thick_line
 
 

--- a/arcade/draw/point.py
+++ b/arcade/draw/point.py
@@ -1,6 +1,6 @@
 import array
 
-from arcade.types import Color, RGBA255, PointList
+from arcade.types import RGBA255, Color, PointList
 from arcade.types.rect import XYWH
 from arcade.window_commands import get_window
 

--- a/arcade/draw/polygon.py
+++ b/arcade/draw/polygon.py
@@ -1,7 +1,7 @@
 from arcade import gl
+from arcade.earclip import earclip
 from arcade.types import RGBA255, Point2List
 
-from arcade.earclip import earclip
 from .helpers import _generic_draw_line_strip, get_points_for_thick_line
 
 

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -1,13 +1,14 @@
 import array
 
 from arcade import gl
-from arcade.math import rotate_point
-from arcade.types import RGBA255, PointList, AsFloat, Rect, LRBT, LBWH, XYWH, Color
-from arcade.texture import Texture
-from arcade.sprite import BasicSprite
-from arcade.window_commands import get_window
-from .helpers import _generic_draw_line_strip
 from arcade.color import WHITE
+from arcade.math import rotate_point
+from arcade.sprite import BasicSprite
+from arcade.texture import Texture
+from arcade.types import LBWH, LRBT, RGBA255, XYWH, AsFloat, Color, PointList, Rect
+from arcade.window_commands import get_window
+
+from .helpers import _generic_draw_line_strip
 
 
 def draw_texture_rect(

--- a/arcade/draw/triangle.py
+++ b/arcade/draw/triangle.py
@@ -1,7 +1,8 @@
 from arcade import gl
 from arcade.types import RGBA255
-from .polygon import draw_polygon_outline
+
 from .helpers import _generic_draw_line_strip
+from .polygon import draw_polygon_outline
 
 
 def draw_triangle_filled(

--- a/arcade/easing.py
+++ b/arcade/easing.py
@@ -4,9 +4,10 @@ Functions used to support easing
 
 from __future__ import annotations
 
-from math import pi, sin, cos
 from dataclasses import dataclass
+from math import cos, pi, sin
 from typing import Callable, Optional
+
 from .math import get_distance
 
 

--- a/arcade/experimental/actor_map.py
+++ b/arcade/experimental/actor_map.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import random
 
-import arcade
-from arcade.gl import geometry
-from arcade import hitbox
 from pyglet.math import Mat4
+
+import arcade
+from arcade import hitbox
+from arcade.gl import geometry
 
 
 class ActorMap(arcade.Window):

--- a/arcade/experimental/atlas_render_into.py
+++ b/arcade/experimental/atlas_render_into.py
@@ -5,6 +5,7 @@ Render into a sub-section of a texture atlas
 from __future__ import annotations
 
 import math
+
 import arcade
 
 

--- a/arcade/experimental/atlas_replace_image.py
+++ b/arcade/experimental/atlas_replace_image.py
@@ -8,6 +8,7 @@ over time at (not too frequently) we can update the underlying atlas directly.
 from __future__ import annotations
 
 from itertools import cycle
+
 import arcade
 
 TEXTURE_PATHS = [

--- a/arcade/experimental/background/background.py
+++ b/arcade/experimental/background/background.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from arcade.window_commands import get_window
 import arcade.gl as gl
-
 from arcade.experimental.background import BackgroundTexture
+from arcade.window_commands import get_window
 
 
 class Background:

--- a/arcade/experimental/background/background_texture.py
+++ b/arcade/experimental/background/background_texture.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import Optional
 
 from PIL import Image
+from pyglet.math import Mat3
 
 import arcade.gl as gl
+from arcade import ArcadeContext
 from arcade.resources import resolve
 from arcade.window_commands import get_window
-from pyglet.math import Mat3
-from arcade import ArcadeContext
 
 
 class BackgroundTexture:

--- a/arcade/experimental/bloom_multilayer_defender.py
+++ b/arcade/experimental/bloom_multilayer_defender.py
@@ -11,13 +11,13 @@ python -m arcade.examples.defender
 
 from __future__ import annotations
 
-import arcade
 import os
 import random
 
+import arcade
+
 # --- Bloom related ---
 from arcade.experimental import postprocessing
-
 
 # Size/title of the window
 SCREEN_WIDTH = 1280

--- a/arcade/experimental/clock/clock.py
+++ b/arcade/experimental/clock/clock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+
 from arcade.experimental.clock.timer import Timer
 
 

--- a/arcade/experimental/clock/clock_window.py
+++ b/arcade/experimental/clock/clock_window.py
@@ -13,28 +13,22 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Optional
+from typing import Optional, Union
 
 import pyglet
-
 import pyglet.gl as gl
 import pyglet.window.mouse
 from pyglet.display.base import ScreenMode
 
 import arcade
-from arcade import get_display_size
-from arcade import set_viewport
-from arcade import set_window
-from arcade import NoOpenGLException
+from arcade import NoOpenGLException, SectionManager, get_display_size, set_viewport, set_window
 from arcade.color import TRANSPARENT_BLACK
 from arcade.context import ArcadeContext
-from arcade.types import Color, RGBOrA255, RGBOrANormalized
-from arcade import SectionManager
-from arcade.utils import is_raspberry_pi
 
 # NEW IMPORTS
 from arcade.experimental.clock.clock import Clock
-from typing import Union
+from arcade.types import Color, RGBOrA255, RGBOrANormalized
+from arcade.utils import is_raspberry_pi
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/experimental/clock/timer.py
+++ b/arcade/experimental/clock/timer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from typing import Callable, Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:
     from arcade.experimental.clock.clock import Clock

--- a/arcade/experimental/crt_filter.py
+++ b/arcade/experimental/crt_filter.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from arcade.experimental import Shadertoy
 from pyglet.math import Vec2
+
+from arcade.experimental import Shadertoy
 
 
 class CRTFilter:

--- a/arcade/experimental/depth_of_field.py
+++ b/arcade/experimental/depth_of_field.py
@@ -22,20 +22,19 @@ python -m arcade.experimental.examples.array_backed_grid
 
 from __future__ import annotations
 
-from typing import Optional, cast
-from textwrap import dedent
-from math import cos, pi
-from random import uniform, randint
 from contextlib import contextmanager
+from math import cos, pi
+from random import randint, uniform
+from textwrap import dedent
+from typing import Optional, cast
 
 from pyglet.graphics import Batch
 
-from arcade import get_window, Window, SpriteSolidColor, SpriteList, Text
+from arcade import SpriteList, SpriteSolidColor, Text, Window, get_window
 from arcade.color import RED
-from arcade.types import Color, RGBA255
-
-from arcade.gl import geometry, NEAREST, Program, Texture2D
 from arcade.experimental.postprocessing import GaussianBlur
+from arcade.gl import NEAREST, Program, Texture2D, geometry
+from arcade.types import RGBA255, Color
 
 
 class DepthOfField:

--- a/arcade/experimental/geo_culling_check.py
+++ b/arcade/experimental/geo_culling_check.py
@@ -8,10 +8,11 @@ Simply run the program and move draw the sprites around using the mouse.
 
 from __future__ import annotations
 
-from arcade.sprite import Sprite
-from pyglet.math import Mat4
 import PIL
+from pyglet.math import Mat4
+
 import arcade
+from arcade.sprite import Sprite
 
 
 class GeoCullingTest(arcade.Window):

--- a/arcade/experimental/light_demo.py
+++ b/arcade/experimental/light_demo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+
 import arcade
 from arcade.experimental.lights import Light, LightLayer
 

--- a/arcade/experimental/light_demo_perf.py
+++ b/arcade/experimental/light_demo_perf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import random
+
 import arcade
 from arcade.experimental.lights import Light, LightLayer
 

--- a/arcade/experimental/lights.py
+++ b/arcade/experimental/lights.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from array import array
-from typing import Iterable, Sequence, Optional
+from typing import Iterable, Optional, Sequence
 
 from arcade import gl
+from arcade.color import WHITE
 from arcade.experimental.texture_render_target import RenderTargetTexture
 from arcade.types import RGBOrA255
-from arcade.color import WHITE
 
 
 class Light:

--- a/arcade/experimental/postprocessing.py
+++ b/arcade/experimental/postprocessing.py
@@ -4,11 +4,11 @@ Post-processing shaders.
 
 from __future__ import annotations
 
-from arcade.context import ArcadeContext
-from arcade.gl.texture import Texture2D
 from arcade import get_window
-from arcade.gl import geometry
+from arcade.context import ArcadeContext
 from arcade.experimental.gaussian_kernel import gaussian_kernel
+from arcade.gl import geometry
+from arcade.gl.texture import Texture2D
 
 
 class PostProcessing:

--- a/arcade/experimental/profiling.py
+++ b/arcade/experimental/profiling.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import cProfile
 import pstats
-from io import StringIO
 from contextlib import contextmanager
+from io import StringIO
 
 
 class Profiler:

--- a/arcade/experimental/query_demo.py
+++ b/arcade/experimental/query_demo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import time
+
 import arcade
 
 # Do the math to figure out our screen dimensions

--- a/arcade/experimental/render_offscreen_animated.py
+++ b/arcade/experimental/render_offscreen_animated.py
@@ -8,9 +8,9 @@ python -m arcade.examples.shape_list_skylines
 from __future__ import annotations
 
 import random
-import arcade
 import time
 
+import arcade
 from arcade.gl import geometry
 
 SCREEN_WIDTH = 1280

--- a/arcade/experimental/shadertoy.py
+++ b/arcade/experimental/shadertoy.py
@@ -22,12 +22,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
 
-from arcade import get_window
 import arcade
+from arcade import get_window
 from arcade.context import ArcadeContext
-from arcade.gl import geometry, Texture2D
-from arcade.gl.program import Program
+from arcade.gl import Texture2D, geometry
 from arcade.gl.framebuffer import Framebuffer
+from arcade.gl.program import Program
 
 
 class ShadertoyBase:

--- a/arcade/experimental/shadertoy_demo.py
+++ b/arcade/experimental/shadertoy_demo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 import arcade
 from arcade.experimental.shadertoy import Shadertoy
 

--- a/arcade/experimental/shadertoy_video_cv2.py
+++ b/arcade/experimental/shadertoy_video_cv2.py
@@ -8,9 +8,10 @@ Dependencies:
 
 from __future__ import annotations
 
+import cv2  # type: ignore
+
 import arcade
 from arcade.experimental.shadertoy import Shadertoy
-import cv2  # type: ignore
 
 SCREEN_WIDTH = 400
 SCREEN_HEIGHT = 300

--- a/arcade/experimental/shapes_buffered_2_glow.py
+++ b/arcade/experimental/shapes_buffered_2_glow.py
@@ -10,9 +10,11 @@ python -m arcade.examples.shapes_buffered
 from __future__ import annotations
 
 import random
+
+from pyglet import gl
+
 import arcade
 from arcade.experimental import postprocessing
-from pyglet import gl
 
 # Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 1280

--- a/arcade/experimental/shapes_perf.py
+++ b/arcade/experimental/shapes_perf.py
@@ -4,12 +4,13 @@ This is for testing geometry shader shapes. Please keep.
 
 from __future__ import annotations
 
-import time
 import math
 import random
+import time
+
+from pyglet.math import Mat4
 
 import arcade
-from pyglet.math import Mat4
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600

--- a/arcade/experimental/sprite_collect_coins_minimap.py
+++ b/arcade/experimental/sprite_collect_coins_minimap.py
@@ -11,9 +11,10 @@ python -m arcade.examples.sprite_collect_coins
 
 from __future__ import annotations
 
-import random
-import arcade
 import os
+import random
+
+import arcade
 from arcade.gl import geometry
 
 # --- Constants ---

--- a/arcade/experimental/sprite_depth_cosine.py
+++ b/arcade/experimental/sprite_depth_cosine.py
@@ -17,9 +17,10 @@ python -m arcade.experimental.sprite_depth_cosine
 from __future__ import annotations
 
 import math
-import arcade
+
 from pyglet.graphics import Batch
 
+import arcade
 
 # All constants are in pixels
 WIDTH, HEIGHT = 1280, 720

--- a/arcade/experimental/subpixel_experiment.py
+++ b/arcade/experimental/subpixel_experiment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from itertools import cycle
+
 import arcade
 from arcade import gl
 

--- a/arcade/experimental/texture_render_target.py
+++ b/arcade/experimental/texture_render_target.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from arcade import get_window
-from arcade.types import RGBA255
+from arcade.color import TRANSPARENT_BLACK
 from arcade.gl import geometry
 from arcade.gl.texture import Texture2D
-from arcade.color import TRANSPARENT_BLACK
+from arcade.types import RGBA255
 
 
 class RenderTargetTexture:

--- a/arcade/experimental/texture_transforms.py
+++ b/arcade/experimental/texture_transforms.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+
 import arcade
 from arcade.texture import transforms
 

--- a/arcade/experimental/video_cv2.py
+++ b/arcade/experimental/video_cv2.py
@@ -15,9 +15,10 @@ from math import floor
 from pathlib import Path
 from typing import Union
 
+import cv2  # type: ignore
+
 import arcade
 from arcade.gl.geometry import quad_2d_fs
-import cv2  # type: ignore
 
 
 class VideoPlayerCV2:

--- a/arcade/experimental/video_player.py
+++ b/arcade/experimental/video_player.py
@@ -12,6 +12,7 @@ from typing import Optional, Union
 
 # import sys
 import pyglet
+
 import arcade
 
 

--- a/arcade/geometry.py
+++ b/arcade/geometry.py
@@ -8,8 +8,9 @@ Point in polygon function from https://www.geeksforgeeks.org/how-to-check-if-a-g
 
 from __future__ import annotations
 
-from arcade.types import Point, PointList
 from sys import maxsize as sys_int_maxsize
+
+from arcade.types import Point, PointList
 
 
 def are_polygons_intersecting(poly_a: PointList, poly_b: PointList) -> bool:

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from ctypes import byref, string_at
 import weakref
-from typing import Optional, TYPE_CHECKING
+from ctypes import byref, string_at
+from typing import TYPE_CHECKING, Optional
 
 from pyglet import gl
 
-from .utils import data_to_ctypes
 from arcade.types import BufferProtocol
+
+from .utils import data_to_ctypes
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context

--- a/arcade/gl/compute_shader.py
+++ b/arcade/gl/compute_shader.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
-from ctypes import (
-    c_char,
-    cast,
-    byref,
-    POINTER,
-    c_char_p,
-    pointer,
-    c_int,
-    create_string_buffer,
-    c_buffer,
-)
 import weakref
+from ctypes import (
+    POINTER,
+    byref,
+    c_buffer,
+    c_char,
+    c_char_p,
+    c_int,
+    cast,
+    create_string_buffer,
+    pointer,
+)
+from typing import TYPE_CHECKING, Union
 
 from pyglet import gl
+
 from .uniform import Uniform, UniformBlock
 
 if TYPE_CHECKING:

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -11,13 +11,13 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
     Tuple,
     Union,
     overload,
-    Literal,
 )
 
 import pyglet
@@ -25,6 +25,7 @@ import pyglet.gl.lib
 from pyglet import gl
 from pyglet.window import Window
 
+from ..types import BufferProtocol
 from .buffer import Buffer
 from .compute_shader import ComputeShader
 from .framebuffer import DefaultFrameBuffer, Framebuffer
@@ -34,7 +35,6 @@ from .query import Query
 from .texture import Texture2D
 from .types import BufferDescription, GLenumLike, PyGLenum
 from .vertex_array import Geometry
-from ..types import BufferProtocol
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/gl/enums.py
+++ b/arcade/gl/enums.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pyglet import gl
 
-
 # Texture min/mag filters
 NEAREST = 0x2600
 LINEAR = 0x2601

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from ctypes import c_int, string_at
-from contextlib import contextmanager
-from typing import Generator, Optional, TYPE_CHECKING
 import weakref
-
+from contextlib import contextmanager
+from ctypes import c_int, string_at
+from typing import TYPE_CHECKING, Generator, Optional
 
 from pyglet import gl
 

--- a/arcade/gl/geometry.py
+++ b/arcade/gl/geometry.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import math
 from array import array
 
-from arcade.gl import Context, BufferDescription
+from arcade.gl import BufferDescription, Context
 from arcade.gl.vertex_array import Geometry
 
 

--- a/arcade/gl/glsl.py
+++ b/arcade/gl/glsl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Optional
 import re
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from pyglet import gl
 

--- a/arcade/gl/program.py
+++ b/arcade/gl/program.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-from ctypes import (
-    c_char,
-    c_int,
-    c_buffer,
-    c_char_p,
-    cast,
-    POINTER,
-    pointer,
-    byref,
-    create_string_buffer,
-)
-from typing import Any, Iterable, TYPE_CHECKING, Union, Optional
 import typing
 import weakref
+from ctypes import (
+    POINTER,
+    byref,
+    c_buffer,
+    c_char,
+    c_char_p,
+    c_int,
+    cast,
+    create_string_buffer,
+    pointer,
+)
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 from pyglet import gl
 
-from .uniform import Uniform, UniformBlock
-from .types import AttribFormat, GLTypes, SHADER_TYPE_NAMES, PyGLenum
 from .exceptions import ShaderException
+from .types import SHADER_TYPE_NAMES, AttribFormat, GLTypes, PyGLenum
+from .uniform import Uniform, UniformBlock
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context

--- a/arcade/gl/query.py
+++ b/arcade/gl/query.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import weakref
+from typing import TYPE_CHECKING
 
 from pyglet import gl
 

--- a/arcade/gl/texture.py
+++ b/arcade/gl/texture.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from ctypes import byref, string_at
 import weakref
-from typing import Optional, Union, TYPE_CHECKING
+from ctypes import byref, string_at
+from typing import TYPE_CHECKING, Optional, Union
 
 from pyglet import gl
 
-from .buffer import Buffer
-from .utils import data_to_ctypes
-from .types import PyGLuint, pixel_formats, BufferOrBufferProtocol
 from ..types import BufferProtocol
+from .buffer import Buffer
+from .types import BufferOrBufferProtocol, PyGLuint, pixel_formats
+from .utils import data_to_ctypes
 
 if TYPE_CHECKING:  # handle import cycle caused by type hinting
     from arcade.gl import Context

--- a/arcade/gl/types.py
+++ b/arcade/gl/types.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, Iterable, Sequence, Union
-from typing_extensions import TypeAlias
+from typing import Iterable, Optional, Sequence, Union
 
 from pyglet import gl
+from typing_extensions import TypeAlias
 
-from .buffer import Buffer
 from arcade.types import BufferProtocol
 
+from .buffer import Buffer
 
 BufferOrBufferProtocol = Union[BufferProtocol, Buffer]
 

--- a/arcade/gl/uniform.py
+++ b/arcade/gl/uniform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from ctypes import cast, POINTER
+from ctypes import POINTER, cast
+
 from pyglet import gl
 
 from .exceptions import ShaderException

--- a/arcade/gl/utils.py
+++ b/arcade/gl/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from array import array
-from typing import Any
 from ctypes import c_byte
+from typing import Any
 
 
 def data_to_ctypes(data: Any) -> tuple[int, Any]:

--- a/arcade/gl/vertex_array.py
+++ b/arcade/gl/vertex_array.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from ctypes import c_void_p, byref
-from typing import Optional, Sequence, TYPE_CHECKING, Union
 import weakref
+from ctypes import byref, c_void_p
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from pyglet import gl
 
 from .buffer import Buffer
-from .types import BufferDescription, GLenumLike, GLuintLike, gl_name
 from .program import Program
+from .types import BufferDescription, GLenumLike, GLuintLike, gl_name
 
 if TYPE_CHECKING:
     from arcade.gl import Context

--- a/arcade/gui/constructs.py
+++ b/arcade/gui/constructs.py
@@ -11,7 +11,7 @@ from arcade.gui.events import UIOnActionEvent, UIOnClickEvent
 from arcade.gui.mixins import UIMouseFilterMixin
 from arcade.gui.nine_patch import NinePatchTexture
 from arcade.gui.widgets.buttons import UIFlatButton
-from arcade.gui.widgets.layout import UIBoxLayout, UIAnchorLayout
+from arcade.gui.widgets.layout import UIAnchorLayout, UIBoxLayout
 from arcade.gui.widgets.text import UITextArea
 
 

--- a/arcade/gui/experimental/password_input.py
+++ b/arcade/gui/experimental/password_input.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from arcade.gui import UIInputText, UIEvent, UITextEvent, Surface
+from arcade.gui import Surface, UIEvent, UIInputText, UITextEvent
 
 
 class UIPasswordInput(UIInputText):

--- a/arcade/gui/experimental/scroll_area.py
+++ b/arcade/gui/experimental/scroll_area.py
@@ -6,14 +6,14 @@ from pyglet.event import EVENT_UNHANDLED
 
 import arcade
 from arcade.gui import (
-    UIWidget,
     Property,
     Surface,
-    bind,
     UIEvent,
     UIMouseDragEvent,
-    UIMouseScrollEvent,
     UIMouseEvent,
+    UIMouseScrollEvent,
+    UIWidget,
+    bind,
 )
 from arcade.types import LBWH
 

--- a/arcade/gui/mixins.py
+++ b/arcade/gui/mixins.py
@@ -4,8 +4,8 @@ from typing import Optional
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
 
-from arcade.gui.widgets import UIWidget, UILayout
 from arcade.gui.events import UIMouseDragEvent, UIMouseEvent
+from arcade.gui.widgets import UILayout, UIWidget
 
 
 class UIDraggableMixin(UILayout):

--- a/arcade/gui/style.py
+++ b/arcade/gui/style.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Mapping, TypeVar, Generic, overload, Any
+from typing import Any, Generic, Mapping, TypeVar, overload
 
 from arcade.gui.property import DictProperty
 from arcade.gui.widgets import UIWidget

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Union, Optional
+from typing import Optional, Union
 
 import arcade
 from arcade import Texture
-from arcade.camera import OrthographicProjector, OrthographicProjectionData, CameraData
+from arcade.camera import CameraData, OrthographicProjectionData, OrthographicProjector
 from arcade.color import TRANSPARENT_BLACK
 from arcade.gl import Framebuffer
 from arcade.gui.nine_patch import NinePatchTexture
 from arcade.types import RGBA255, Point
-from arcade.types.rect import Rect, LBWH
+from arcade.types.rect import LBWH, Rect
 
 
 class Surface:

--- a/arcade/gui/widgets/buttons.py
+++ b/arcade/gui/widgets/buttons.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 import arcade
 from arcade import Texture
 from arcade.gui.nine_patch import NinePatchTexture
-from arcade.gui.property import bind, DictProperty
+from arcade.gui.property import DictProperty, bind
 from arcade.gui.style import UIStyleBase, UIStyledWidget
 from arcade.gui.surface import Surface
 from arcade.gui.widgets import UIInteractiveWidget

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Iterable, TypeVar, Optional, cast
+from typing import Iterable, Optional, TypeVar, cast
 
 from arcade.gui.property import bind, unbind
-from arcade.gui.widgets import UIWidget, UILayout
+from arcade.gui.widgets import UILayout, UIWidget
 
 __all__ = ["UILayout", "UIAnchorLayout", "UIBoxLayout", "UIGridLayout"]
 

--- a/arcade/gui/widgets/slider.py
+++ b/arcade/gui/widgets/slider.py
@@ -2,24 +2,24 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Union, Mapping
+from typing import Mapping, Optional, Union
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
 
 import arcade
 from arcade import Texture
 from arcade.gui import (
+    NinePatchTexture,
     Surface,
     UIEvent,
-    UIMouseDragEvent,
     UIInteractiveWidget,
-    NinePatchTexture,
+    UIMouseDragEvent,
     UIOnClickEvent,
 )
 from arcade.gui.events import UIOnChangeEvent
 from arcade.gui.property import Property, bind
 from arcade.gui.style import UIStyleBase, UIStyledWidget
-from arcade.types import Color, RGBA255
+from arcade.types import RGBA255, Color
 
 
 class UIBaseSlider(UIInteractiveWidget, metaclass=ABCMeta):

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import pyglet
-from pyglet.event import EVENT_UNHANDLED, EVENT_HANDLED
+from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
 from pyglet.text.caret import Caret
 from pyglet.text.document import AbstractDocument
 
@@ -11,13 +11,13 @@ import arcade
 from arcade import LBWH
 from arcade.gui.events import (
     UIEvent,
+    UIMouseDragEvent,
+    UIMouseEvent,
     UIMousePressEvent,
+    UIMouseScrollEvent,
     UITextEvent,
     UITextMotionEvent,
     UITextMotionSelectEvent,
-    UIMouseEvent,
-    UIMouseDragEvent,
-    UIMouseScrollEvent,
 )
 from arcade.gui.property import bind
 from arcade.gui.surface import Surface

--- a/arcade/gui/widgets/toggle.py
+++ b/arcade/gui/widgets/toggle.py
@@ -5,7 +5,7 @@ from typing import Optional
 from PIL import ImageEnhance
 
 from arcade import Texture
-from arcade.gui.events import UIOnClickEvent, UIOnChangeEvent
+from arcade.gui.events import UIOnChangeEvent, UIOnClickEvent
 from arcade.gui.property import Property, bind
 from arcade.gui.surface import Surface
 from arcade.gui.widgets import UIInteractiveWidget

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from math import cos, radians, sin
 from typing import Any
-from typing_extensions import Self
 
 from PIL.Image import Image
+from typing_extensions import Self
 
-from arcade.types import Point2, Point2List, EMPTY_POINT_LIST
+from arcade.types import EMPTY_POINT_LIST, Point2, Point2List
 
 __all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
 

--- a/arcade/hitbox/bounding_box.py
+++ b/arcade/hitbox/bounding_box.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from PIL.Image import Image
+
 from arcade.types import Point2List
+
 from .base import HitBoxAlgorithm
 
 

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from typing import Optional
-from PIL.Image import Image
+
 import pymunk
+from PIL.Image import Image
+from pymunk import Vec2d
 from pymunk.autogeometry import (
     PolylineSet,
     march_soft,
     simplify_curves,
 )
-from pymunk import Vec2d
+
 from arcade.types import Point2, Point2List
+
 from .base import HitBoxAlgorithm
 
 

--- a/arcade/hitbox/simple.py
+++ b/arcade/hitbox/simple.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from PIL.Image import Image
+
 from arcade.types import Point, Point2List
+
 from .base import HitBoxAlgorithm
 
 

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import math
 import random
 from typing import Sequence, Union
+
+from pyglet.math import Vec2
+
 from arcade.types import AsFloat, Point, Point2
 from arcade.types.rect import Rect
-from pyglet.math import Vec2
 from arcade.types.vector_like import Point3
-
 
 _PRECISION = 2
 

--- a/arcade/particles/emitter.py
+++ b/arcade/particles/emitter.py
@@ -5,11 +5,13 @@ over their lifetime
 
 from __future__ import annotations
 
+from typing import Callable, Optional, cast
+
 import arcade
-from .particle import Particle
-from typing import Optional, Callable, cast
 from arcade import Vec2
 from arcade.types import Point, Velocity
+
+from .particle import Particle
 
 
 class EmitController:

--- a/arcade/particles/emitter_simple.py
+++ b/arcade/particles/emitter_simple.py
@@ -7,12 +7,13 @@ These trade away some flexibility in favor of simplicity to allow beginners to s
 from __future__ import annotations
 
 import random
-
 from typing import Sequence, Type
-from arcade.types import Point, PathOrTexture
+
 from arcade.math import rand_in_circle, rand_on_circle
-from .particle import LifetimeParticle, FadeParticle
-from .emitter import Emitter, EmitBurst, EmitterIntervalWithTime
+from arcade.types import PathOrTexture, Point
+
+from .emitter import EmitBurst, Emitter, EmitterIntervalWithTime
+from .particle import FadeParticle, LifetimeParticle
 
 
 def make_burst_emitter(

--- a/arcade/particles/particle.py
+++ b/arcade/particles/particle.py
@@ -3,11 +3,12 @@ Particle - Object produced by an Emitter.  Often used in large quantity to produ
 """
 
 from __future__ import annotations
+
 from typing import Literal, Optional
 
+from arcade.math import clamp, lerp
 from arcade.sprite import Sprite
-from arcade.math import lerp, clamp
-from arcade.types import Point, PathOrTexture, Velocity
+from arcade.types import PathOrTexture, Point, Velocity
 
 
 class Particle(Sprite):

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -5,7 +5,7 @@ Classic A-star algorithm for path finding.
 from __future__ import annotations
 
 import math
-from typing import cast, Optional, Union
+from typing import Optional, Union, cast
 
 from arcade import Sprite, SpriteList, check_for_collision_with_list, get_sprites_at_point
 from arcade.math import get_distance, lerp_2d

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import random
 
 import pyglet.clock
-from pyglet.shapes import Line
 from pyglet.graphics import Batch
+from pyglet.shapes import Line
 
 import arcade
-from arcade.types import Color, RGBA255
+from arcade.types import RGBA255, Color
 
 __all__ = ["PerfGraph"]
 

--- a/arcade/perf_info.py
+++ b/arcade/perf_info.py
@@ -5,9 +5,9 @@ Utility functions to keep performance information
 from __future__ import annotations
 
 import collections
+import time
 
 import pyglet
-import time
 
 # Evil globals
 _timings: dict = {}

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 # pylint: disable=too-many-arguments, too-many-locals, too-few-public-methods
 import math
-
 from typing import Iterable, Optional, Union
 
 from arcade import (
@@ -20,7 +19,7 @@ from arcade.math import get_distance
 
 __all__ = ["PhysicsEngineSimple", "PhysicsEnginePlatformer"]
 
-from arcade.utils import copy_dunders_unimplemented, Chain
+from arcade.utils import Chain, copy_dunders_unimplemented
 
 
 def _wiggle_until_free(colliding: Sprite, walls: Iterable[SpriteList]) -> None:

--- a/arcade/scene.py
+++ b/arcade/scene.py
@@ -12,14 +12,13 @@ It allows you to do the following:
 
 from __future__ import annotations
 
-from typing import Optional, Union, Iterable
+from typing import Iterable, Optional, Union
+from warnings import warn
 
 from arcade import Sprite, SpriteList
-from arcade.types import Color, RGBA255
-from arcade.gl.types import OpenGlFilter, BlendFunction
+from arcade.gl.types import BlendFunction, OpenGlFilter
 from arcade.tilemap import TileMap
-
-from warnings import warn
+from arcade.types import RGBA255, Color
 
 __all__ = ["Scene", "SceneKeyError"]
 

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Iterable, Union, Generator
 import math
+from typing import TYPE_CHECKING, Generator, Iterable, Optional, Union
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED
 
@@ -10,8 +10,8 @@ from arcade.camera.default import DefaultProjector
 from arcade.types.rect import LRBT, Rect
 
 if TYPE_CHECKING:
-    from arcade.camera import Projector
     from arcade import View
+    from arcade.camera import Projector
 
 __all__ = ["Section", "SectionManager"]
 

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -8,30 +8,26 @@ the graphics card for much faster render times.
 
 from __future__ import annotations
 
-from array import array
-from collections import OrderedDict
 import itertools
 import math
+from array import array
+from collections import OrderedDict
 from typing import (
+    Generic,
     Iterable,
     Optional,
     Sequence,
     TypeVar,
-    Generic,
     cast,
 )
 
 import pyglet.gl as gl
 
-from arcade.types import Color, Point, PointList, RGBA255
-
-from arcade.utils import copy_dunders_unimplemented
-from arcade import get_window, get_points_for_thick_line
-from arcade.gl import Buffer, Geometry, BufferDescription
-from arcade.gl import Program
-from arcade import ArcadeContext
+from arcade import ArcadeContext, get_points_for_thick_line, get_window
+from arcade.gl import Buffer, BufferDescription, Geometry, Program
 from arcade.math import rotate_point
-
+from arcade.types import RGBA255, Color, Point, PointList
+from arcade.utils import copy_dunders_unimplemented
 
 __all__ = [
     "Shape",

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -9,8 +9,9 @@ import os
 from pathlib import Path
 from typing import Optional, Union
 
-from arcade.resources import resolve
 import pyglet
+
+from arcade.resources import resolve
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
     pyglet.options["audio"] = tuple(

--- a/arcade/sprite/animated.py
+++ b/arcade/sprite/animated.py
@@ -4,14 +4,15 @@ import bisect
 import math
 from typing import Optional
 
-from .sprite import Sprite
 from arcade import Texture
+
 from .enums import (
+    FACE_DOWN,
     FACE_LEFT,
     FACE_RIGHT,
     FACE_UP,
-    FACE_DOWN,
 )
+from .sprite import Sprite
 
 
 class TextureKeyframe:

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, TypeVar, Any
+from typing import TYPE_CHECKING, Any, Iterable, TypeVar
+
+from pyglet.math import Vec2
 
 import arcade
-from arcade.types import AsFloat, Point, Color, Point2, RGBA255, RGBOrA255, PointList, Rect, LRBT
 from arcade.color import BLACK, WHITE
 from arcade.hitbox import HitBox
 from arcade.texture import Texture
-from arcade.utils import copy_dunders_unimplemented, ReplacementWarning, warning
-
-from pyglet.math import Vec2
+from arcade.types import LRBT, RGBA255, AsFloat, Color, Point, Point2, PointList, Rect, RGBOrA255
+from arcade.utils import ReplacementWarning, copy_dunders_unimplemented, warning
 
 if TYPE_CHECKING:
     from arcade.sprite_list import SpriteList

--- a/arcade/sprite/colored.py
+++ b/arcade/sprite/colored.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Optional
 from weakref import WeakValueDictionary
 
@@ -13,7 +14,7 @@ from arcade.texture import (
     make_circle_texture,
     make_soft_circle_texture,
 )
-from arcade.types import Color, RGBA255
+from arcade.types import RGBA255, Color
 from arcade.types.rect import Rect
 
 from .sprite import Sprite

--- a/arcade/sprite/mixins.py
+++ b/arcade/sprite/mixins.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Optional
 
 

--- a/arcade/sprite_list/spatial_hash.py
+++ b/arcade/sprite_list/spatial_hash.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from math import trunc
 from typing import Generic
-from arcade.sprite.base import BasicSprite
-from arcade.types import Point, IPoint
+
 from arcade.sprite import SpriteType
+from arcade.sprite.base import BasicSprite
+from arcade.types import IPoint, Point
 from arcade.types.rect import Rect
 
 

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -14,16 +14,16 @@ from collections import deque
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
+    ClassVar,
     Deque,
+    Generic,
     Iterable,
     Iterator,
     Optional,
-    Union,
-    Generic,
-    Callable,
-    cast,
     Sized,
-    ClassVar,
+    Union,
+    cast,
 )
 
 from arcade import (
@@ -32,15 +32,15 @@ from arcade import (
     get_window,
     gl,
 )
-from arcade.gl import Texture2D, Program
-from arcade.types import Color, RGBA255, RGBOrANormalized, RGBANormalized
-from arcade.gl.types import OpenGlFilter, BlendFunction, PyGLenum
+from arcade.gl import Program, Texture2D
 from arcade.gl.buffer import Buffer
+from arcade.gl.types import BlendFunction, OpenGlFilter, PyGLenum
 from arcade.gl.vertex_array import Geometry
+from arcade.types import RGBA255, Color, RGBANormalized, RGBOrANormalized
 from arcade.utils import copy_dunders_unimplemented
 
 if TYPE_CHECKING:
-    from arcade import Texture, DefaultTextureAtlas
+    from arcade import DefaultTextureAtlas, Texture
     from arcade.texture_atlas import TextureAtlasBase
 
 LOG = logging.getLogger(__name__)

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -11,9 +11,9 @@ import pyglet
 
 import arcade
 from arcade.resources import resolve
-from arcade.types import Color, Point, RGBA255, RGBOrA255
-from arcade.utils import PerformanceWarning, warning
 from arcade.texture_atlas import TextureAtlasBase
+from arcade.types import RGBA255, Color, Point, RGBOrA255
+from arcade.utils import PerformanceWarning, warning
 
 __all__ = ["load_font", "Text", "create_text_sprite", "draw_text"]
 

--- a/arcade/texture/generate.py
+++ b/arcade/texture/generate.py
@@ -4,15 +4,16 @@ import logging
 from typing import Optional
 
 import PIL.Image
-import PIL.ImageOps
 import PIL.ImageDraw
+import PIL.ImageOps
 
-from arcade.types import RGBA255
-from arcade.math import lerp
+from arcade import cache
 from arcade.color import TRANSPARENT_BLACK
 from arcade.hitbox import HitBoxAlgorithm
-from arcade import cache
-from .texture import Texture, ImageData
+from arcade.math import lerp
+from arcade.types import RGBA255
+
+from .texture import ImageData, Texture
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/texture/loading.py
+++ b/arcade/texture/loading.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union
 from pathlib import Path
+from typing import Optional, Union
 
 import PIL.Image
 
-from arcade.resources import resolve
 from arcade.hitbox import HitBoxAlgorithm
-from .texture import Texture, ImageData
+from arcade.resources import resolve
+
 from .spritesheet import SpriteSheet
+from .texture import ImageData, Texture
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/texture/manager.py
+++ b/arcade/texture/manager.py
@@ -1,20 +1,21 @@
 import logging
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional, Union
 
 import PIL.Image
-import PIL.ImageOps
 import PIL.ImageDraw
+import PIL.ImageOps
 
 import arcade
 from arcade import hitbox
-from arcade.texture import ImageData, SpriteSheet
-from .texture import Texture
 from arcade.cache import (
-    TextureCache,
-    ImageDataCache,
     HitBoxCache,
+    ImageDataCache,
+    TextureCache,
 )
+from arcade.texture import ImageData, SpriteSheet
+
+from .texture import Texture
 
 LOG = logging.getLogger(__name__)
 

--- a/arcade/texture/spritesheet.py
+++ b/arcade/texture/spritesheet.py
@@ -1,6 +1,7 @@
-from PIL import Image
 from pathlib import Path
-from typing import Union, Optional, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, Optional, Union
+
+from PIL import Image
 
 # from arcade import Texture
 from arcade.texture import Texture

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any, Optional, Type, Union
 from pathlib import Path
+from typing import Any, Optional, Type, Union
 
 import PIL.Image
 import PIL.ImageDraw
@@ -23,7 +23,6 @@ from arcade.texture.transforms import (
     TransposeTransform,
     TransverseTransform,
 )
-
 from arcade.types import RGBA255, Point2List
 
 # from arcade.types.rect import Rect

--- a/arcade/texture/tools.py
+++ b/arcade/texture/tools.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from PIL import Image, ImageDraw
+
 import arcade
 import arcade.cache
-from .texture import ImageData, Texture
 from arcade.types import Size2D
+
+from .texture import ImageData, Texture
 
 _DEFAULT_TEXTURE = None
 _DEFAULT_IMAGE_SIZE = (128, 128)

--- a/arcade/texture/transforms.py
+++ b/arcade/texture/transforms.py
@@ -9,6 +9,7 @@ transform the texture coordinates and hit box points.
 from __future__ import annotations
 
 from enum import Enum
+
 from arcade.math import rotate_point
 from arcade.types import Point2List
 

--- a/arcade/texture_atlas/atlas_array.py
+++ b/arcade/texture_atlas/atlas_array.py
@@ -3,9 +3,9 @@ THIS IS WORK IN PROGRESS. DO NOT USE.
 """
 
 from typing import (
-    Tuple,
     TYPE_CHECKING,
     Optional,
+    Tuple,
 )
 
 from .base import TextureAtlasBase

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -1,17 +1,17 @@
+import contextlib
 import copy
-import time
 import logging
+import time
 from pathlib import Path
 from typing import (
-    Dict,
-    Optional,
-    Tuple,
-    Sequence,
-    Union,
     TYPE_CHECKING,
+    Dict,
     List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
 )
-import contextlib
 from weakref import WeakSet, WeakValueDictionary, finalize
 
 import PIL.Image
@@ -22,17 +22,17 @@ from pyglet.image.atlas import (
 )
 from pyglet.math import Mat4
 
-from arcade.window_commands import get_window
-from arcade.texture.transforms import Transform
 from arcade.camera.static import static_from_raw_orthographic
+from arcade.texture.transforms import Transform
+from arcade.window_commands import get_window
 
+from .base import TextureAtlasBase
 from .ref_counters import (
     ImageDataRefCounter,
     UniqueTextureRefCounter,
 )
-from .base import TextureAtlasBase
-from .uv_data import UVData
 from .region import AtlasRegion
+from .uv_data import UVData
 
 if TYPE_CHECKING:
     from arcade import ArcadeContext, Texture

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -28,18 +28,20 @@ from __future__ import annotations
 import abc
 import contextlib
 from typing import (
+    TYPE_CHECKING,
     Optional,
     Tuple,
-    TYPE_CHECKING,
 )
+
 import PIL.Image
+
 import arcade
 
 if TYPE_CHECKING:
     from arcade import ArcadeContext, Texture
+    from arcade.gl import Framebuffer, Texture2D
     from arcade.texture import ImageData
     from arcade.texture_atlas import AtlasRegion
-    from arcade.gl import Framebuffer, Texture2D
 
 # The amount of pixels we increase the atlas when scanning for a reasonable size.
 # It must be a power of two number like 64, 256, 512 ..

--- a/arcade/texture_atlas/ref_counters.py
+++ b/arcade/texture_atlas/ref_counters.py
@@ -8,11 +8,10 @@ Reference counters for tracking textures and images in an atlas
   simply a texture using the same image and the same vertex order.
 """
 
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
-    from arcade.texture import Texture
-    from arcade.texture import ImageData
+    from arcade.texture import ImageData, Texture
 
 
 class ImageDataRefCounter:

--- a/arcade/texture_atlas/region.py
+++ b/arcade/texture_atlas/region.py
@@ -3,7 +3,8 @@ Metadata about where an image is located in the atlas.
 """
 
 from typing import TYPE_CHECKING, Optional
-from .base import TextureAtlasBase, TexCoords
+
+from .base import TexCoords, TextureAtlasBase
 
 if TYPE_CHECKING:
     from arcade.texture import ImageData

--- a/arcade/texture_atlas/uv_data.py
+++ b/arcade/texture_atlas/uv_data.py
@@ -2,9 +2,9 @@
 A helper class to keep track of texture coordinates stored in a texture.
 """
 
-from typing import TYPE_CHECKING, Dict
 from array import array
 from collections import deque
+from typing import TYPE_CHECKING, Dict
 
 from .base import (
     UV_TEXTURE_WIDTH,

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -20,16 +20,16 @@ import pytiled_parser
 import pytiled_parser.tiled_object
 from pytiled_parser import Color
 
+import arcade
 from arcade import (
-    TextureAnimationSprite,
-    TextureKeyframe,
-    TextureAnimation,
     Sprite,
     SpriteList,
+    TextureAnimation,
+    TextureAnimationSprite,
+    TextureKeyframe,
     get_window,
 )
 from arcade.hitbox import HitBoxAlgorithm, RotatableHitBox
-import arcade
 
 if TYPE_CHECKING:
     from arcade import DefaultTextureAtlas, Texture

--- a/arcade/types/color.py
+++ b/arcade/types/color.py
@@ -21,12 +21,11 @@ named color values, please see the following:
 from __future__ import annotations
 
 import random
-from typing import Iterable, Optional, Union, TypeVar
+from typing import Iterable, Optional, TypeVar, Union
 
-from typing_extensions import Self, Final
+from typing_extensions import Final, Self
 
 from arcade.utils import ByteRangeError, IntOutsideRangeError, NormalizedRangeError
-
 
 __all__ = (
     "Color",

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -1,6 +1,7 @@
 """Rects all act the same, but take four of the possible eight attributes and calculate the rest."""
 
 from __future__ import annotations
+
 import math
 from typing import NamedTuple, Optional, TypedDict
 

--- a/arcade/types/vector_like.py
+++ b/arcade/types/vector_like.py
@@ -9,7 +9,7 @@ This is a submodule of :py:mod:`arcade.types` to avoid issues with:
 
 from __future__ import annotations
 
-from typing import Union, Sequence
+from typing import Sequence, Union
 
 from pyglet.math import Vec2, Vec3
 

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -11,9 +11,8 @@ import platform
 import sys
 import warnings
 from itertools import chain
-from typing import Type, TypeVar, Generator, Generic, Sequence
 from pathlib import Path
-
+from typing import Generator, Generic, Sequence, Type, TypeVar
 
 _CT = TypeVar('_CT')  # Comparable type, ie supports the <= operator
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import gc
 import os
+from typing import TYPE_CHECKING, Callable, Optional
 
 import pyglet
 
-from typing import Callable, Optional, TYPE_CHECKING
 from arcade.types import RGBA255, Color
 
 if TYPE_CHECKING:

--- a/make.py
+++ b/make.py
@@ -14,11 +14,11 @@ For help, see the following:
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
-from shutil import which, rmtree
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Union, Generator, Optional
+from shutil import rmtree, which
+from typing import Generator, Optional, Union
 
 PathLike = Union[Path, str, bytes]
 
@@ -47,13 +47,16 @@ FULL_BUILD_DIR = PROJECT_ROOT / FULL_BUILD_PREFIX
 
 # Linting
 RUFF = "ruff"
-RUFFOPTS = ["check", "arcade"]
+RUFFOPTS = ["check"]
+RUFFOPTS_ISORT = ["check", "--select", "I"]
+RUFFOPTS_PACKAGE = "arcade"
 MYPY = "mypy"
 MYPYOPTS = ["arcade"]
 PYRIGHT = "pyright"
 PYRIGHTOPTS = []
 BLACK = "black"
 BLACKOPTS = ["arcade"]
+ISORTOPTS = ["check", "--select", "I"]
 
 # Testing
 PYTEST = "pytest"
@@ -467,7 +470,7 @@ def lint():
 
 @app.command(rich_help_panel="Code Quality")
 def ruff():
-    run([RUFF, *RUFFOPTS])
+    run([RUFF, *RUFFOPTS, RUFFOPTS_PACKAGE])
     print("Ruff Finished.")
 
 
@@ -489,7 +492,16 @@ def pyright():
 def format(check: bool = False):
     "Format code using black"
     black(check)
+    isort(check)
     print("Formatting Complete.")
+
+
+@app.command(rich_help_panel="Code Quality")
+def isort(check: bool = False):
+    "Format code using isort(actually ruff)"
+    if not check:
+        RUFFOPTS_ISORT.append("--fix")
+    run([RUFF, *RUFFOPTS_ISORT, RUFFOPTS_PACKAGE])
 
 
 @app.command(rich_help_panel="Code Quality")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,13 @@ lint.select = [
     "W",
 ]
 
+# This ignores __init__.py files and examples for import sorting
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["I"]
+"arcade/examples/*" = ["I"]
+"arcade/gui/examples/*" = ["I"]
+"util/*" = ["I"]
+"benchmarks/*" = ["I"]
 
 [tool.mypy]
 disable_error_code = "annotation-unchecked"


### PR DESCRIPTION
Does an initial pass to sort all imports with ruff(isort).

Excludes any `__init__.py` file, as well as example files.

Sorting the imports of `__init__.py` files is a bit untenable at the moment, the order of imports in those files is very fragile, and moving almost any of them is likely to cause a circular dependency error. This also adds a new `make.py isort` command for sorting the imports(similar supports a `--check` option like black).

This functionality has also been added to the `make.py format` command, and as such is covered by GitHub CI now. Running `make.py format` will first run black, and then run import sorting.