### PR TITLE
Atlas tweaks again

### DIFF
--- a/arcade/gui/nine_patch.py
+++ b/arcade/gui/nine_patch.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import arcade
 import arcade.gl as gl
-from arcade.types.rect import Rect
 
 
 class NinePatchTexture:
@@ -96,7 +95,7 @@ class NinePatchTexture:
         # References for the texture
         self._atlas = atlas or self.ctx.default_atlas
         self._texture = texture
-        self._set_texture(texture)
+        self._add_to_atlas(texture)
 
         # pixel texture co-ordinate start and end of central box.
         self._left = left
@@ -105,15 +104,6 @@ class NinePatchTexture:
         self._top = top
 
         self._check_sizes()
-
-    @classmethod
-    def from_rect(
-        cls, rect: Rect, texture: arcade.Texture, atlas: Optional[arcade.DefaultTextureAtlas] = None
-    ) -> NinePatchTexture:
-        """Construct a new SpriteSolidColor from a :py:class:`~arcade.types.rect.Rect`."""
-        return cls(
-            int(rect.left), int(rect.right), int(rect.bottom), int(rect.top), texture, atlas=atlas
-        )
 
     @property
     def ctx(self) -> arcade.ArcadeContext:
@@ -127,7 +117,8 @@ class NinePatchTexture:
 
     @texture.setter
     def texture(self, texture: arcade.Texture):
-        self._set_texture(texture)
+        self._texture = texture
+        self._add_to_atlas(texture)
 
     @property
     def program(self) -> gl.program.Program:
@@ -142,7 +133,7 @@ class NinePatchTexture:
     def program(self, program: gl.program.Program):
         self._program = program
 
-    def _set_texture(self, texture: arcade.Texture):
+    def _add_to_atlas(self, texture: arcade.Texture):
         """
         Internal method for setting the texture.
 
@@ -150,7 +141,6 @@ class NinePatchTexture:
         """
         if not self._atlas.has_texture(texture):
             self._atlas.add(texture)
-        self._texture = texture
 
     @property
     def left(self) -> int:

--- a/arcade/resources/system/shaders/gui/nine_patch_gs.glsl
+++ b/arcade/resources/system/shaders/gui/nine_patch_gs.glsl
@@ -65,20 +65,28 @@ void main() {
     //     )
     // Get texture coordinates
     vec2 uv0, uv1, uv2, uv3;
-    getSpriteUVs(uv_texture, int(texture_id), uv0, uv1, uv2, uv3);
     vec2 atlas_size = vec2(textureSize(sprite_texture, 0));
-    // Corner offsets (upper left, upper, right, lower left, lower right)
-    // This is the global texture coordiante offset in the entire atlas
+    getSpriteUVs(uv_texture, int(texture_id), uv0, uv1, uv2, uv3);
+    // TODO: Do center pixel interpolation. Revert by 0.5 pixels for now
+    vec2 half_px = 0.5 / atlas_size;
+    uv0 -= half_px;
+    uv1 += vec2(half_px.x, -half_px.y);
+    uv2 += vec2(-half_px.x, half_px.y);
+    uv3 += half_px;
+
+    // Local corner offsets in pixels
     float left = start.x;
     float right = t_size.x - end.x;
     float top = t_size.y - end.y;
     float bottom = start.y;
+    // UV offsets to the inner rectangle in the patch
+    // This is the global texture coordiante offset in the entire atlas
+    vec2 c1 = vec2(left, top) / atlas_size;      // Upper left corner
+    vec2 c2 = vec2(right, top) / atlas_size;     // Upper right corner
+    vec2 c3 = vec2(left, bottom) / atlas_size;   // Lower left corner
+    vec2 c4 = vec2(right, bottom) / atlas_size;  // Lower right corner
 
-    vec2 c1 = vec2(left, top) / atlas_size;
-    vec2 c2 = vec2(right, top) / atlas_size;
-    vec2 c3 = vec2(left, bottom) / atlas_size;
-    vec2 c4 = vec2(right, bottom) / atlas_size;
-
+    // Texture coordinates for all the points in the patch
     vec2 t1 = uv0;
     vec2 t2 = uv0 + vec2(c1.x, 0.0);
     vec2 t3 = uv1 - vec2(c2.x, 0.0);
@@ -100,9 +108,8 @@ void main() {
     vec2 t16 = uv3;
 
     mat4 mvp = window.projection * window.view;
-    // First row - two fixed corners + strechy middle - 8 vertices
-    // NOTE: This should ideally be done with 3 strips
-    // Upper left corner
+    // First row - two fixed corners + strechy middle
+    // Upper left corner. Fixed size.
     gl_Position = mvp * vec4(p1, 0.0, 1.0);
     uv = t1;
     EmitVertex();
@@ -117,7 +124,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // Upper middle part
+    // Upper middle part streches on x axis
     gl_Position = mvp * vec4(p2, 0.0, 1.0);
     uv = t2;
     EmitVertex();
@@ -132,7 +139,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // Upper right corner
+    // Upper right corner. Fixed size
     gl_Position = mvp * vec4(p3, 0.0, 1.0);
     uv = t3;
     EmitVertex();
@@ -147,8 +154,8 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // middle row - three strechy parts - 8 vertices
-    // left border
+    // Middle row: Two strechy sides + strechy middle
+    // left border steching on y axis
     gl_Position = mvp * vec4(p5, 0.0, 1.0);
     uv = t5;
     EmitVertex();
@@ -163,7 +170,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
   
-    // Center area
+    // Center strechy area
     gl_Position = mvp * vec4(p6, 0.0, 1.0);
     uv = t6;
     EmitVertex();
@@ -178,7 +185,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // Right border
+    // Right border. Steches on y axis
     gl_Position = mvp * vec4(p7, 0.0, 1.0);
     uv = t7;
     EmitVertex();
@@ -193,8 +200,8 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // last row - two fixed corners + strechy middle - 8 vertices
-    // Lower left corner
+    // Bottom row: two fixed corners + strechy middle
+    // Lower left corner. Fixed size
     gl_Position = mvp * vec4(p9, 0.0, 1.0);
     uv = t9;
     EmitVertex();
@@ -209,7 +216,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // Lower middle part
+    // Lower middle part. Streches on x axis
     gl_Position = mvp * vec4(p10, 0.0, 1.0);
     uv = t10;
     EmitVertex();
@@ -224,7 +231,7 @@ void main() {
     EmitVertex();
     EndPrimitive();
 
-    // Lower right corner
+    // Lower right corner. Fixed size
     gl_Position = mvp * vec4(p11, 0.0, 1.0);
     uv = t11;
     EmitVertex();

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -593,7 +593,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         """Check if an image is already in the atlas"""
         return image_data.hash in self._images
 
-    def resize(self, size: Tuple[int, int]) -> None:
+    def resize(self, size: Tuple[int, int], force=False) -> None:
         """
         Resize the atlas.
 
@@ -607,12 +607,13 @@ class DefaultTextureAtlas(TextureAtlasBase):
         undefined state.
 
         :param size: The new size
+        :param force: Force a resize even if the size is the same
         """
         LOG.info("[%s] Resizing atlas from %s to %s", id(self), self._size, size)
         # print("Resizing atlas from", self._size, "to", size)
 
         # Only resize if the size actually changed
-        if size == self._size:
+        if size == self._size and not force:
             return
 
         self._check_size(size)
@@ -620,6 +621,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
 
         # Keep a reference to the old atlas texture so we can copy it into the new one
         atlas_texture_old = self._texture
+        atlas_texture_old.filter = self._ctx.NEAREST, self._ctx.NEAREST
         self._size = size
 
         # Create new image uv data temporarily keeping the old one

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -5,11 +5,8 @@ import time
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Dict,
-    List,
     Optional,
     Sequence,
-    Tuple,
     Union,
 )
 from weakref import WeakSet, WeakValueDictionary, finalize
@@ -94,7 +91,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
 
     def __init__(
         self,
-        size: Tuple[int, int],
+        size: tuple[int, int],
         *,
         border: int = 1,
         textures: Optional[Sequence["Texture"]] = None,
@@ -104,7 +101,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
     ):
         self._ctx = ctx or get_window().ctx
         self._max_size = self._ctx.info.MAX_VIEWPORT_DIMS
-        self._size: Tuple[int, int] = size
+        self._size: tuple[int, int] = size
         self._allocator = Allocator(*self._size)
         self._auto_resize = auto_resize
         self._capacity = capacity
@@ -143,8 +140,8 @@ class DefaultTextureAtlas(TextureAtlasBase):
         # The texture regions are clones of the image regions with transforms applied
         # in order to map the same image using different orders or texture coordinates.
         # The key is the cache name for a texture
-        self._image_regions: Dict[str, AtlasRegion] = dict()
-        self._texture_regions: Dict[str, AtlasRegion] = dict()
+        self._image_regions: dict[str, AtlasRegion] = dict()
+        self._texture_regions: dict[str, AtlasRegion] = dict()
 
         # Ref counter for images and textures. Per atlas we need to keep
         # track of ho many times an image is used in textures to determine
@@ -162,7 +159,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         # All textures added to the atlas
         self._textures: WeakSet[Texture] = WeakSet()
         # atlas_name: Set of textures with matching atlas name
-        self._unique_textures: Dict[str, WeakSet["Texture"]] = dict()
+        self._unique_textures: dict[str, WeakSet["Texture"]] = dict()
 
         # Add all the textures
         for tex in textures or []:
@@ -187,7 +184,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         return self._max_size[1]
 
     @property
-    def max_size(self) -> Tuple[int, int]:
+    def max_size(self) -> tuple[int, int]:
         """
         The maximum size of the atlas in pixels (x, y)
         """
@@ -227,7 +224,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         return self._texture_uvs.texture
 
     @property
-    def textures(self) -> List["Texture"]:
+    def textures(self) -> list["Texture"]:
         """
         All textures instance added to the atlas regardless
         of their internal state. See :py:meth:`unique_textures``
@@ -236,7 +233,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         return list(self._textures)
 
     @property
-    def unique_textures(self) -> List["Texture"]:
+    def unique_textures(self) -> list["Texture"]:
         """
         All unique textures in the atlas.
 
@@ -245,7 +242,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         can be found in :py:meth:`textures`.
         """
         # Grab the first texture from each set
-        textures: List[Texture] = []
+        textures: list[Texture] = []
         for tex_set in self._unique_textures.values():
             if len(tex_set) == 0:
                 raise RuntimeError("Empty set in unique textures")
@@ -253,7 +250,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         return textures
 
     @property
-    def images(self) -> List["ImageData"]:
+    def images(self) -> list["ImageData"]:
         """
         Return a list of all the images in the atlas.
 
@@ -261,7 +258,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         """
         return list(self._images.values())
 
-    def add(self, texture: "Texture") -> Tuple[int, AtlasRegion]:
+    def add(self, texture: "Texture") -> tuple[int, AtlasRegion]:
         """
         Add a texture to the atlas.
 
@@ -271,7 +268,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         """
         return self._add(texture)
 
-    def _add(self, texture: "Texture", create_finalizer=True) -> Tuple[int, AtlasRegion]:
+    def _add(self, texture: "Texture", create_finalizer=True) -> tuple[int, AtlasRegion]:
         """
         Internal add method with additional control. We we rebuild the atlas
         we don't want to create finalizers for the texture or they will be
@@ -367,7 +364,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
             "and let the python garbage collector handle the removal."
         )
 
-    def _allocate_texture(self, texture: "Texture") -> Tuple[int, AtlasRegion]:
+    def _allocate_texture(self, texture: "Texture") -> tuple[int, AtlasRegion]:
         """
         Add or update a unique texture in the atlas.
         This is mainly responsible for updating the texture coordinates
@@ -391,7 +388,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
 
         return slot, texture_region
 
-    def _allocate_image(self, image_data: "ImageData") -> Tuple[int, int, int, AtlasRegion]:
+    def _allocate_image(self, image_data: "ImageData") -> tuple[int, int, int, AtlasRegion]:
         """
         Attempts to allocate space for an image in the atlas or
         update the existing space for the image.
@@ -593,7 +590,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         """Check if an image is already in the atlas"""
         return image_data.hash in self._images
 
-    def resize(self, size: Tuple[int, int], force=False) -> None:
+    def resize(self, size: tuple[int, int], force=False) -> None:
         """
         Resize the atlas.
 
@@ -731,7 +728,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
     def render_into(
         self,
         texture: "Texture",
-        projection: Optional[Tuple[float, float, float, float]] = None,
+        projection: Optional[tuple[float, float, float, float]] = None,
     ):
         """
         Render directly into a sub-section of the atlas.
@@ -814,7 +811,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         flip: bool = False,
         components: int = 4,
         draw_borders: bool = False,
-        border_color: Tuple[int, int, int] = (255, 0, 0),
+        border_color: tuple[int, int, int] = (255, 0, 0),
     ) -> Image.Image:
         """
         Convert the atlas to a Pillow image.
@@ -856,7 +853,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         flip: bool = False,
         components: int = 4,
         draw_borders: bool = False,
-        border_color: Tuple[int, int, int] = (255, 0, 0),
+        border_color: tuple[int, int, int] = (255, 0, 0),
     ) -> None:
         """
         Show the texture atlas using Pillow.
@@ -882,7 +879,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         flip: bool = False,
         components: int = 4,
         draw_borders: bool = False,
-        border_color: Tuple[int, int, int] = (255, 0, 0),
+        border_color: tuple[int, int, int] = (255, 0, 0),
     ) -> None:
         """
         Save the texture atlas to a png.
@@ -903,7 +900,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
             border_color=border_color,
         ).save(path, format="png")
 
-    def _check_size(self, size: Tuple[int, int]) -> None:
+    def _check_size(self, size: tuple[int, int]) -> None:
         """Check it the atlas exceeds the hardware limitations"""
         if size[0] > self._max_size[0] or size[1] > self._max_size[1]:
             raise Exception(

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 
 import abc
 import contextlib
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Optional,
     Union,
 )
-from pathlib import Path
 
 import PIL.Image
 

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -30,8 +30,9 @@ import contextlib
 from typing import (
     TYPE_CHECKING,
     Optional,
-    Tuple,
+    Union,
 )
+from pathlib import Path
 
 import PIL.Image
 
@@ -40,15 +41,15 @@ import arcade
 if TYPE_CHECKING:
     from arcade import ArcadeContext, Texture
     from arcade.gl import Framebuffer, Texture2D
-    from arcade.texture import ImageData
-    from arcade.texture_atlas import AtlasRegion
+    from arcade.texture.texture import ImageData
+    from arcade.texture_atlas.region import AtlasRegion
 
 # The amount of pixels we increase the atlas when scanning for a reasonable size.
 # It must be a power of two number like 64, 256, 512 ..
 RESIZE_STEP = 128
 UV_TEXTURE_WIDTH = 4096
 # Texture coordinates for a texture (4 x vec2)
-TexCoords = Tuple[float, float, float, float, float, float, float, float]
+TexCoords = tuple[float, float, float, float, float, float, float, float]
 
 
 class TextureAtlasBase(abc.ABC):
@@ -65,7 +66,7 @@ class TextureAtlasBase(abc.ABC):
 
     def __init__(self, ctx: Optional["ArcadeContext"]):
         self._ctx = ctx or arcade.get_window().ctx
-        self._size: Tuple[int, int] = 0, 0
+        self._size: tuple[int, int] = 0, 0
         self._layers: int = 1
 
     @property
@@ -109,14 +110,14 @@ class TextureAtlasBase(abc.ABC):
         return self._layers
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """The width and height of the texture atlas in pixels"""
         return self._size
 
     # --- Core ---
 
     @abc.abstractmethod
-    def add(self, texture: "Texture") -> Tuple[int, AtlasRegion]:
+    def add(self, texture: "Texture") -> tuple[int, AtlasRegion]:
         """
         Add a texture to the atlas.
 
@@ -235,7 +236,7 @@ class TextureAtlasBase(abc.ABC):
     def render_into(
         self,
         texture: "Texture",
-        projection: Optional[Tuple[float, float, float, float]] = None,
+        projection: Optional[tuple[float, float, float, float]] = None,
     ):
         """
         Render directly into a sub-section of the atlas.
@@ -316,7 +317,13 @@ class TextureAtlasBase(abc.ABC):
     # --- Debugging ---
 
     @abc.abstractmethod
-    def to_image(self) -> PIL.Image.Image:
+    def to_image(
+        self,
+        flip: bool = False,
+        components: int = 4,
+        draw_borders: bool = False,
+        border_color: tuple[int, int, int] = (255, 0, 0),
+    ) -> PIL.Image.Image:
         """
         Convert the atlas to a Pillow image.
 
@@ -332,7 +339,13 @@ class TextureAtlasBase(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def show(self) -> None:
+    def show(
+        self,
+        flip: bool = False,
+        components: int = 4,
+        draw_borders: bool = False,
+        border_color: tuple[int, int, int] = (255, 0, 0),
+    ) -> None:
         """
         Show the texture atlas using Pillow.
 
@@ -344,7 +357,35 @@ class TextureAtlasBase(abc.ABC):
         :param draw_borders: Draw region borders into image
         :param color: RGB color of the borders
         """
+        self.to_image(
+            flip=flip,
+            components=components,
+            draw_borders=draw_borders,
+            border_color=border_color,
+        ).show()
         ...
+
+    @abc.abstractmethod
+    def save(
+        self,
+        path: Union[str, Path],
+        flip: bool = False,
+        components: int = 4,
+        draw_borders: bool = False,
+        border_color: tuple[int, int, int] = (255, 0, 0),
+    ) -> None:
+        """
+        Save the texture atlas to a png.
+
+        Borders can also be drawn into the image to visualize the
+        regions of the atlas.
+
+        :param path: The path to save the atlas on disk
+        :param flip: Flip the image horizontally
+        :param components: Number of components. (3 = RGB, 4 = RGBA)
+        :param color: RGB color of the borders
+        :return: A pillow image containing the atlas texture
+        """
 
 
 __all__ = (

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -141,7 +141,7 @@ class TextureAtlasBase(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def resize(self, *args, **kwargs) -> None:
+    def resize(self, size: tuple[int, int], force=False) -> None:
         """
         Resize the atlas.
 
@@ -155,6 +155,7 @@ class TextureAtlasBase(abc.ABC):
         undefined state.
 
         :param size: The new size
+        :param force: Force a resize even if the size is the same
         """
         ...
 

--- a/arcade/texture_atlas/region.py
+++ b/arcade/texture_atlas/region.py
@@ -108,7 +108,7 @@ class AtlasRegion:
         at any point causing an atlas update to fail.
         """
         if image_data.size != (self.width, self.height):
-            raise ValueError(
+            raise RuntimeError(
                 (
                     f"ImageData '{image_data.hash}' change their internal image "
                     f"size from {self.width}x{self.height} to "

--- a/arcade/texture_atlas/region.py
+++ b/arcade/texture_atlas/region.py
@@ -78,20 +78,26 @@ class AtlasRegion:
             # Width and height
             _width = self.width / atlas.width
             _height = self.height / atlas.height
+            # Half pixel correction
+            hp_x, hp_y = 0.5 / atlas.width, 0.5 / atlas.height
+            # Upper left corner. Note that are mapping the texture upside down and corners
+            # are named as from the vertex position point of view.
+            ul_x, ul_y = self.x / atlas.width, self.y / atlas.height
+
             # upper_left, upper_right, lower_left, lower_right
             self.texture_coordinates = (
                 # upper_left
-                self.x / atlas.width,
-                self.y / atlas.height,
+                ul_x + hp_x,
+                ul_y + hp_y,
                 # upper_right
-                (self.x / atlas.width) + _width,
-                (self.y / atlas.height),
+                ul_x + _width - hp_x,
+                ul_y + hp_y,
                 # lower_left
-                (self.x / atlas.width),
-                (self.y / atlas.height) + _height,
+                ul_x + hp_x,
+                ul_y + _height - hp_y,
                 # lower_right
-                (self.x / atlas.width) + _width,
-                (self.y / atlas.height) + _height,
+                ul_x + _width - hp_x,
+                ul_y + _height - hp_y,
             )
 
     def verify_image_size(self, image_data: "ImageData"):

--- a/tests/unit/atlas/test_region.py
+++ b/tests/unit/atlas/test_region.py
@@ -1,0 +1,43 @@
+"""Test AtlasRegion class."""
+import pytest   
+import PIL.Image
+
+from arcade.texture_atlas.region import AtlasRegion
+from arcade.texture.texture import Texture, ImageData
+from arcade.texture_atlas.atlas_default import DefaultTextureAtlas
+
+
+def test_region_coordinates(ctx):
+    """Test region class."""
+    atlas = DefaultTextureAtlas(size=(8, 8), border=0, auto_resize=False)
+    region = AtlasRegion(atlas=atlas, x=0, y=0, width=8, height=8)
+    assert region.x == 0
+    assert region.y == 0
+    assert region.width == 8
+    assert region.height == 8
+    # Simulate the half pixel location
+    a, b = 0.5 / 8, 1 - 0.5 / 8
+    assert region.texture_coordinates == (
+        a, a,
+        b, a,
+        a, b,
+        b, b,
+    )
+    # Above raw values:
+    # (
+    #     0.0625, 0.0625,
+    #     0.9375, 0.0625,
+    #     0.0625, 0.9375,
+    #     0.9375, 0.9375)
+    # )
+
+
+def test_verify_size(ctx):
+    im_data = ImageData(PIL.Image.new("RGBA", (8, 8)))
+    texture = Texture(im_data)
+    region = AtlasRegion(atlas=ctx.default_atlas, x=0, y=0, width=8, height=8)
+
+    region.verify_image_size(im_data)
+    im_data = ImageData(PIL.Image.new("RGBA", (9, 9)))
+    with pytest.raises(RuntimeError):
+        region.verify_image_size(im_data)

--- a/tests/unit/gui/test_ninepatch.py
+++ b/tests/unit/gui/test_ninepatch.py
@@ -1,6 +1,7 @@
 import pytest
 from arcade.gui import NinePatchTexture
 import arcade
+from pyglet.math import Vec2
 
 # ":resources:gui_basic_assets/button_square_blue_pressed.png"
 # ":resources:gui_basic_assets/button_square_blue.png"
@@ -69,3 +70,86 @@ def test_draw_position(ctx, texture):
     patch.draw_sized(size=(200, 200), position=(200, 200))
     patch.draw_sized(size=(200, 200), position=(400, 400))
     # arcade.get_image().save("test_draw_position.png")
+
+
+def shader_math():
+    """
+    This is just around to debug shader math.
+    The shader needs to be simplified at some point.
+    """
+    atlas_size = Vec2(8, 8)
+    atlas_size_uniform = 8
+    # 8 x x texture
+    uv0 = Vec2(0.0625, 0.0625)  # upper_left
+    uv1 = Vec2(0.9375, 0.0625)  # upper_right
+    uv2 = Vec2(0.0625, 0.9375)  # lower_left
+    uv3 = Vec2(0.9375, 0.9375)  # lower_right
+
+    # Initial borders per side
+    left, right, top, bottom = 1, 1, 1, 1
+
+    # The size of the patch
+    size = Vec2(8, 8)
+    # The inner area of the patch
+    start = Vec2(left, bottom)
+    end = Vec2(size.x - right, size.y - top)
+    # Size of the patch texture
+    t_size = Vec2(8, 8)
+
+    # Borders adjusted rectangle (and reverse y axis)
+    left = start.x
+    right = t_size.x - end.x
+    top = t_size.y - end.y
+    bottom = start.y
+
+    c1 = Vec2(left, top) / atlas_size_uniform
+    # Upper left corner
+    c2 = Vec2(right, top) / atlas_size_uniform
+    # Upper right corner
+    c3 = Vec2(left, bottom) / atlas_size_uniform
+    # Lower left corner
+    c4 = Vec2(right, bottom) / atlas_size_uniform
+    # Lower right corner
+
+    print("--- left, right, bottom, top ---")
+    print(left, right, top, bottom)
+    print("--- corners ---")
+    print("c1:", c1, 1 / c1.x, 1 / c1.y)
+    print("c2:", c2, 1 / c2.x, 1 / c2.y)
+    print("c3:", c3, 1 / c3.x, 1 / c3.y)
+    print("c4:", c4, 1 / c4.x, 1 / c4.y)
+
+    t1 = uv0
+    t2 = uv0 + Vec2(c1.x, 0.0)
+    t3 = uv1 - Vec2(c2.x, 0.0)
+    t4 = uv1
+
+    t5 = uv0 + Vec2(0.0, c1.y)
+    t6 = uv0 + c1
+    t7 = uv1 + Vec2(-c2.x, c2.y)
+    t8 = uv1 + Vec2(0.0, c2.y)
+
+    t9 = uv2 - Vec2(0.0, c3.y)
+    t10 = uv2 + Vec2(c3.x, -c3.y)
+    t11 = uv3 - c4
+    t12 = uv3 - Vec2(0.0, c4.y)
+
+    t13 = uv2
+    t14 = uv2 + Vec2(c3.x, 0.0)
+    t15 = uv3 - Vec2(c4.x, 0.0)
+    t16 = uv3
+
+    print("--- row 1 ---")
+    print(t1, t5, t2, t6)
+    print(t2, t6, t3, t7)
+    print(t3, t7, t4, t8)
+
+    print("--- row 2 ---")
+    print(t5, t9, t6, t10)
+    print(t6, t10, t7, t11)
+    print(t7, t11, t8, t12)
+
+    print("--- row 3 ---")
+    print(t9, t13, t10, t14)
+    print(t10, t14, t11, t15)
+    print(t11, t15, t12, t16)

--- a/tests/unit/gui/test_ninepatch_draw.py
+++ b/tests/unit/gui/test_ninepatch_draw.py
@@ -1,5 +1,4 @@
 import itertools
-from typing import Tuple
 import pytest
 import arcade
 from pyglet.math import Mat4
@@ -15,13 +14,13 @@ PATCH_SIZE = 100, 100
 
 
 def create_ninepatch(
-    texture_size: Tuple[int, int],
-    patch_size: Tuple[int, int],
+    texture_size: tuple[int, int],
+    patch_size: tuple[int, int],
     left: int,
     right: int,
     bottom: int,
     top: int,
-) -> Tuple[Image.Image, NinePatchTexture]:
+) -> tuple[NinePatchTexture, Image.Image,]:
     """Create a ninepatch texture with the given borders."""
     # Manually create a ninepatch texture.
     # We make it white by default and draw a red rectangle in the middle.
@@ -31,6 +30,7 @@ def create_ninepatch(
     draw = ImageDraw.Draw(patch_image)
     draw.rectangle((left, top, texture_size[0] - right - 1, texture_size[1] - bottom - 1), fill=(255, 0, 0, 255))
     texture = arcade.Texture(patch_image)
+    # patch_image.show()
 
     # Create the expected image
     expected_image = Image.new("RGBA", patch_size, (255, 255, 255, 255))
@@ -72,6 +72,8 @@ def test_draw(ctx, fbo, left, right, bottom, top):
         )
 
     fbo_image = ctx.get_framebuffer_image(fbo)
+    # fbo_image.show()
+    # expected_image.show()
 
     # Temp dump images
     # expected_image.save(f"_expected-{left}-{right}-{bottom}-{top}.png")


### PR DESCRIPTION
* `AtlasRegion` will now calculate texture coordinates using the center pixel. This should make textures rendered with 1.0 scale a bit sharper and help with artifacts when zooming.
* Ninepatches will revert the half pixel in texture coordinates for now
* Removed `NinePatchTexture.from_rect` because it doesn't make sense
* Fixed type annotations in atlas modules
* Added missing arguments and docstrings to `TextureAtlasBase`
* Added unit tests for `AtlasRegion`
* Fixed some tests