### PR TITLE
Fixing the SpatialHash issue 2186

### DIFF
--- a/arcade/sprite_list/spatial_hash.py
+++ b/arcade/sprite_list/spatial_hash.py
@@ -33,10 +33,10 @@ class SpatialHash(Generic[SpriteType]):
 
     def __init__(self, cell_size: int) -> None:
         # Sanity check the cell size
+        if not isinstance(cell_size, int):
+            raise TypeError("cell_size must be an int (integer)")
         if cell_size <= 0:
             raise ValueError("cell_size must be greater than 0")
-        if not isinstance(cell_size, int):
-            raise ValueError("cell_size must be an integer")
 
         self.cell_size: int = cell_size
         """How big each grid cell is on each side.

--- a/tests/unit/spritelist/test_spatial_hash.py
+++ b/tests/unit/spritelist/test_spatial_hash.py
@@ -10,6 +10,13 @@ def test_create():
     assert sh.buckets_for_sprite == {}
     assert sh.count == 0
 
+def test_incorrect_str_input():
+    with pytest.raises(TypeError):
+        sh = SpatialHash(cell_size="10")
+    
+def test_incorrect_inf_input():
+    with pytest.raises(TypeError):
+        sh = SpatialHash(cell_size=float("inf"))
 
 def test_reset():
     sh = SpatialHash(cell_size=10)


### PR DESCRIPTION
This PR is addressing the issue raised in https://github.com/pythonarcade/arcade/issues/2186

Steps (as kindly explained in the issue)

- [X] Move the isinstance check first
- [X] Make it raise a TypeError instead
- [X] Add tests in tests/unit/spritelist/test_spatial_hash.py in the test_create() function which use pytest.raises to check both cases above