### PR TITLE
Start end render

### DIFF
--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -44,7 +44,7 @@ def draw_texture_rect(
 
     atlas = atlas or ctx.default_atlas
 
-    texture_id, _ = ctx.default_atlas.add(texture)
+    texture_id, _ = atlas.add(texture)
     if pixelated:
         atlas.texture.filter = gl.NEAREST, gl.NEAREST
     else:

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -1,10 +1,12 @@
 import array
+from typing import Optional
 
 from arcade import gl
 from arcade.color import WHITE
 from arcade.math import rotate_point
 from arcade.sprite import BasicSprite
 from arcade.texture import Texture
+from arcade.texture_atlas.base import TextureAtlasBase
 from arcade.types import LBWH, LRBT, RGBA255, XYWH, Color, PointList, Rect
 from arcade.window_commands import get_window
 
@@ -20,6 +22,7 @@ def draw_texture_rect(
     blend=True,
     alpha=1.0,
     pixelated=False,
+    atlas: Optional[TextureAtlasBase] = None,
 ) -> None:
     """
     Draw a texture on a rectangle.
@@ -30,6 +33,7 @@ def draw_texture_rect(
     :param angle: Rotation of the texture in degrees. Defaults to zero.
     :param blend: If True, enable alpha blending. Defaults to True.
     :param alpha: Transparency of image. 0.0 is fully transparent, 1.0 (default) is visible.
+    :param atlas: The texture atlas the texture resides in. if not supplied the default texture atlas is used
     """
     ctx = get_window().ctx
 
@@ -38,7 +42,7 @@ def draw_texture_rect(
     else:
         ctx.disable(ctx.BLEND)
 
-    atlas = ctx.default_atlas
+    atlas = atlas or ctx.default_atlas
 
     texture_id, _ = ctx.default_atlas.add(texture)
     if pixelated:
@@ -64,11 +68,22 @@ def draw_texture_rect(
         ctx.disable(ctx.BLEND)
 
 
-def draw_sprite(sprite: BasicSprite, *, blend: bool = True, alpha=1.0, pixelated=False) -> None:
+def draw_sprite(
+    sprite: BasicSprite,
+    *,
+    blend: bool = True,
+    alpha=1.0,
+    pixelated=False,
+    atlas: Optional[TextureAtlasBase] = None,
+) -> None:
     """
     Draw a sprite.
 
     :param sprite: The sprite to draw.
+    :param blend: Draw the sprite with or without alpha blending
+    :param alpha: Fade the sprite from completely transparent to opaque (range: 0.0 to 1.0)
+    :param pixelated: If true the sprite will be render in pixelated style. Otherwise smooth/linear
+    :param atlas: The texture atlas the texture resides in. if not supplied the default texture atlas is used
     """
     draw_texture_rect(
         sprite.texture,
@@ -78,16 +93,28 @@ def draw_sprite(sprite: BasicSprite, *, blend: bool = True, alpha=1.0, pixelated
         blend=blend,
         alpha=alpha,
         pixelated=pixelated,
+        atlas=atlas,
     )
 
 
 def draw_sprite_rect(
-    sprite: BasicSprite, rect: Rect, *, blend: bool = True, alpha=1.0, pixelated=False
+    sprite: BasicSprite,
+    rect: Rect,
+    *,
+    blend: bool = True,
+    alpha=1.0,
+    pixelated=False,
+    atlas: Optional[TextureAtlasBase] = None,
 ) -> None:
     """
     Draw a sprite.
 
     :param sprite: The sprite to draw.
+    :param rect: The location and size of the sprite
+    :param blend: Draw the sprite with or without alpha blending
+    :param alpha: Fade the sprite from completely transparent to opaque (range: 0.0 to 1.0)
+    :param pixelated: If true the sprite will be render in pixelated style. Otherwise smooth/linear
+    :param atlas: The texture atlas the texture resides in. if not supplied the default texture atlas is used
     """
     draw_texture_rect(
         sprite.texture,
@@ -97,6 +124,7 @@ def draw_sprite_rect(
         blend=blend,
         alpha=alpha,
         pixelated=pixelated,
+        atlas=atlas,
     )
 
 

--- a/arcade/examples/drawing_primitives.py
+++ b/arcade/examples/drawing_primitives.py
@@ -21,7 +21,7 @@ python -m arcade.examples.drawing_primitives
 import arcade
 
 # Open the window. Set the window title and dimensions (width and height)
-arcade.open_window(600, 600, "Drawing Primitives Example")
+arcade.open_window(600, 600, "Drawing Primitives Example", resizable=True)
 
 # Set the background color to white
 # For a list of named colors see

--- a/arcade/examples/happy_face.py
+++ b/arcade/examples/happy_face.py
@@ -13,7 +13,7 @@ SCREEN_HEIGHT = 600
 SCREEN_TITLE = "Happy Face Example"
 
 # Open the window. Set the window title and dimensions
-arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
+arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE, resizable=True)
 
 # Set the background color
 arcade.set_background_color(arcade.color.WHITE)

--- a/arcade/examples/sections_demo_3.py
+++ b/arcade/examples/sections_demo_3.py
@@ -283,7 +283,7 @@ class GameView(arcade.View):
         self.section_manager.add_section(self.map)
 
     def on_draw(self):
-        arcade.start_render()
+        self.clear()
 
 
 def main():

--- a/arcade/gui/examples/exp_scroll_area.py
+++ b/arcade/gui/examples/exp_scroll_area.py
@@ -41,7 +41,7 @@ class MyWindow(Window):
         anchor.add(UIInputText().with_border())
 
     def on_draw(self):
-        arcade.start_render()
+        self.clear()
         self.ui.draw()
 
 

--- a/arcade/gui/examples/side_bars_with_box_layout.py
+++ b/arcade/gui/examples/side_bars_with_box_layout.py
@@ -55,7 +55,7 @@ class MyView(arcade.View):
         pass
 
     def on_draw(self):
-        arcade.start_render()
+        self.clear()
         self.ui.draw()
 
 

--- a/arcade/start_finish_data.py
+++ b/arcade/start_finish_data.py
@@ -26,6 +26,7 @@ class StartFinishRenderData:
         )
         self.atlas.add(self.texture)
         self._generator_func = None
+        self.completed = False
 
     def begin(self):
         """Enable rendering into the buffer"""
@@ -39,6 +40,7 @@ class StartFinishRenderData:
     def end(self):
         """Switch back to rendering into the window"""
         self.generator_func.__exit__(None, None, None)
+        self.completed = True
 
     def draw(self):
         """Draw the buffer to the screen"""

--- a/arcade/start_finish_data.py
+++ b/arcade/start_finish_data.py
@@ -1,0 +1,55 @@
+from arcade.draw.rect import draw_texture_rect
+from arcade.texture.texture import Texture
+from arcade.types import LBWH, AnchorPoint
+from arcade.window_commands import get_window
+
+
+class StartFinishRenderData:
+    """
+    State data for offscreen rendering with :py:meth:`arcade.start_render` and
+    :py:meth:`arcade.finish_render`. This is only meant for simply module level
+    drawing like creating a static image we display on the screen.
+
+    :param pixelated: Should the image be pixelated or smooth when scaled?
+    :param blend: Should we draw with alpha blending enabled?
+    """
+
+    def __init__(self, pixelated: bool = False, blend: bool = True):
+        from arcade.texture_atlas.atlas_default import DefaultTextureAtlas
+
+        self.window = get_window()
+        self.pixelated = pixelated
+        self.blend = blend
+        self.atlas = DefaultTextureAtlas(self.window.get_framebuffer_size(), border=0)
+        self.texture = Texture.create_empty(
+            "start_finish_render_texture", size=self.window.get_framebuffer_size()
+        )
+        self.atlas.add(self.texture)
+        self._generator_func = None
+
+    def begin(self):
+        """Enable rendering into the buffer"""
+        self.generator_func = self.atlas.render_into(self.texture)
+        fbo = self.generator_func.__enter__()
+        fbo.clear(color=self.window.background_color)
+
+        if self.blend:
+            self.window.ctx.enable(self.window.ctx.BLEND)
+
+    def end(self):
+        """Switch back to rendering into the window"""
+        self.generator_func.__exit__(None, None, None)
+
+    def draw(self):
+        """Draw the buffer to the screen"""
+        # Stretch the texture to the window size with black bars if needed
+        w, h = self.window.get_size()
+        min_factor = min(w / self.texture.width, h / self.texture.height)
+        region = LBWH(0, 0, self.texture.width, self.texture.height).scale(
+            min_factor, anchor=AnchorPoint.BOTTOM_LEFT
+        )
+        region = region.move(dx=(w - region.width) / 2, dy=(h - region.height) / 2)
+
+        draw_texture_rect(
+            self.texture, region, pixelated=self.pixelated, blend=False, atlas=self.atlas
+        )

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -220,6 +220,9 @@ def finish_render() -> None:
     if window._start_finish_render_data is None:
         raise RuntimeError("finish_render() was called without a matching start_render() call.")
 
+    if window._start_finish_render_data.completed:
+        raise RuntimeError("finish_render() was called more than once.")
+
     window._start_finish_render_data.end()
 
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -179,31 +179,48 @@ def exit() -> None:
     pyglet.app.exit()
 
 
-def start_render() -> None:
+def start_render(pixelated=False, blend=True) -> None:
     """
-    Clears the window.
+    Start recording drawing functions into an offscreen buffer.
+    Call :py:func:`arcade.finish_render` to stop recording. The
+    start_render/finish_render calls can only be called once.
 
-    More practical alternatives to this function is
-    :py:meth:`arcade.Window.clear`
-    or :py:meth:`arcade.View.clear`.
+    When running arcade this buffer will be presented to the screen.
+
+    A few configuration options are available in this function.
+
+    :param pixelated: If True, the buffer will be be pixelated when resized. Otherwise, it will be smooth.
+    :param blend: If alpha blending
     """
-    get_window().clear()
+    from arcade.start_finish_data import StartFinishRenderData
+
+    window = get_window()
+    if window._start_finish_render_data is not None:
+        raise RuntimeError(
+            (
+                "start_render() can only be called once during the application's lifetime "
+                "and should only be used when calling draw functions at module level in "
+                "a simple script to produce a static image. If you are seeing this error "
+                "you likely intended to call clear() instead."
+            )
+        )
+
+    window._start_finish_render_data = StartFinishRenderData(pixelated=pixelated, blend=blend)
+    window._start_finish_render_data.begin()
 
 
-def finish_render():
+def finish_render() -> None:
     """
-    Swap buffers and displays what has been drawn.
+    Stop recording drawing functions into an offscreen buffer.
+    :py:func:`arcade.start_render` should be called before this function.
 
-    .. Warning::
-
-        If you are extending the :py:class:`~arcade.Window` class, this function
-        should not be called. The event loop will automatically swap the window
-        framebuffer for you after ``on_draw``.
-
+    :py:func:`arcade.run` can be called after this function to present the buffer.
     """
-    get_window().static_display = True
-    get_window().flip_count = 0
-    get_window().flip()
+    window = get_window()
+    if window._start_finish_render_data is None:
+        raise RuntimeError("finish_render() was called without a matching start_render() call.")
+
+    window._start_finish_render_data.end()
 
 
 def set_background_color(color: RGBA255) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def prepare_window(window: arcade.Window):
     # ctx._atlas = None  # Clear the global atlas
     # default_texture_cache.flush()  # Clear the global/default texture cache
     arcade.SpriteList.DEFAULT_TEXTURE_FILTER = gl.LINEAR, gl.LINEAR
+    window._start_finish_render_data = None
     window.hide_view()  # Disable views if any is active
     window.dispatch_pending_events()
     try:
@@ -170,6 +171,14 @@ class WindowProxy:
     def current_camera(self):
         return self.window.current_camera
 
+    @property
+    def _start_finish_render_data(self):
+        return self.window._start_finish_render_data
+    
+    @_start_finish_render_data.setter
+    def _start_finish_render_data(self, data):
+        self.window._start_finish_render_data = data
+
     @current_camera.setter
     def current_camera(self, new_camera):
         self.window.current_camera = new_camera
@@ -199,6 +208,9 @@ class WindowProxy:
 
     def set_size(self, width, height):
         self.window.set_size(width, height)
+
+    def get_framebuffer_size(self):
+        return self.window.get_framebuffer_size()
 
     def get_pixel_ratio(self):
         return self.window.get_pixel_ratio()
@@ -283,7 +295,9 @@ def window_proxy():
 
     _open_window = arcade.open_window
     def open_window(*args, **kwargs):
-        return create_window(*args, **kwargs)
+        window = create_window(*args, **kwargs)
+        prepare_window(window)
+        return window
     arcade.open_window = open_window
 
     yield None

--- a/tests/unit/physics_engine/test_physics_engine.py
+++ b/tests/unit/physics_engine/test_physics_engine.py
@@ -37,7 +37,7 @@ def test_physics_engine(window):
     physics_engine = arcade.PhysicsEngineSimple(character_sprite, wall_list)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         wall_list.draw()
         character_list.draw()
 

--- a/tests/unit/physics_engine/test_physics_engine_platformer.py
+++ b/tests/unit/physics_engine/test_physics_engine_platformer.py
@@ -33,7 +33,7 @@ def test_physics_engine(window):
     )
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         wall_list.draw()
         character_list.draw()
 

--- a/tests/unit/shape_list/test_buffered_line_strip.py
+++ b/tests/unit/shape_list/test_buffered_line_strip.py
@@ -4,6 +4,7 @@ from arcade import shape_list
 
 def test_buffered_lines(window):
     window.background_color = arcade.color.WHITE
+    window.clear()
 
     point_list = ([0, 100],
                     [100, 100],
@@ -11,7 +12,6 @@ def test_buffered_lines(window):
                     [300, 300])
     line_strip = shape_list.create_line_strip(point_list, arcade.csscolor.BLACK, 10)
 
-    arcade.start_render()
     line_strip.draw()
     p = arcade.get_pixel(0, 100)
     assert p == (0, 0, 0)

--- a/tests/unit/sprite/test_sprite_animated_walking.py
+++ b/tests/unit/sprite/test_sprite_animated_walking.py
@@ -46,7 +46,7 @@ def test_sprite_animated_old(window: arcade.Window):
     character_list.append(player)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         character_list.draw()
 
     def update(delta_time):

--- a/tests/unit/sprite/test_sprite_render.py
+++ b/tests/unit/sprite/test_sprite_render.py
@@ -97,7 +97,7 @@ def test_render_with_movement(window: arcade.Window):
     individual_coin.position = (230, 230)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         coin_list.draw()
         character_list.draw()
         assert arcade.get_pixel(150, 50) == (191, 121, 88)
@@ -163,7 +163,7 @@ def test_render_sprite_solid_pixels(window: arcade.Window):
         character_list.append(character_sprite)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         character_list.draw()
 
         for i in range(7):
@@ -274,7 +274,7 @@ def test_render_sprite_remove(window):
     character_list.append(sprite_3)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         character_list.draw()
 
     def update(delta_time):

--- a/tests/unit/text/test_text.py
+++ b/tests/unit/text/test_text.py
@@ -11,7 +11,7 @@ def test_text(window):
     SCREEN_HEIGHT = window.height
     LINE_HEIGHT = 20
 
-    arcade.start_render()
+    window.clear()
     current_x = 20
 
     # First line
@@ -83,7 +83,7 @@ def test_text_instances(window):
     SCREEN_HEIGHT = window.height
     LINE_HEIGHT = 20
 
-    arcade.start_render()
+    window.clear()
     current_x = 20
 
     text_list: List[arcade.Text] = []

--- a/tests/unit/tilemap/test_show_tiled_map.py
+++ b/tests/unit/tilemap/test_show_tiled_map.py
@@ -16,7 +16,7 @@ def test_show_tilemap(window: arcade.Window):
         my_map.sprite_lists["Blocking Sprites"].update_animation(delta_time)
 
     def on_draw():
-        arcade.start_render()
+        window.clear()
         my_map.sprite_lists["Blocking Sprites"].draw()
 
     window.on_draw = on_draw

--- a/tests/unit/window/test_window.py
+++ b/tests/unit/window/test_window.py
@@ -2,9 +2,6 @@ import pytest
 import time
 
 import arcade
-import pyglet
-
-from pyglet.math import Mat4
 
 
 def test_window(window: arcade.Window):
@@ -47,9 +44,6 @@ def test_window(window: arcade.Window):
     assert isinstance(factor, float) 
     assert factor > 0
 
-    arcade.start_render()
-    arcade.finish_render()
-
     def f():
         pass
 
@@ -57,3 +51,30 @@ def test_window(window: arcade.Window):
     time.sleep(0.01)
     arcade.unschedule(f)
     window.test()
+
+
+def test_start_finish_render(window):
+    """Test start and finish render"""
+    # start_render must be called first
+    with pytest.raises(RuntimeError):
+        arcade.finish_render()
+
+    arcade.start_render()
+    assert window._start_finish_render_data is not None
+
+    # Draw something into the buffer
+    arcade.draw_lbwh_rectangle_filled(0, 0, 100, 100, arcade.color.RED)
+
+    # Only allowed to call start_render once
+    with pytest.raises(RuntimeError):
+        arcade.start_render()
+  
+    arcade.finish_render()
+
+    # Make sure we rendered something to the screen
+    window._start_finish_render_data.draw()
+    assert arcade.get_pixel(50, 50) == arcade.color.RED.rgb
+
+    # Only allowed to call finish_render once
+    with pytest.raises(RuntimeError):
+        arcade.finish_render()


### PR DESCRIPTION
## Problem

The `start_render` and `finish_render` system never really worked well. Some window systems never swap buffers. Then simply blit the back buffer to the front buffer instead. These users never saw any render output in the window. n addition users will be able to resize, minimize, maximize, show and hide the window without losing content because we just keep drawing the recorded framebuffer content. These actions will destroy and recreate the internal buffers so the the result is gone forever.

users would mistakenly use start/finish_render when they shouldn't. Some use them in window or view classes and get the "double swap" bug that make everything flicker like crazy.

The only way to solve it is to have ownership of the pixel data.

## Solution

* `start_render` and `finish_render` can only be called once during the application's lifetime. An error message will be presented to the user explaining what did they wrong if they call this function outside of its intended area.
* These functions are ONLY supposed to be used when drawing at module level to produce a static image we display
* We capture the rendered image in the texture atlas and draw it to the screen once per frame later. This means resizing, hiding or generally moving the window no longer causes the content to go away.
* The generated image will resize and keep its aspect ratio when the window is resized

Fixes issue : https://github.com/pythonarcade/arcade/issues/858