### PR TITLE
`Text` `int` typing for positions to `float`

### DIFF
--- a/arcade/text.py
+++ b/arcade/text.py
@@ -67,7 +67,9 @@ def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames
         elif isinstance(font_name, tuple):
             font_list = font_name
         else:
-            raise TypeError("font_name parameter must be a string, or a tuple of strings that specify a font name.")
+            raise TypeError(
+                "font_name parameter must be a string, or a tuple of strings that specify a font name."
+            )
 
         for font in font_list:
             try:

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -61,16 +61,13 @@ def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames
     :return: Either a resolved path or the original tuple
     """
     if font_name:
-
         # ensure
         if isinstance(font_name, str):
             font_list: tuple[str, ...] = (font_name,)
         elif isinstance(font_name, tuple):
             font_list = font_name
         else:
-            raise TypeError(
-                "font_name parameter must be a string, or a tuple of strings that specify a font name."
-            )
+            raise TypeError("font_name parameter must be a string, or a tuple of strings that specify a font name.")
 
         for font in font_list:
             try:
@@ -174,8 +171,8 @@ class Text:
     def __init__(
         self,
         text: str,
-        x: int,
-        y: int,
+        x: float,
+        y: float,
         color: RGBOrA255 = arcade.color.WHITE,
         font_size: float = 12,
         width: Optional[int] = 0,
@@ -189,7 +186,7 @@ class Text:
         rotation: float = 0,
         batch: Optional[pyglet.graphics.Batch] = None,
         group: Optional[pyglet.graphics.Group] = None,
-        z: int = 0,
+        z: float = 0,
     ):
         # Raises a RuntimeError if no window for better user feedback
         arcade.get_window()
@@ -203,9 +200,10 @@ class Text:
         adjusted_font = _attempt_font_name_resolution(font_name)
         self._label = pyglet.text.Label(
             text=text,
-            x=x,
-            y=y,
-            z=z,
+            # pyglet is lying about what it takes here and float is entirely valid
+            x=x,  # type: ignore
+            y=y,  # type: ignore
+            z=z,  # type: ignore
             font_name=adjusted_font,
             font_size=font_size,
             # use type: ignore since cast is slow & pyglet used Literal


### PR DESCRIPTION
Pyglet types these attributes as `int` but happily accepts `float`, and we use float for position everywhere else and ¯\\_(ツ)_/¯

It was messing up my typing in Charm frankly so I figured other people would run into it