### PR TITLE
Fix color annotations in drawing helpers + some doc updates

### DIFF
--- a/arcade/draw/arc.py
+++ b/arcade/draw/arc.py
@@ -2,7 +2,7 @@ import math
 
 from arcade import gl
 from arcade.math import rotate_point
-from arcade.types import RGBA255
+from arcade.types import RGBOrA255
 
 from .helpers import _generic_draw_line_strip
 
@@ -12,7 +12,7 @@ def draw_arc_filled(
     center_y: float,
     width: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     start_angle: float,
     end_angle: float,
     tilt_angle: float = 0,
@@ -62,7 +62,7 @@ def draw_arc_outline(
     center_y: float,
     width: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     start_angle: float,
     end_angle: float,
     border_width: float = 1,

--- a/arcade/draw/circle.py
+++ b/arcade/draw/circle.py
@@ -1,7 +1,7 @@
 import array
 
 from arcade import gl
-from arcade.types import RGBA255, Color
+from arcade.types import Color, RGBOrA255
 from arcade.window_commands import get_window
 
 
@@ -9,7 +9,7 @@ def draw_circle_filled(
     center_x: float,
     center_y: float,
     radius: float,
-    color: RGBA255,
+    color: RGBOrA255,
     tilt_angle: float = 0,
     num_segments: int = -1,
 ) -> None:
@@ -42,7 +42,7 @@ def draw_circle_outline(
     center_x: float,
     center_y: float,
     radius: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
     tilt_angle: float = 0,
     num_segments: int = -1,
@@ -80,7 +80,7 @@ def draw_ellipse_filled(
     center_y: float,
     width: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     tilt_angle: float = 0,
     num_segments: int = -1,
 ) -> None:
@@ -130,7 +130,7 @@ def draw_ellipse_outline(
     center_y: float,
     width: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
     tilt_angle: float = 0,
     num_segments: int = -1,

--- a/arcade/draw/helpers.py
+++ b/arcade/draw/helpers.py
@@ -2,7 +2,7 @@ import array
 import math
 
 from arcade import gl
-from arcade.types import RGBA255, Color, Point2, Point2List
+from arcade.types import Color, Point2, Point2List, RGBOrA255
 from arcade.window_commands import get_window
 
 
@@ -43,7 +43,7 @@ def get_points_for_thick_line(
 
 
 def _generic_draw_line_strip(
-    point_list: Point2List, color: RGBA255, mode: int = gl.LINE_STRIP
+    point_list: Point2List, color: RGBOrA255, mode: int = gl.LINE_STRIP
 ) -> None:
     """
     Draw a line strip. A line strip is a set of continuously connected

--- a/arcade/draw/line.py
+++ b/arcade/draw/line.py
@@ -1,13 +1,13 @@
 import array
 
 from arcade import gl
-from arcade.types import RGBA255, Color, Point2List
+from arcade.types import Color, Point2List, RGBOrA255
 from arcade.window_commands import get_window
 
 from .helpers import _generic_draw_line_strip, get_points_for_thick_line
 
 
-def draw_line_strip(point_list: Point2List, color: RGBA255, line_width: float = 1) -> None:
+def draw_line_strip(point_list: Point2List, color: RGBOrA255, line_width: float = 1) -> None:
     """
     Draw a multi-point line.
 
@@ -38,7 +38,7 @@ def draw_line(
     start_y: float,
     end_x: float,
     end_y: float,
-    color: RGBA255,
+    color: RGBOrA255,
     line_width: float = 1,
 ) -> None:
     """
@@ -73,7 +73,7 @@ def draw_line(
     ctx.disable(ctx.BLEND)
 
 
-def draw_lines(point_list: Point2List, color: RGBA255, line_width: float = 1) -> None:
+def draw_lines(point_list: Point2List, color: RGBOrA255, line_width: float = 1) -> None:
     """
     Draw a set of lines.
 

--- a/arcade/draw/parabola.py
+++ b/arcade/draw/parabola.py
@@ -1,4 +1,4 @@
-from arcade.types import RGBA255
+from arcade.types import RGBOrA255
 
 from .arc import draw_arc_filled, draw_arc_outline
 
@@ -8,7 +8,7 @@ def draw_parabola_filled(
     start_y: float,
     end_x: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     tilt_angle: float = 0,
 ) -> None:
     """
@@ -35,7 +35,7 @@ def draw_parabola_outline(
     start_y: float,
     end_x: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
     tilt_angle: float = 0,
 ) -> None:

--- a/arcade/draw/point.py
+++ b/arcade/draw/point.py
@@ -1,6 +1,6 @@
 import array
 
-from arcade.types import Color, PointList, RGBOrA255
+from arcade.types import Color, RGBOrA255, Point2List
 from arcade.types.rect import XYWH
 from arcade.window_commands import get_window
 
@@ -8,27 +8,49 @@ from .rect import draw_rect_filled
 
 
 def draw_point(x: float, y: float, color: RGBOrA255, size: float) -> None:
-    """
-    Draw a point.
+    """Draw a 2D point at ``(x, y)`` as a square ``size`` pixels wide.
 
-    :param x: x position of point.
-    :param y: y position of point.
-    :param color: A color as an RGBA tuple, RGB tuple, or a
-        :py:class:`~arcade.types.Color` instance.
-    :param size: Size of the point in pixels.
+    The square will be centered on ``(x, y)`` with the given ``color``
+    as its fill value.
+
+    To draw more rounded shapes, please see:
+
+    * :py:func:`arcade.draw.circle.draw_circle_filled`
+    * :py:func:`pyglet.shapes.Circle`
+
+    Args:
+        x:
+            The center of the square along the x axis.
+        y:
+            The center of the square along the y axis.
+        color:
+            The fill color of the square as an RGBA :py:class:`tuple`,
+            RGB py:class:`tuple`, or a :py:class:`.Color` instance.
+        size:
+             The width and height of the square in pixels.
     """
     draw_rect_filled(XYWH(x, y, size, size), color)
 
 
-def draw_points(point_list: PointList, color: RGBOrA255, size: float = 1) -> None:
-    """
-    Draw a set of points.
+def draw_points(point_list: Point2List, color: RGBOrA255, size: float = 1) -> None:
+    """Draw 2D points as squares ``size`` pixels  wide.
 
-    :param point_list: List of points Each point is
-         in a list. So it is a list of lists.
-    :param color: A color as an RGBA tuple, RGB tuple, or a
-        :py:class:`~arcade.types.Color` instance.
-    :param size: Size of the point in pixels.
+    Each point in ``point_list`` will be drawn centered on its x and y
+    value with the same ``color`` and square ``size`` in pixels.
+
+    To draw more rounded shapes, please see:
+
+    * :py:func:`arcade.draw.circle.draw_circle_filled`
+    * :py:func:`pyglet.shapes.Circle`
+
+    Args:
+        point_list:
+            A :py:class:`list` or :py:class:`tuple` of 2D points.
+        color:
+            The fill color for the points as an RGBA :py:class:`tuple`,
+            RGB :py:class:`tuple`, or :py:class:`.Color` instance.
+        size:
+            The width and height of each point's square in pixels.
     """
     # Fails immediately if we don't have a window or context
     window = get_window()

--- a/arcade/draw/point.py
+++ b/arcade/draw/point.py
@@ -1,32 +1,32 @@
 import array
 
-from arcade.types import RGBA255, Color, PointList
+from arcade.types import Color, PointList, RGBOrA255
 from arcade.types.rect import XYWH
 from arcade.window_commands import get_window
 
 from .rect import draw_rect_filled
 
 
-def draw_point(x: float, y: float, color: RGBA255, size: float) -> None:
+def draw_point(x: float, y: float, color: RGBOrA255, size: float) -> None:
     """
     Draw a point.
 
     :param x: x position of point.
     :param y: y position of point.
-    :param color: A color, specified as an RGBA tuple or a
+    :param color: A color as an RGBA tuple, RGB tuple, or a
         :py:class:`~arcade.types.Color` instance.
     :param size: Size of the point in pixels.
     """
     draw_rect_filled(XYWH(x, y, size, size), color)
 
 
-def draw_points(point_list: PointList, color: RGBA255, size: float = 1) -> None:
+def draw_points(point_list: PointList, color: RGBOrA255, size: float = 1) -> None:
     """
     Draw a set of points.
 
     :param point_list: List of points Each point is
          in a list. So it is a list of lists.
-    :param color: A color, specified as an RGBA tuple or a
+    :param color: A color as an RGBA tuple, RGB tuple, or a
         :py:class:`~arcade.types.Color` instance.
     :param size: Size of the point in pixels.
     """

--- a/arcade/draw/point.py
+++ b/arcade/draw/point.py
@@ -1,6 +1,6 @@
 import array
 
-from arcade.types import Color, RGBOrA255, Point2List
+from arcade.types import Color, Point2List, RGBOrA255
 from arcade.types.rect import XYWH
 from arcade.window_commands import get_window
 

--- a/arcade/draw/point.py
+++ b/arcade/draw/point.py
@@ -7,7 +7,7 @@ from arcade.window_commands import get_window
 from .rect import draw_rect_filled
 
 
-def draw_point(x: float, y: float, color: RGBOrA255, size: float) -> None:
+def draw_point(x: float, y: float, color: RGBOrA255, size: float = 1.0) -> None:
     """Draw a 2D point at ``(x, y)`` as a square ``size`` pixels wide.
 
     The square will be centered on ``(x, y)`` with the given ``color``
@@ -32,7 +32,7 @@ def draw_point(x: float, y: float, color: RGBOrA255, size: float) -> None:
     draw_rect_filled(XYWH(x, y, size, size), color)
 
 
-def draw_points(point_list: Point2List, color: RGBOrA255, size: float = 1) -> None:
+def draw_points(point_list: Point2List, color: RGBOrA255, size: float = 1.0) -> None:
     """Draw 2D points as squares ``size`` pixels  wide.
 
     Each point in ``point_list`` will be drawn centered on its x and y

--- a/arcade/draw/polygon.py
+++ b/arcade/draw/polygon.py
@@ -1,11 +1,11 @@
 from arcade import gl
 from arcade.earclip import earclip
-from arcade.types import RGBA255, Point2List
+from arcade.types import Point2List, RGBOrA255
 
 from .helpers import _generic_draw_line_strip, get_points_for_thick_line
 
 
-def draw_polygon_filled(point_list: Point2List, color: RGBA255) -> None:
+def draw_polygon_filled(point_list: Point2List, color: RGBOrA255) -> None:
     """
     Draw a polygon that is filled in.
 
@@ -18,7 +18,7 @@ def draw_polygon_filled(point_list: Point2List, color: RGBA255) -> None:
     _generic_draw_line_strip(flattened_list, color, gl.TRIANGLES)
 
 
-def draw_polygon_outline(point_list: Point2List, color: RGBA255, line_width: float = 1) -> None:
+def draw_polygon_outline(point_list: Point2List, color: RGBOrA255, line_width: float = 1) -> None:
     """
     Draw a polygon outline. Also known as a "line loop."
 

--- a/arcade/draw/polygon.py
+++ b/arcade/draw/polygon.py
@@ -18,7 +18,7 @@ def draw_polygon_filled(point_list: Point2List, color: RGBOrA255) -> None:
     _generic_draw_line_strip(flattened_list, color, gl.TRIANGLES)
 
 
-def draw_polygon_outline(point_list: Point2List, color: RGBOrA255, line_width: float = 1) -> None:
+def draw_polygon_outline(point_list: Point2List, color: RGBOrA255, line_width: float = 1.0) -> None:
     """
     Draw a polygon outline. Also known as a "line loop."
 

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -7,7 +7,7 @@ from arcade.math import rotate_point
 from arcade.sprite import BasicSprite
 from arcade.texture import Texture
 from arcade.texture_atlas.base import TextureAtlasBase
-from arcade.types import LBWH, LRBT, RGBA255, XYWH, Color, Point2List, Rect
+from arcade.types import LBWH, LRBT, XYWH, Color, Point2List, Rect, RGBOrA255
 from arcade.window_commands import get_window
 
 from .helpers import _generic_draw_line_strip
@@ -133,7 +133,7 @@ def draw_lrbt_rectangle_outline(
     right: float,
     bottom: float,
     top: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
 ) -> None:
     """
@@ -162,7 +162,7 @@ def draw_lbwh_rectangle_outline(
     bottom: float,
     width: float,
     height: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
 ) -> None:
     """
@@ -180,7 +180,7 @@ def draw_lbwh_rectangle_outline(
 
 
 def draw_lrbt_rectangle_filled(
-    left: float, right: float, bottom: float, top: float, color: RGBA255
+    left: float, right: float, bottom: float, top: float, color: RGBOrA255
 ) -> None:
     """
     Draw a rectangle by specifying left, right, bottom and top edges.
@@ -206,7 +206,7 @@ def draw_lrbt_rectangle_filled(
 
 
 def draw_lbwh_rectangle_filled(
-    left: float, bottom: float, width: float, height: float, color: RGBA255
+    left: float, bottom: float, width: float, height: float, color: RGBOrA255
 ) -> None:
     """
     Draw a filled rectangle extending from bottom left to top right
@@ -222,7 +222,7 @@ def draw_lbwh_rectangle_filled(
 
 
 def draw_rect_outline(
-    rect: Rect, color: RGBA255, border_width: float = 1, tilt_angle: float = 0
+    rect: Rect, color: RGBOrA255, border_width: float = 1, tilt_angle: float = 0
 ) -> None:
     """
     Draw a rectangle outline.
@@ -260,7 +260,7 @@ def draw_rect_outline(
     _generic_draw_line_strip(point_list, color, gl.TRIANGLE_STRIP)
 
 
-def draw_rect_filled(rect: Rect, color: RGBA255, tilt_angle: float = 0) -> None:
+def draw_rect_filled(rect: Rect, color: RGBOrA255, tilt_angle: float = 0) -> None:
     """
     Draw a filled-in rectangle.
 

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -298,14 +298,14 @@ def draw_rect_filled(rect: Rect, color: RGBOrA255, tilt_angle: float = 0) -> Non
 # These might be "oddly specific" and also needs docstrings. Disabling or 3.0.0
 
 # def draw_rect_outline_kwargs(
-#     color: RGBA255 = WHITE, border_width: int = 1, tilt_angle: float = 0, **kwargs: AsFloat
+#     color: RGBAOrA255 = WHITE, border_width: int = 1, tilt_angle: float = 0, **kwargs: AsFloat
 # ) -> None:
 #     rect = Rect.from_kwargs(**kwargs)
 #     draw_rect_outline(rect, color, border_width, tilt_angle)
 
 
 # def draw_rect_filled_kwargs(
-#     color: RGBA255 = WHITE, tilt_angle: float = 0, **kwargs: AsFloat
+#     color: RGBAOrA255 = WHITE, tilt_angle: float = 0, **kwargs: AsFloat
 # ) -> None:
 #     rect = Rect.from_kwargs(**kwargs)
 #     draw_rect_filled(rect, color, tilt_angle)

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -143,7 +143,8 @@ def draw_lrbt_rectangle_outline(
     :param right: The x coordinate of the right edge of the rectangle.
     :param bottom: The y coordinate of the rectangle bottom.
     :param top: The y coordinate of the top of the rectangle.
-    :param color: The color of the rectangle.
+    :param color: The outline color as an RGBA :py:class:`tuple`, RGB
+        :py:class:`tuple`, or a :py:class:`.Color` instance.
     :param border_width: The width of the border in pixels. Defaults to one.
     :Raises ValueError: Raised if left > right or top < bottom.
 
@@ -172,8 +173,8 @@ def draw_lbwh_rectangle_outline(
     :param bottom_left_y: The y coordinate of the bottom of the rectangle.
     :param width: The width of the rectangle.
     :param height: The height of the rectangle.
-    :param color: The color of the rectangle as an RGBA
-        :py:class:`tuple` or :py:class`~arcade.types.Color` instance.
+    :param color: The outline color as an RGBA :py:class:`tuple`, RGB
+        :py:class:`tuple`, or a :py:class:`.Color` instance.
     :param border_width: The width of the border in pixels. Defaults to one.
     """
     draw_rect_outline(LBWH(left, bottom, width, height), color, border_width)
@@ -189,7 +190,8 @@ def draw_lrbt_rectangle_filled(
     :param right: The x coordinate of the right edge of the rectangle.
     :param bottom: The y coordinate of the rectangle bottom.
     :param top: The y coordinate of the top of the rectangle.
-    :param color: The color of the rectangle.
+    :param color: The fill color as an RGBA :py:class:`tuple`,
+        RGB :py:class:`tuple`, or a :py:class:`.Color` instance.
     :Raises ValueError: Raised if left > right or top < bottom.
     """
     if left > right:
@@ -215,8 +217,8 @@ def draw_lbwh_rectangle_filled(
     :param bottom: The y coordinate of the bottom of the rectangle.
     :param width: The width of the rectangle.
     :param height: The height of the rectangle.
-    :param color: The color of the rectangles an RGBA
-        :py:class:`tuple` or :py:class`~arcade.types.Color` instance.
+    :param color: The fill color as an RGBA :py:class:`tuple`, RGB
+        :py:class:`tuple`, :py:class:`~arcade.types.Color` instance
     """
     draw_rect_filled(LBWH(left, bottom, width, height), color)
 
@@ -229,8 +231,8 @@ def draw_rect_outline(
 
     :param rect: The rectangle to draw.
         a :py:class`~arcade.types.Rect` instance.
-    :param color: The color of the rectangle.
-        :py:class:`tuple` or :py:class`~arcade.types.Color` instance.
+    :param color: The fill color as an RGBA :py:class:`tuple`,
+        RGB :py:class:`tuple`, or :py:class`.Color` instance.
     :param border_width: width of the lines, in pixels.
     :param tilt_angle: rotation of the rectangle. Defaults to zero (clockwise).
     """
@@ -266,8 +268,8 @@ def draw_rect_filled(rect: Rect, color: RGBOrA255, tilt_angle: float = 0) -> Non
 
     :param rect: The rectangle to draw.
         a :py:class`~arcade.types.Rect` instance.
-    :param color: The color of the rectangle as an RGBA
-        :py:class:`tuple` or :py:class`~arcade.types.Color` instance.
+    :param color: The fill color as an RGBA :py:class:`tuple`,
+        RGB :py:class:`tuple, or :py:class`.Color` instance.
     :param tilt_angle: rotation of the rectangle (clockwise). Defaults to zero.
     """
     # Fail if we don't have a window, context, or right GL abstractions

--- a/arcade/draw/triangle.py
+++ b/arcade/draw/triangle.py
@@ -1,12 +1,12 @@
 from arcade import gl
-from arcade.types import RGBA255
+from arcade.types import RGBOrA255
 
 from .helpers import _generic_draw_line_strip
 from .polygon import draw_polygon_outline
 
 
 def draw_triangle_filled(
-    x1: float, y1: float, x2: float, y2: float, x3: float, y3: float, color: RGBA255
+    x1: float, y1: float, x2: float, y2: float, x3: float, y3: float, color: RGBOrA255
 ) -> None:
     """
     Draw a filled in triangle.
@@ -35,7 +35,7 @@ def draw_triangle_outline(
     y2: float,
     x3: float,
     y3: float,
-    color: RGBA255,
+    color: RGBOrA255,
     border_width: float = 1,
 ) -> None:
     """
@@ -47,7 +47,7 @@ def draw_triangle_outline(
     :param y2: y value of second coordinate.
     :param x3: x value of third coordinate.
     :param y3: y value of third coordinate.
-    :param color: RGBA255 of triangle as an RGBA
+    :param color: RGBOrA255 of triangle as an RGBA
         :py:class:`tuple` or :py:class`~arcade.types.Color` instance.
     :param border_width: Width of the border in pixels. Defaults to 1.
     """


### PR DESCRIPTION
**TL;DR:** Pre-req for #2223 and we need it anyway

* Replace RGBA255 with RGBOrA255 since we use `Color.from_iterable(arg).normalized` before passing to shaders anyway
* Make the point drawing docstrings clearer with cross-refs for people who want to draw circles for points
* Some other docstring and style cleanup (`arg: float = 1` just looks wrong)