### PR TITLE
Pyglet2.1dev$VERSION updates

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -401,7 +401,7 @@ __version__ = VERSION
 # Piggyback on pyglet's doc run detection
 if not getattr(sys, "is_pyglet_doc_run", False):
     # Load additional game controller mappings to Pyglet
-    if not arcade.headless:
+    if not headless:
         try:
             import pyglet.input.controller
 

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -69,7 +69,7 @@ if sys.platform == "darwin" or os.environ.get("ARCADE_HEADLESS") or utils.is_ras
     pyglet.options.shadow_window = False
 
 # Use the old gdi fonts on windows until directwrite is fast/stable
-# pyglet.options['win32_gdi_font'] = True
+# pyglet.options.win32_gdi_font = True
 
 # Imports from modules that don't do anything circular
 

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 # Error out if we import Arcade with an incompatible version of Python.
 import sys
 import os
-from typing import Optional, Final
+from typing import Final, Optional
 
 from pathlib import Path
 

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -58,17 +58,6 @@ else:
 # noinspection PyPep8
 import pyglet
 
-# TODO: Remove ASAP after pyglet >= 2.1dev2 is out
-if pyglet.version == "2.1.dev2":
-    # Temporary monkeypatch via deletion since dev2 still includes
-    # overly-specific __eq__ behavior. Later pyglet commits restore
-    # equality with same-valued tuples by deleting the __eq__ methods.
-    from pyglet import math as _pyglet_math
-
-    del _pyglet_math.Vec2.__eq__
-    del _pyglet_math.Vec3.__eq__
-    del _pyglet_math.Vec4.__eq__
-
 # Env variable shortcut for headless mode
 if os.environ.get("ARCADE_HEADLESS"):
     pyglet.options["headless"] = True

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -62,16 +62,14 @@ import pyglet
 # Env variable shortcut for headless mode
 headless: Final[bool] = bool(os.environ.get("ARCADE_HEADLESS"))
 if headless:
-    # TODO: fix once pyglet/__init__.pyi is fixed
-    pyglet.options.headless = headless  # type: ignore
+    pyglet.options.headless = headless  # type: ignore # pending https://github.com/pyglet/pyglet/issues/1164
 
 
 from arcade import utils
 
 # Disable shadow window on macs and in headless mode.
 if sys.platform == "darwin" or os.environ.get("ARCADE_HEADLESS") or utils.is_raspberry_pi():
-    # TODO: fix once pyglet/__init__.pyi is fixed
-    pyglet.options.shadow_window = False  # type: ignore
+    pyglet.options.shadow_window = False  # type: ignore # pending https://github.com/pyglet/pyglet/issues/1164
 
 # Use the old gdi fonts on windows until directwrite is fast/stable
 # pyglet.options.win32_gdi_font = True

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 # Error out if we import Arcade with an incompatible version of Python.
 import sys
 import os
-from typing import Optional
+from typing import Optional, Final
 
 from pathlib import Path
 
@@ -58,15 +58,20 @@ else:
 # noinspection PyPep8
 import pyglet
 
+
 # Env variable shortcut for headless mode
-if os.environ.get("ARCADE_HEADLESS"):
-    pyglet.options.headless = True
+headless: Final[bool] = bool(os.environ.get("ARCADE_HEADLESS"))
+if headless:
+    # TODO: fix once pyglet/__init__.pyi is fixed
+    pyglet.options.headless = headless  # type: ignore
+
 
 from arcade import utils
 
 # Disable shadow window on macs and in headless mode.
 if sys.platform == "darwin" or os.environ.get("ARCADE_HEADLESS") or utils.is_raspberry_pi():
-    pyglet.options.shadow_window = False
+    # TODO: fix once pyglet/__init__.pyi is fixed
+    pyglet.options.shadow_window = False  # type: ignore
 
 # Use the old gdi fonts on windows until directwrite is fast/stable
 # pyglet.options.win32_gdi_font = True
@@ -141,7 +146,7 @@ from .screenshot import get_image
 from .screenshot import get_pixel
 
 # We don't have joysticks game controllers in headless mode
-if not pyglet.options.headless:
+if not headless:  # type: ignore
     from .joysticks import get_game_controllers
     from .joysticks import get_joysticks
     from .controller import ControllerManager
@@ -396,7 +401,7 @@ __version__ = VERSION
 # Piggyback on pyglet's doc run detection
 if not getattr(sys, "is_pyglet_doc_run", False):
     # Load additional game controller mappings to Pyglet
-    if not pyglet.options.headless:
+    if not arcade.headless:
         try:
             import pyglet.input.controller
 

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -60,13 +60,13 @@ import pyglet
 
 # Env variable shortcut for headless mode
 if os.environ.get("ARCADE_HEADLESS"):
-    pyglet.options["headless"] = True
+    pyglet.options.headless = True
 
 from arcade import utils
 
 # Disable shadow window on macs and in headless mode.
 if sys.platform == "darwin" or os.environ.get("ARCADE_HEADLESS") or utils.is_raspberry_pi():
-    pyglet.options["shadow_window"] = False
+    pyglet.options.shadow_window = False
 
 # Use the old gdi fonts on windows until directwrite is fast/stable
 # pyglet.options['win32_gdi_font'] = True
@@ -141,7 +141,7 @@ from .screenshot import get_image
 from .screenshot import get_pixel
 
 # We don't have joysticks game controllers in headless mode
-if not pyglet.options["headless"]:
+if not pyglet.options.headless:
     from .joysticks import get_game_controllers
     from .joysticks import get_joysticks
     from .controller import ControllerManager
@@ -396,7 +396,7 @@ __version__ = VERSION
 # Piggyback on pyglet's doc run detection
 if not getattr(sys, "is_pyglet_doc_run", False):
     # Load additional game controller mappings to Pyglet
-    if not pyglet.options["headless"]:
+    if not pyglet.options.headless:
         try:
             import pyglet.input.controller
 

--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -401,6 +401,7 @@ if not getattr(sys, "is_pyglet_doc_run", False):
             import pyglet.input.controller
 
             mappings_file = resources.resolve(":system:gamecontrollerdb.txt")
-            pyglet.input.controller.add_mappings_from_file(mappings_file)
+            # TODO: remove string conversion once fixed upstream
+            pyglet.input.controller.add_mappings_from_file(str(mappings_file))
         except AssertionError:
             pass

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -161,7 +161,7 @@ class Window(pyglet.window.Window):
             gl_version = 3, 1
             gl_api = "gles"
 
-        self.headless: bool = pyglet.options.get("headless") is True
+        self.headless: bool = arcade.headless
         """If True, the window is running in headless mode."""
 
         config = None
@@ -291,7 +291,7 @@ class Window(pyglet.window.Window):
         if enable_polling:
             self.keyboard = pyglet.window.key.KeyStateHandler()
 
-            if pyglet.options.headless:
+            if arcade.headless:
                 self.push_handlers(self.keyboard)
 
             else:

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -412,10 +412,10 @@ class Window(pyglet.window.Window):
     def set_fullscreen(
         self,
         fullscreen: bool = True,
-        screen: Optional["Window"] = None,
-        mode: Optional[ScreenMode] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        screen: pyglet.window.Window | None = None,
+        mode: ScreenMode | None = None,
+        width: float | None = None,
+        height: float | None = None,
     ) -> None:
         """
         Change the fullscreen status of the window.
@@ -442,6 +442,13 @@ class Window(pyglet.window.Window):
             height (int, optional): Override the height of the window
         """
         super().set_fullscreen(fullscreen, screen, mode, width, height)
+        # fmt: off
+        super().set_fullscreen(
+            fullscreen, screen, mode,
+            # TODO: resolve the upstream int / float screen coord issue
+            None if width is None else int(width),
+            None if height is None else int(height))
+        # fmt: on
 
     def center_window(self) -> None:
         """Center the window on your desktop."""

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -291,7 +291,7 @@ class Window(pyglet.window.Window):
         if enable_polling:
             self.keyboard = pyglet.window.key.KeyStateHandler()
 
-            if pyglet.options["headless"]:
+            if pyglet.options.headless:
                 self.push_handlers(self.keyboard)
 
             else:

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -215,9 +215,10 @@ class Window(pyglet.window.Window):
                 visible=visible,
                 style=style,
             )
-            self.register_event_type("on_update")
-            self.register_event_type("on_action")
-            self.register_event_type("on_fixed_update")
+            # pending: weird import tricks resolved
+            self.register_event_type("on_update")  # type: ignore
+            self.register_event_type("on_action")  # type: ignore
+            self.register_event_type("on_fixed_update")  # type: ignore
         except pyglet.window.NoSuchConfigException:
             raise NoOpenGLException(
                 "Unable to create an OpenGL 3.3+ context. "

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -439,10 +439,11 @@ class Window(pyglet.window.Window):
                 have been obtained by enumerating `Screen.get_modes`.  If
                 None, an appropriate mode will be selected from the given
                 `width` and `height`.
-            width (int, optional): Override the width of the window
-            height (int, optional): Override the height of the window
+            width: Override the width of the window. Will be rounded to
+                :py:attr:`int`.
+            height: Override the height of the window. Will be rounded to
+                :py:attr:`int`.
         """
-        super().set_fullscreen(fullscreen, screen, mode, width, height)
         # fmt: off
         super().set_fullscreen(
             fullscreen, screen, mode,

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -413,7 +413,7 @@ class Window(pyglet.window.Window):
     def set_fullscreen(
         self,
         fullscreen: bool = True,
-        screen: pyglet.window.Window | None = None,
+        screen=None,
         mode: ScreenMode | None = None,
         width: float | None = None,
         height: float | None = None,

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -132,14 +132,14 @@ class Window(pyglet.window.Window):
         self,
         width: int = 1280,
         height: int = 720,
-        title: Optional[str] = "Arcade Window",
+        title: str | None = "Arcade Window",
         fullscreen: bool = False,
         resizable: bool = False,
         update_rate: float = 1 / 60,
         antialiasing: bool = True,
         gl_version: tuple[int, int] = (3, 3),
-        screen: Optional[pyglet.display.Screen] = None,
-        style: Optional[str] = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
+        screen: pyglet.display.Screen | None = None,
+        style: str | None = pyglet.window.Window.WINDOW_STYLE_DEFAULT,
         visible: bool = True,
         vsync: bool = False,
         gc_mode: str = "context_gc",
@@ -149,7 +149,7 @@ class Window(pyglet.window.Window):
         gl_api: str = "gl",
         draw_rate: float = 1 / 60,
         fixed_rate: float = 1.0 / 60.0,
-        fixed_frame_cap: Optional[int] = None,
+        fixed_frame_cap: int | None = None,
     ) -> None:
         # In certain environments we can't have antialiasing/MSAA enabled.
         # Detect replit environment

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -171,7 +171,7 @@ class Window(pyglet.window.Window):
                 config = pyglet.gl.Config(
                     major_version=gl_version[0],
                     minor_version=gl_version[1],
-                    opengl_api=gl_api,
+                    opengl_api=gl_api,  # type: ignore  # pending: upstream fix
                     double_buffer=True,
                     sample_buffers=1,
                     samples=samples,

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -195,7 +195,7 @@ class Window(pyglet.window.Window):
             config = pyglet.gl.Config(
                 major_version=gl_version[0],
                 minor_version=gl_version[1],
-                opengl_api=gl_api,
+                opengl_api=gl_api,  # type: ignore  # pending: upstream fix
                 double_buffer=True,
                 depth_size=24,
                 stencil_size=8,

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -183,7 +183,7 @@ class Window(pyglet.window.Window):
                     alpha_size=8,
                 )
                 display = pyglet.display.get_display()
-                screen = display.get_default_screen()
+                screen = display.get_default_screen()  # type: ignore  # pending: resolve upstream type tricks
                 if screen:
                     config = screen.get_best_config(config)
             except pyglet.window.NoSuchConfigException:

--- a/arcade/camera/projection_functions.py
+++ b/arcade/camera/projection_functions.py
@@ -27,12 +27,12 @@ def generate_view_matrix(camera_data: CameraData) -> Mat4:
     po = Vec3(*camera_data.position)
 
     # fmt: off
-    return Mat4((
+    return Mat4(
         ri.x, up.x, -fo.x, 0.0,
         ri.y, up.y, -fo.y, 0.0,
         ri.z, up.z, -fo.z, 0.0,
         -ri.dot(po), -up.dot(po), fo.dot(po), 1.0
-    ))
+    )
     # fmt: on
 
 
@@ -69,12 +69,12 @@ def generate_orthographic_matrix(
     tz = -(z_far + z_near) / depth
 
     # fmt: off
-    return Mat4((
+    return Mat4(
         sx, 0.0, 0.0, 0.0,
         0.0,  sy, 0.0, 0.0,
         0.0, 0.0,  sz, 0.0,
         tx,  ty,  tz, 1.0
-    ))
+    )
     # fmt: on
 
 
@@ -110,12 +110,12 @@ def generate_perspective_matrix(
     h = 2 * z_near / height
 
     # fmt: off
-    return Mat4((
+    return Mat4(
         w, 0, 0, 0,
         0, h, 0, 0,
         0, 0, q, -1,
         0, 0, qn, 0
-    ))
+    )
     # fmt: on
 
 

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -48,7 +48,10 @@ class ArcadeContext(Context):
     atlas_size: tuple[int, int] = 512, 512
 
     def __init__(
-        self, window: pyglet.window.Window, gc_mode: str = "context_gc", gl_api: str = "gl"
+        self,
+        window: pyglet.window.Window,  # type: ignore
+        gc_mode: str = "context_gc",
+        gl_api: str = "gl",
     ) -> None:
         super().__init__(window, gc_mode=gc_mode, gl_api=gl_api)
 

--- a/arcade/examples/perspective.py
+++ b/arcade/examples/perspective.py
@@ -18,7 +18,7 @@ python -m arcade.examples.perspective
 from array import array
 
 import arcade
-from pyglet.math import Mat4
+from pyglet.math import Mat4, Vec3
 from arcade.gl import BufferDescription
 
 
@@ -121,8 +121,8 @@ class Perspective(arcade.Window):
         self.fbo.color_attachments[0].use(unit=0)
 
         # Move the plane into camera view and rotate it
-        translate = Mat4.from_translation((0, 0, -2))
-        rotate = Mat4.from_rotation(self.time / 2, (1, 0, 0))
+        translate = Mat4.from_translation(Vec3(0, 0, -2))
+        rotate = Mat4.from_rotation(self.time / 2, Vec3(1, 0, 0))
         self.program["model"] = translate @ rotate
 
         # Scroll the texture coordinates

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -183,7 +183,8 @@ class Context:
     _valid_apis = ("gl", "gles")
 
     def __init__(
-        self, window: pyglet.window.Window,  # type: ignore
+        self,
+        window: pyglet.window.Window,  # type: ignore
         gc_mode: str = "context_gc",
         gl_api: str = "gl",
     ):

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -183,7 +183,9 @@ class Context:
     _valid_apis = ("gl", "gles")
 
     def __init__(
-        self, window: pyglet.window.Window, gc_mode: str = "context_gc", gl_api: str = "gl"
+        self, window: pyglet.window.Window,  # type: ignore
+        gc_mode: str = "context_gc",
+        gl_api: str = "gl",
     ):
         self._window_ref = weakref.ref(window)
         if gl_api not in self._valid_apis:

--- a/arcade/gui/constructs.py
+++ b/arcade/gui/constructs.py
@@ -46,7 +46,7 @@ class UIMessageBox(UIMouseFilterMixin, UIAnchorLayout):
             raise ValueError("At least a single value has to be available for `buttons`")
 
         super().__init__(size_hint=(1, 1))
-        self.register_event_type("on_action")
+        self.register_event_type("on_action")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
         space = 20
 
@@ -136,7 +136,7 @@ class UIButtonRow(UIBoxLayout):
             space_between=space_between,
             style=style,
         )
-        self.register_event_type("on_action")
+        self.register_event_type("on_action")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
         self.button_factory = button_factory
 

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -99,7 +99,7 @@ class UIManager(EventDispatcher):
         self._render_to_surface_camera = arcade.Camera2D()
         # this camera is used for rendering the UI and should not be changed by the user
 
-        self.register_event_type("on_event")
+        self.register_event_type("on_event")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
     def add(self, widget: W, *, index=None, layer=0) -> W:
         """

--- a/arcade/gui/widgets/__init__.py
+++ b/arcade/gui/widgets/__init__.py
@@ -99,8 +99,8 @@ class UIWidget(EventDispatcher, ABC):
         self.size_hint_min = size_hint_min
         self.size_hint_max = size_hint_max
 
-        self.register_event_type("on_event")
-        self.register_event_type("on_update")
+        self.register_event_type("on_event")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
+        self.register_event_type("on_update")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
         for child in children:
             self.add(child)
@@ -516,7 +516,7 @@ class UIInteractiveWidget(UIWidget):
             size_hint_max=size_hint_max,
             **kwargs,
         )
-        self.register_event_type("on_click")
+        self.register_event_type("on_click")  # type: ignore
 
         self.interaction_buttons = interaction_buttons
 

--- a/arcade/gui/widgets/dropdown.py
+++ b/arcade/gui/widgets/dropdown.py
@@ -100,7 +100,7 @@ class UIDropdown(UILayout):
         # add children after super class setup
         self.add(self._default_button)
 
-        self.register_event_type("on_change")
+        self.register_event_type("on_change")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
         self.with_border(color=arcade.color.RED)
 

--- a/arcade/gui/widgets/slider.py
+++ b/arcade/gui/widgets/slider.py
@@ -76,7 +76,7 @@ class UIBaseSlider(UIInteractiveWidget, metaclass=ABCMeta):
         bind(self, "pressed", self.trigger_render)
         bind(self, "disabled", self.trigger_render)
 
-        self.register_event_type("on_change")
+        self.register_event_type("on_change")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
     def _x_for_value(self, value: float):
         """Provides the x coordinate for the given value."""

--- a/arcade/gui/widgets/toggle.py
+++ b/arcade/gui/widgets/toggle.py
@@ -72,7 +72,7 @@ class UITextureToggle(UIInteractiveWidget):
         )
 
         self.value = value
-        self.register_event_type("on_change")
+        self.register_event_type("on_change")  # type: ignore  # https://github.com/pyglet/pyglet/pull/1173  # noqa
 
         bind(self, "value", self.trigger_render)
         bind(self, "value", self._dispatch_on_change_event)

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -38,9 +38,7 @@ class Sound:
             raise FileNotFoundError(f"The sound file '{file_name}' is not a file or can't be read.")
         self.file_name = str(file_name)
 
-        self.source: Source = media.load(
-            self.file_name, streaming=streaming
-        )
+        self.source: Source = media.load(self.file_name, streaming=streaming)
 
         if self.source.duration is None:
             raise ValueError(

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -17,10 +17,10 @@ from arcade.resources import resolve
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
     pyglet.options.audio = tuple(  # type: ignore
-        v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(","))
+        v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(",")
+    )
 else:
-    pyglet.options.audio = ( # type: ignore
-        "openal", "xaudio2", "directsound", "pulse", "silent")
+    pyglet.options.audio = ("openal", "xaudio2", "directsound", "pulse", "silent")  # type: ignore
 
 import pyglet.media as media
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -16,9 +16,11 @@ from pyglet.media import Source
 from arcade.resources import resolve
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
-    pyglet.options.audio = tuple(v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(","))
+    pyglet.options.audio = tuple(  # type: ignore
+        v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(","))
 else:
-    pyglet.options.audio = ("openal", "xaudio2", "directsound", "pulse", "silent")
+    pyglet.options.audio = ( # type: ignore
+        "openal", "xaudio2", "directsound", "pulse", "silent")
 
 import pyglet.media as media
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -15,11 +15,11 @@ import pyglet
 from arcade.resources import resolve
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
-    pyglet.options["audio"] = tuple(
+    pyglet.options.audio = tuple(
         v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(",")
     )
 else:
-    pyglet.options["audio"] = ("openal", "xaudio2", "directsound", "pulse", "silent")
+    pyglet.options.audio = ("openal", "xaudio2", "directsound", "pulse", "silent")
 
 import pyglet.media as media
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import pyglet
+from pyglet.media import Source
 
 from arcade.resources import resolve
 
@@ -37,7 +38,7 @@ class Sound:
             raise FileNotFoundError(f"The sound file '{file_name}' is not a file or can't be read.")
         self.file_name = str(file_name)
 
-        self.source: Union[media.StaticSource, media.StreamingSource] = media.load(
+        self.source: Source = media.load(
             self.file_name, streaming=streaming
         )
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -15,9 +15,7 @@ import pyglet
 from arcade.resources import resolve
 
 if os.environ.get("ARCADE_SOUND_BACKENDS"):
-    pyglet.options.audio = tuple(
-        v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(",")
-    )
+    pyglet.options.audio = tuple(v.strip() for v in os.environ["ARCADE_SOUND_BACKENDS"].split(","))
 else:
     pyglet.options.audio = ("openal", "xaudio2", "directsound", "pulse", "silent")
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -45,9 +45,8 @@ def load_font(path: Union[str, Path]) -> None:
 FontNameOrNames = Union[str, tuple[str, ...]]
 
 
-def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames:
-    """
-    Attempt to resolve a tuple of font names.
+def _attempt_font_name_resolution(font_name: FontNameOrNames) -> str:
+    """Attempt to resolve a font name.
 
     Preserves the original logic of this section, even though it
     doesn't seem to make sense entirely. Comments are an attempt
@@ -83,8 +82,12 @@ def _attempt_font_name_resolution(font_name: FontNameOrNames) -> FontNameOrNames
             except FileNotFoundError:
                 pass
 
-    # failed to find it ourselves, hope pyglet can make sense of it
-    return font_name
+        # failed to find it ourselves, hope pyglet can make sense of it
+        # Note this is the best approximation of what I unerstand the old
+        # behavior to have been.
+        return pyglet.font.load(font_list).name
+
+    raise ValueError(f"Couldn't find a font for {font_name!r}")
 
 
 def _draw_pyglet_label(label: pyglet.text.Label) -> None:
@@ -204,6 +207,7 @@ class Text:
             )
 
         adjusted_font = _attempt_font_name_resolution(font_name)
+
         self._label = pyglet.text.Label(
             text=text,
             # pyglet is lying about what it takes here and float is entirely valid

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -517,7 +517,7 @@ class Text:
         self._label.bold = bold
 
     @property
-    def italic(self) -> bool:
+    def italic(self) -> bool | str:
         """
         Get or set the italic state of the label
         """

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -336,11 +336,17 @@ class Text:
         """
         Get or set the font name(s) for the label
         """
-        return self._label.font_name
+        if not isinstance(self._label.font_name, str):
+            return tuple(self._label.font_name)
+        else:
+            return self._label.font_name
 
     @font_name.setter
     def font_name(self, font_name: FontNameOrNames) -> None:
-        self._label.font_name = font_name
+        if isinstance(font_name, str):
+            self._label.font_name = font_name
+        else:
+            self._label.font_name = list(font_name)
 
     @property
     def font_size(self) -> float:

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -386,7 +386,7 @@ class Text:
         """
         Get or set the text color for the label
         """
-        return self._label.color
+        return Color.from_iterable(self._label.color)
 
     @color.setter
     def color(self, color: RGBOrA255):

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -135,7 +135,8 @@ class Text:
     :param width: A width limit in pixels
     :param align: Horizontal alignment; values other than "left" require width to be set
     :param Union[str, tuple[str, ...]] font_name: A font name, path to a font file, or list of names
-    :param bold: Whether to draw the text as bold
+    :param bold: Whether to draw the text as bold, and if a string,
+        how bold. See :py:attr:`.bold` to learn more.
     :param italic: Whether to draw the text as italic
     :param anchor_x: How to calculate the anchor point's x coordinate.
                          Options: "left", "center", or "right"
@@ -184,7 +185,7 @@ class Text:
         width: int | None = None,
         align: str = "left",
         font_name: FontNameOrNames = ("calibri", "arial"),
-        bold: bool = False,
+        bold: bool | str = False,
         italic: bool = False,
         anchor_x: str = "left",
         anchor_y: str = "baseline",
@@ -490,14 +491,23 @@ class Text:
         self._label.set_style("align", align)
 
     @property
-    def bold(self) -> bool:
+    def bold(self) -> bool | str:
         """
-        Get or set bold state of the label
+        Get or set bold state of the label.
+
+        The supported values include:
+
+        * ``"black"``
+        * ``"bold" (same as ``True``)
+        * ``"semibold"``
+        * ``"semilight"``
+        * ``"light"``
+
         """
         return self._label.bold
 
     @bold.setter
-    def bold(self, bold: bool):
+    def bold(self, bold: bool | str):
         self._label.bold = bold
 
     @property
@@ -593,7 +603,7 @@ def create_text_sprite(
     width: int | None = None,
     align: str = "left",
     font_name: FontNameOrNames = ("calibri", "arial"),
-    bold: bool = False,
+    bold: bool | str = False,
     italic: bool = False,
     anchor_x: str = "left",
     multiline: bool = False,
@@ -684,7 +694,7 @@ def draw_text(
     width: int | None = None,
     align: str = "left",
     font_name: FontNameOrNames = ("calibri", "arial"),
-    bold: bool = False,
+    bold: bool | str = False,
     italic: bool = False,
     anchor_x: str = "left",
     anchor_y: str = "baseline",
@@ -724,7 +734,8 @@ def draw_text(
     :param width: A width limit in pixels
     :param align: Horizontal alignment; values other than "left" require width to be set
     :param Union[str, tuple[str, ...]] font_name: A font name, path to a font file, or list of names
-    :param bold: Whether to draw the text as bold
+    :param bold: Whether to draw the text as bold, and if a :py:class:`str`,
+        how bold to draw it. See :py:attr:`.Text.bold` to learn more.
     :param italic: Whether to draw the text as italic
     :param anchor_x: How to calculate the anchor point's x coordinate
     :param anchor_y: How to calculate the anchor point's y coordinate

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -217,7 +217,7 @@ class Text:
             anchor_y=anchor_y,  # type: ignore
             color=Color.from_iterable(color),
             width=width,
-            align=align,
+            align=align,  # type: ignore
             bold=bold,
             italic=italic,
             multiline=multiline,

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -215,7 +215,8 @@ class Text:
             y=y,  # type: ignore
             z=z,  # type: ignore
             font_name=adjusted_font,
-            font_size=font_size,
+            # TODO: Fix this upstream (Mac & Linux seem to allow float)
+            font_size=font_size,  # type: ignore
             # use type: ignore since cast is slow & pyglet used Literal
             anchor_x=anchor_x,  # type: ignore
             anchor_y=anchor_y,  # type: ignore

--- a/doc/programming_guide/headless.rst
+++ b/doc/programming_guide/headless.rst
@@ -32,7 +32,11 @@ This can be done in the following ways:
     import os
     os.environ["ARCADE_HEADLESS"] = "True"
 
-This means you can configure headless externally.
+    # The above is a shortcut for
+    import pyglet
+    pyglet.options.headless = True
+
+This of course also means you can configure headless externally.
 
 .. code:: bash
 
@@ -178,10 +182,10 @@ to a physical device (graphics card) or a virtual card/device.
 .. code:: py
 
     # Default setting
-    pyglet.options['headless_device'] = 0
+    pyglet.options.headless_device = 0
 
     # Use the second gpu/device
-    pyglet.options['headless_device'] = 1
+    pyglet.options.headless_device = 1
 
 Issues?
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pyglet == 2.1dev3",
+    # Use pyglet's development branch as a rolling release package
+    # at the cost of slow download and constant pip install -I -e .[dev]
+    "pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
+    # Expected future dev preview release on PyPI (not yet released)
+    # pyglet == 2.1dev4
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # Use pyglet's development branch as a rolling release package
+    # Fallback to use pyglet's development branch as a rolling release package
     # at the cost of slow download and constant pip install -I -e .[dev]
-    "pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
+    #"pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
     # Expected future dev preview release on PyPI (not yet released)
-    # pyglet == 2.1dev4
+    'pyglet == 2.1dev4',
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # at the cost of slow download and constant pip install -I -e .[dev]
     #"pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
     # Expected future dev preview release on PyPI (not yet released)
-    'pyglet == 2.1dev4',
+    'pyglet == 2.1.dev4',
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
 ]
 dependencies = [
     # Fallback to use pyglet's development branch as a rolling release package
-    # at the cost of slow download and constant pip install -I -e .[dev]
-    #"pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
+    # at the cost of slow download and constant pip install -I -e .[dev]    
+    # "pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
     # Expected future dev preview release on PyPI (not yet released)
-    'pyglet == 2.1.dev4',
+    'pyglet==2.1.dev4',
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",
@@ -42,14 +42,14 @@ Book = "https://learn.arcade.academy"
 # Used for dev work
 dev = [
     # --- Documentation: Sphinx 7 based currently
-    "sphinx==7.3.7",  # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
-    "sphinx_rtd_theme==2.0.0",  # Nov 2023
+    "sphinx==7.3.7",               # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
+    "sphinx_rtd_theme==2.0.0",     # Nov 2023
     "sphinx-rtd-dark-mode==1.3.0",
-    "sphinx-autobuild==2024.4.16",  # April 2024 | Due to this, Python 3.10+ is required to serve docs
-    "sphinx-copybutton==0.5.2", # April 2023
-    "sphinx-sitemap==2.6.0",  # April 2024
-    "pygments==2.17.2",  # 2.18 has breaking changes in lexer
-    "docutils==0.20.1",  # ?
+    "sphinx-autobuild==2024.4.16", # April 2024 | Due to this, Python 3.10+ is required to serve docs
+    "sphinx-copybutton==0.5.2",    # April 2023
+    "sphinx-sitemap==2.6.0",       # April 2024
+    "pygments==2.17.2",            # 2.18 has breaking changes in lexer
+    "docutils==0.20.1",            # ?
     # "pyyaml==6.0.1",
     # "readthedocs-sphinx-search==0.3.2",
     # "sphinx-autodoc-typehints==2.0.1",
@@ -58,12 +58,12 @@ dev = [
     "pytest-cov",
     "pytest-mock",
     "coverage",
-    "coveralls",  # Do we really need this?
+    "coveralls",          # Do we really need this?
     "black",
     "ruff",
     "mypy",
-    "pyright==1.1.355",    
-    "typer[all]==0.11.0",  # Needed for make.py
+    "pyright==1.1.355",
+    "typer[all]==0.11.0", # Needed for make.py
     "wheel",
 ]
 # Testing only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pyglet == 2.1dev2",
+    "pyglet == 2.1dev3",
     "pillow~=10.2.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     "black",
     "ruff",
     "mypy",
-    "pyright==1.1.355",
+    "pyright==1.1.372",
     "typer[all]==0.11.0", # Needed for make.py
     "wheel",
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,4 @@ import os
 # Headless mode
 if os.environ.get("ARCADE_HEADLESS_TEST"):
     import pyglet
-    pyglet.options["headless"] = True
+    pyglet.options.headless = True

--- a/tests/unit/test_arcade.py
+++ b/tests/unit/test_arcade.py
@@ -5,6 +5,10 @@ import arcade
 from arcade import *
 
 
+# TODO: double-check whether this is actually the right solution?
+builtin_types = frozenset((bool, str, int, ModuleType))
+
+
 def test_import():
     """Compare arcade.__all__ to the actual module contents"""
     import arcade
@@ -16,7 +20,8 @@ def test_import():
     remaining = arcade_names - common
     for name in copy(remaining):
         attr = getattr(arcade, name)
-        if type(attr) is ModuleType:
+        attr_type = type(attr)
+        if attr_type in builtin_types:
             remaining.remove(name)
         elif not attr.__module__.startswith('arcade.'):
             remaining.remove(name)

--- a/tests/unit/test_arcade.py
+++ b/tests/unit/test_arcade.py
@@ -2,6 +2,7 @@ from types import ModuleType
 from copy import copy
 import logging
 import arcade
+import inspect
 from arcade import *
 
 
@@ -16,9 +17,13 @@ def test_import():
     remaining = arcade_names - common
     for name in copy(remaining):
         attr = getattr(arcade, name)
-        if type(attr) is ModuleType:
+        if type(attr) is ModuleType or not inspect.isroutine(attr):
             remaining.remove(name)
-        elif not attr.__module__.startswith('arcade.'):
+        # Extra awful trick because:
+        # 1. attempting to get __module__ of bool members raises AttributeError
+        # 2. inspect.isbuiltin(bool) does not return True for bool
+        # 2. inspect.getmodule(bool) returns the builtins module
+        elif not inspect.getmodule(attr).__name__.startswith('arcade.'):
             remaining.remove(name)
 
     assert len(remaining) == 0

--- a/tests/unit/test_arcade.py
+++ b/tests/unit/test_arcade.py
@@ -2,7 +2,6 @@ from types import ModuleType
 from copy import copy
 import logging
 import arcade
-import inspect
 from arcade import *
 
 
@@ -17,13 +16,9 @@ def test_import():
     remaining = arcade_names - common
     for name in copy(remaining):
         attr = getattr(arcade, name)
-        if type(attr) is ModuleType or not inspect.isroutine(attr):
+        if type(attr) is ModuleType:
             remaining.remove(name)
-        # Extra awful trick because:
-        # 1. attempting to get __module__ of bool members raises AttributeError
-        # 2. inspect.isbuiltin(bool) does not return True for bool
-        # 2. inspect.getmodule(bool) returns the builtins module
-        elif not inspect.getmodule(attr).__name__.startswith('arcade.'):
+        elif not attr.__module__.startswith('arcade.'):
             remaining.remove(name)
 
     assert len(remaining) == 0


### PR DESCRIPTION
*Supercedes #2183 (same contents, just a branch on the main Arcade repo)*

## Big changes:

1. Modified code to use `pyglet.options` object appropriately
2. No more `__eq__` deletion tricks
3. Partly document and type the pyglet text stack's apparent secret undocumented support for partial bolding (yes, I tested this)

## Other changes:
- [x] Sound annotations
- [x] Align & `pyright`'s spec-violating ideas o on `Literal` for text
- [x] Document the apparent undocumented support for string bold values across non-win32 platforms
- [x] Use `| None` in a few places
- [x] Temp fix `float` vs `int` for window sizes (Apple supports these, apparently  to simplify touch events)

## To resolve:
(moved to #2278 + will move to sub-issues as needed)