### PR TITLE
Resolve correct member paths in the documentation

### DIFF
--- a/util/check_example_line_length.py
+++ b/util/check_example_line_length.py
@@ -1,41 +1,43 @@
-import os
-import glob
-import shutil
-import re
+"""
+Utility for finding long lines in example.
 
+This causes issues when displaying in docs because the code will
+visually be cut off on the right side.
+"""
+import re
 from pathlib import Path
 
+EXAMPLE_ROOT = Path(__file__).resolve().parent.parent / "arcade" / "examples"
 
-def search_files(file_pattern, reg_pattern):
+
+def search_files(path: Path, reg_pattern):
     # Validate HTML files
-    html_files = glob.glob(file_pattern, recursive=True)
+    paths = path.glob("**/*.py") 
 
     regex = re.compile(reg_pattern)
     grand_total = 0
     file_count = 0
-    for file_name in html_files:
+
+    for path in paths:
         file_count += 1
         line_no = 0
-        with open(file_name, encoding="utf8") as f:
+        with open(path, encoding="utf8") as f:
             for line in f:
                 line_no += 1
                 result = regex.search(line)
                 if result:
-                    print(f"  {file_name}:{line_no}: " + line.strip())
+                    print(f"  {path.relative_to(EXAMPLE_ROOT)}:{line_no}: " + line.strip())
                     grand_total += 1
+
     print(f"{grand_total} across {file_count} files.")
     return grand_total
 
 
-def generic_test(title, file_pattern, text_pattern):
-    print()
-    print(title)
-    search_files(file_pattern, text_pattern)
-
-
 def main():
-    # Remove old directory
-    generic_test("LINE_LENGTH", "../arcade/examples/**/*.py", "^.{115}.*$")
+    # Look for lines in examples with line length > 115
+    print()
+    print("LINE_LENGTH")
+    search_files(path=EXAMPLE_ROOT, reg_pattern="^.{115}.*$")
 
 
 main()

--- a/util/convert_rst_to_google_docs.py
+++ b/util/convert_rst_to_google_docs.py
@@ -1,3 +1,9 @@
+"""
+Attempt to convert the docstrings in the Arcade codebase from RST to Google Docs format.
+
+https://github.com/pythonarcade/arcade/issues/1797
+"""
+
 import glob
 import re
 

--- a/util/update_quick_index.py
+++ b/util/update_quick_index.py
@@ -13,7 +13,6 @@ via hotkeys.
 """
 from __future__ import annotations
 
-import os
 import re
 import sys
 from collections.abc import Mapping
@@ -31,7 +30,8 @@ from doc_helpers import (
     EMPTY_TUPLE,
     get_module_path,
     NotExcludedBy,
-    Vfs
+    Vfs,
+    build_import_tree,
 )
 
 
@@ -39,6 +39,7 @@ REPO_ROOT = SharedPaths.REPO_ROOT
 ARCADE_ROOT = SharedPaths.ARCADE_ROOT
 API_DOC_GENERATION_DIR = SharedPaths.API_DOC_ROOT / "api"
 QUICK_INDEX_FILE_PATH = API_DOC_GENERATION_DIR / "quick_index.rst"
+IMPORT_TREE = build_import_tree(ARCADE_ROOT)
 
 # --- 1. Special rules & excludes ---
 
@@ -459,7 +460,7 @@ def generate_api_file(api_file_name: str, vfs: Vfs):
         ) -> Generator[tuple[str, str], None, None]:
             kind_list = member_lists[kind]
             for name in filter(member_not_excluded, kind_list):
-                yield name, f"{module_name}.{name}"
+                yield name, IMPORT_TREE.resolve(f"{module_name}.{name}")
 
         # Classes
         for name, full_name in iter_declarations('class'):


### PR DESCRIPTION
We want all paths in the documentation to use the lowest imported version.

For example: We want `arcade.Sprite`, not `arade.sprite.Sprite`. There are worse examples.

Build a quit import tree parsing the `__init__.py` files in the project and resolve the lowest import of that member. This should automagically fix most issues.

Also cleaned up some other stuff in there with the intention of documenting the existing scripts.