### PR TITLE
Remove font loading on arcade init

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -406,19 +406,6 @@ __version__ = VERSION
 
 # Piggyback on pyglet's doc run detection
 if not getattr(sys, "is_pyglet_doc_run", False):
-    # Auto load fonts
-    load_font(":system:fonts/ttf/Kenney_Blocks.ttf")
-    load_font(":system:fonts/ttf/Kenney_Future.ttf")
-    load_font(":system:fonts/ttf/Kenney_Future_Narrow.ttf")
-    load_font(":system:fonts/ttf/Kenney_High.ttf")
-    load_font(":system:fonts/ttf/Kenney_High_Square.ttf")
-    load_font(":system:fonts/ttf/Kenney_Mini.ttf")
-    load_font(":system:fonts/ttf/Kenney_Mini_Square.ttf")
-    load_font(":system:fonts/ttf/Kenney_Pixel.ttf")
-    load_font(":system:fonts/ttf/Kenney_Pixel_Square.ttf")
-    load_font(":system:fonts/ttf/Kenney_Rocket.ttf")
-    load_font(":system:fonts/ttf/Kenney_Rocket_Square.ttf")
-
     # Load additional game controller mappings to Pyglet
     if not pyglet.options["headless"]:
         try:

--- a/arcade/examples/drawing_text.py
+++ b/arcade/examples/drawing_text.py
@@ -12,6 +12,9 @@ SCREEN_TITLE = "Drawing Text Example"
 DEFAULT_LINE_HEIGHT = 45
 DEFAULT_FONT_SIZE = 20
 
+# Load fonts bumbled with arcade such as the Kenney fonts
+arcade.resources.load_system_fonts()
+
 
 class MyGame(arcade.Window):
     """

--- a/arcade/examples/drawing_text_objects.py
+++ b/arcade/examples/drawing_text_objects.py
@@ -13,6 +13,9 @@ SCREEN_TITLE = "Drawing Text Example"
 DEFAULT_LINE_HEIGHT = 45
 DEFAULT_FONT_SIZE = 20
 
+# Load fonts bumbled with arcade such as the Kenney fonts
+arcade.resources.load_system_fonts()
+
 
 class MyGame(arcade.Window):
     """

--- a/arcade/examples/drawing_text_objects_batch.py
+++ b/arcade/examples/drawing_text_objects_batch.py
@@ -15,6 +15,8 @@ python -m arcade.examples.drawing_text_objects_batch
 import arcade
 from pyglet.graphics import Batch
 
+# Load fonts bumbled with arcade such as the Kenney fonts
+arcade.resources.load_system_fonts()
 
 WINDOW_WIDTH = 1280  # Window width in pixels
 WINDOW_HEIGHT = 800  # Window height in pixels

--- a/arcade/examples/gui_widgets.py
+++ b/arcade/examples/gui_widgets.py
@@ -10,6 +10,9 @@ import arcade.gui.widgets.buttons
 import arcade.gui.widgets.layout
 import arcade.gui.widgets.text
 
+# Load fonts bumbled with arcade such as the Kenney fonts
+arcade.resources.load_system_fonts()
+
 
 class MyView(arcade.View):
     def __init__(self):

--- a/arcade/resources/__init__.py
+++ b/arcade/resources/__init__.py
@@ -202,3 +202,35 @@ def list_built_in_assets(
         filtered_paths.append(path)
 
     return filtered_paths
+
+
+def load_system_fonts() -> None:
+    """Loads all the fonts in arcade's system directory.
+
+    Currently this is only the Kenney fonts::
+
+        Kenney_Blocks.ttf
+        Kenney_Future.ttf
+        Kenney_Future_Narrow.ttf
+        Kenney_High.ttf
+        Kenney_High_Square.ttf
+        Kenney_Mini.ttf
+        Kenney_Mini_Square.ttf
+        Kenney_Pixel.ttf
+        Kenney_Pixel_Square.ttf
+        Kenney_Rocket.ttf
+        Kenney_Rocket_Square.ttf
+    """
+    from arcade.text import load_font
+
+    load_font(":system:fonts/ttf/Kenney_Blocks.ttf")
+    load_font(":system:fonts/ttf/Kenney_Future.ttf")
+    load_font(":system:fonts/ttf/Kenney_Future_Narrow.ttf")
+    load_font(":system:fonts/ttf/Kenney_High.ttf")
+    load_font(":system:fonts/ttf/Kenney_High_Square.ttf")
+    load_font(":system:fonts/ttf/Kenney_Mini.ttf")
+    load_font(":system:fonts/ttf/Kenney_Mini_Square.ttf")
+    load_font(":system:fonts/ttf/Kenney_Pixel.ttf")
+    load_font(":system:fonts/ttf/Kenney_Pixel_Square.ttf")
+    load_font(":system:fonts/ttf/Kenney_Rocket.ttf")
+    load_font(":system:fonts/ttf/Kenney_Rocket_Square.ttf")


### PR DESCRIPTION
* Don't load fonts in `arade.__init__`. This have been a headache for many users trying to distribute they games
* `arcade.resources.load_system_fonts()` can be called instead when you need them