### PR TITLE
Docs: CSS overhaul for new RTD Sphinx theme, Part 2

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -103,21 +103,31 @@ html[data-theme="dark"] .wy-nav-top a {
     content: none;
 }
 
-/* Swap the ordering of default RTD logo/title elements and position accordingly. */
+/* Redesign the top-left logo area. */
 .wy-side-nav-search .icon-home {
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: column-reverse;
     align-items: center;
-    justify-content: left;
 
     padding: 16px 12px;
+    padding-bottom: 32px;
 
     color: var(--color-emphasis) !important;
+
+    border-radius: 16px;
 }
 .wy-side-nav-search .icon-home img.logo {
     margin: 0 !important;
-    padding: 0px;
-    padding-right: 10px;
+    padding: 0;
+    max-width: 100px;
+    padding-bottom: 16px;
+}
+.wy-side-nav-search > div.version {
+    font-size: 85%;
+    /* Same monospace as our `pre` blocks */
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
+    margin-top: -38px;
+    margin-bottom: 24px;
 }
 
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -217,6 +217,57 @@ html[data-theme="dark"] .wy-nav-top a {
     font-size: 85%;
     color: var(--dark-link-color);
 }
+
+
+/*
+ * Facelift example page with custom card layout
+ */
+#examples figure {
+  display: inline-flex;
+  align-items: center;
+  flex-direction: column;
+
+  background-color: #eee;
+
+  padding: 24px;
+  padding-bottom: 0;
+
+  /* Tuned so that all cards with up to 3 rows of text (95%) will be the same height. */
+  min-height: 230px;
+
+  margin-right: 4px;
+
+  width: 190px !important;
+
+  border: #ddd 1px solid;
+  border-radius: 8px;
+}
+
+#examples figure figcaption {
+    padding: 16px 0;
+}
+#examples figure figcaption .headerlink {
+    display: none;
+}
+#examples figure figcaption * {
+    margin: 0;
+    display: inline-block;
+}
+#examples figure img {
+    /* Notice: the uniformity of these "cards" is based on the images all being same height */
+    height: 100px;
+
+    border: #bbb 1px solid;
+    border-radius: 8px;
+}
+
+html[data-theme="dark"] #examples figure {
+  background-color: #2b2b2b;
+  border-color: #333;
+}
+html[data-theme="dark"] #examples figure img {
+    border: #111 2px solid;
+}
 /* Wrap individual main page items for easier group manipulation
  of contents and images. See PR #2027 for main page css changes */
 .main-page-item-wrapper {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -6,6 +6,10 @@
 
     --color-main-bg-light: #f2f2f2;
     --color-main-bg-dark: #202020;
+
+    /* Variable defined by the rtd dark mode extension.
+     * Explicitly redefined to match the light mode link color. */
+    ---dark-link-color: #2980b9;
 }
 
 body {
@@ -22,6 +26,13 @@ body {
     .toc-outside-links {
         columns: 2;
     }
+}
+
+
+/* Fix some basic html element colors in dark mode */
+html[data-theme="dark"] input,
+html[data-theme="dark"] label {
+    color: var(--dark-text-color);
 }
 
 
@@ -199,6 +210,13 @@ html[data-theme="dark"] .wy-nav-top a {
 /* </sidebar_toggle> */
 
 
+/* Fix the monospaced fonts in API quick reference listing */
+#quickapi code {
+    background: none;
+    border: none;
+    font-size: 85%;
+    color: var(--dark-link-color);
+}
 /* Wrap individual main page items for easier group manipulation
  of contents and images. See PR #2027 for main page css changes */
 .main-page-item-wrapper {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -58,6 +58,14 @@ html[data-theme="dark"] .wy-menu-vertical li.toctree-l2.current li.toctree-l3 > 
     border-right: currentcolor;
 }
 
+/* Fix nav tree item visibility for API reference page titles */
+.toctree-l3 code,
+html[data-theme="dark"] .toctree-l3 code {
+    background: none;
+    border: none;
+    font-size: 90%;
+}
+
 
 /* The main content area */
 .wy-nav-content {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -268,6 +268,109 @@ html[data-theme="dark"] #examples figure {
 html[data-theme="dark"] #examples figure img {
     border: #111 2px solid;
 }
+
+
+/*
+ * Syntax highlight color fixes for basic code blocks in dark mode.
+ * <code_colors>
+ */
+html[data-theme="dark"] pre {
+    /* baseline */
+    background-color: #282828 !important;
+    color: #e0e0e0 !important;
+}
+html[data-theme="dark"] pre .linenos {
+    /* line numbers */
+    color: #888 !important;
+    border-right-color: #404040 !important;
+}
+html[data-theme="dark"] pre .nc {
+    /* class declarations */
+    color: #0880FF !important;
+}
+html[data-theme="dark"] pre .kc,
+html[data-theme="dark"] pre .kn,
+html[data-theme="dark"] pre .nb,
+html[data-theme="dark"] pre .bp,
+html[data-theme="dark"] pre .k {
+    /* `None` + `import` + typehints + `self` + keywords */
+    color: var(--color-emphasis) !important;
+}
+html[data-theme="dark"] pre .fm,
+html[data-theme="dark"] pre .vm,
+html[data-theme="dark"] pre .nf {
+    /* function + method declarations + `__name__` */
+    color: #00B7FF !important;
+    font-weight: bold;
+}
+html[data-theme="dark"] pre .nd,
+html[data-theme="dark"] pre .ow,
+html[data-theme="dark"] pre .si,
+html[data-theme="dark"] pre .sa {
+    /* decorators + `in` + f-string tokens */
+    color: #D56CF2 !important;
+}
+html[data-theme="dark"] pre .s1,
+html[data-theme="dark"] pre .s2,
+html[data-theme="dark"] pre .sd {
+    /* strings + docstrings */
+    color: #FF873F !important;
+}
+html[data-theme="dark"] pre .c1 {
+    /* comments */
+    color: #4c8831 !important;
+}
+html[data-theme="dark"] pre .o,
+html[data-theme="dark"] pre .mf,
+html[data-theme="dark"] pre .mi {
+    /* operators + numeral variable values */
+    color: #afafaf !important;
+}
+html[data-theme="dark"] pre .gp {
+    /* The REPL `>>>` token */
+    color: var(--color-emphasis) !important;
+}
+html[data-theme="dark"] pre .hll {
+    /* Line highlights background */
+    background-color: #323331 !important;
+}
+
+html[data-theme="dark"] .rst-content code.literal {
+    /* in-line code blocks */
+    color: #FF873F;
+}
+/* </code_colors> */
+
+
+/*
+ * Color fixes for Sphinx-generated class and function info boxes in dark mode.
+ * <sphinx_colors>
+ */
+html.writer-html4 .rst-content dl:not(.docutils) > dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
+    border-color: var(--color-emphasis);
+    color: #383838;
+    background-color: #eef6eb;
+}
+html[data-theme="dark"].writer-html4 .rst-content dl:not(.docutils) > dt,
+html[data-theme="dark"].writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
+    border-color: #689d52 !important;
+    color: #ababab !important;
+    background-color: #262826 !important;
+}
+
+html[data-theme="dark"] .sig.py .descname .pre,
+html[data-theme="dark"] .sig.py .descclassname .pre {
+    color: #eee !important;
+}
+html[data-theme="dark"] .rst-content .viewcode-link {
+    /* make the "[source]" link less popping in the definition boxes */
+    color: var(--dark-link-color);
+    opacity: 0.3;
+}
+/* </sphinx_colors> */
+
+
 /* Wrap individual main page items for easier group manipulation
  of contents and images. See PR #2027 for main page css changes */
 .main-page-item-wrapper {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,7 +161,7 @@ html_css_files = [
 ]
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/favicon-32x32.png'
+html_logo = '_static/android-chrome-192x192.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
New stylistic features include:

### Specific to new dark mode
- All code blocks recolored
- All sphinx blocks recolored
- API reference links recolored in navigation
- API quick_index table recolored

All recolorizations were made to "match" the light mode as much as possible, with minimal artistic intervention. Eg. string symbol is red in light mode -> make a red-ish variant in dark.


### General
- New logo area!
- Examples page facelift!
- Minor color adjustments to light mode sphinx blocks


### Quick previews

![image](https://github.com/user-attachments/assets/5804ced3-5d95-4973-84f6-c54a7f7693fd)
![image](https://github.com/user-attachments/assets/c5755347-75f6-40de-af6e-ebcf03d7ae21)
