### PR TITLE
Improve header fonts

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -611,8 +611,19 @@ h4,
 h5,
 h6,
 legend {
-  font-weight: 500;
   font-family:"Josefin Sans", Arial, Helvetica, sans-serif;
+}
+
+.rst-content h1 {
+    font-weight: 600;
+}
+
+.rst-content h2,
+h3,
+h4,
+h5,
+h6 {
+    font-weight: 500;
 }
 
 .icon-home {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -592,3 +592,31 @@ body:not([data-theme="light"]) .highlight .c1 {
     margin:0px;
     padding: 0px;
 }
+
+/* Change font for headers and title*/
+@font-face {
+    font-family: 'Josefin Sans';
+    font-style: normal;
+    font-weight: 100 700;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/josefinsans/v32/Qw3aZQNVED7rKGKxtqIqX5EUDXx4.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+.rst-content .toctree-wrapper>p.caption,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+legend {
+  font-weight: 500;
+  font-family:"Josefin Sans", Arial, Helvetica, sans-serif;
+}
+
+.icon-home {
+  font-weight: 500;
+  font-family:"Josefin Sans", Arial, Helvetica, sans-serif;
+  font-size: larger;
+}


### PR DESCRIPTION
We aren't a Western movie, and we're cooler than "Default Read The Docs." Let's get this place classed up a bit, yeah?

Replace Roboto Slab with [Josefin Sans](https://fonts.google.com/specimen/Josefin+Sans).

![arcade_before_after](https://github.com/user-attachments/assets/1fe3cff8-71f2-4aaa-93c8-09c54d94c3f4)
