### PR TITLE
Update the README with both Stable doc and Dev Preview doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ It is ideal for beginning programmers, or programmers who want to create
 2D games without learning a complex framework.
 
 [pyglet]: https://github.com/pyglet/pyglet
-
-Arcade is built on top of [pyglet][] and OpenGL. For examples of games made Arcade,
-please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
+[Games Made with Arcade]: https://api.arcade.academy/en/latest/sample_games.html
+Arcade is built on top of [pyglet][] and OpenGL. See [Games Made with Arcade][]
+for game jam entries and more.
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Arcade is built on top of Pyglet and OpenGL.
 
 ![MIT License](https://img.shields.io/pypi/l/arcade)
 
-
-For games made with Arcade, see the [sample games](https://api.arcade.academy/en/latest/sample_games.html).
+For examples of games made Arcade, please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
 
 ## Stable Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Arcade is built on top of Pyglet and OpenGL.
 
 [<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
 [<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
+[<img src="https://discord.com/api/guilds/458662222697070613/widget.png?style=shield" alt="Discord Shield"/>][Arcade Discord Server]
 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
 

--- a/README.md
+++ b/README.md
@@ -18,37 +18,13 @@ for example game jam entries and more.
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
 ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/pythonarcade/arcade)
 
-
 ## Stable Documentation
 
-[Arcade Academy - Learn Python]: https://learn.arcade.academy
-
-The current stable release is best for following [Arcade Academy - Learn Python][].
-
-Read the stable documentation at https://api.arcade.academy or use these quick links:
-
-[Install Arcade]: https://api.arcade.academy/en/latest/install/index.html
-[Example Code]: https://api.arcade.academy/en/latest/examples/index.html
-[API Reference]: https://api.arcade.academy/en/latest/arcade.html
-[API Search]: https://api.arcade.academy/en/latest/quick_index.html
-[Release Notes]: https://api.arcade.academy/en/latest/development/release_notes.html
-
-| [Install Arcade][] | [Example Code][] | [API Reference][] | [API Search][] | [Release Notes][] |
-|--------------------|------------------|-------------------|----------------|-------------------|
-
-> [!NOTE]
-> This version does not support Python 3.12. See the Development Previews section below.
+Read the stable documentation at https://api.arcade.academy.
 
 ## Development Previews
 
-To help test Arcade's work-in-progress 3.0 version, see https://api.arcade.academy/en/development/
-
-This updates every time this repository's `development` branch is updated. You may
-prefer this version if:
-
-* You are familiar with Python and want the latest features
-* You want to the work of updating when Arcade 3.0 releases
-* You need to use Python 3.12
+For an unfinished preview of the next release, see https://api.arcade.academy/en/development/.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ Arcade is an easy-to-learn Python library for creating 2D video games.
 It is ideal for beginning programmers, or programmers who want to create
 2D games without learning a complex framework.
 
-Arcade is built on top of Pyglet and OpenGL.
+Arcade is built on top of Pyglet and OpenGL. For examples of games made Arcade,
+please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
 ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/pythonarcade/arcade)
 
-
-For examples of games made Arcade, please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
 
 ## Stable Documentation
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Arcade is built on top of Pyglet and OpenGL.
 ![MIT License](https://img.shields.io/pypi/l/arcade)
 
 
+For games made with Arcade, see  https://api.arcade.academy/en/latest/sample_games.html
+
 ## Stable Documentation
 
 [Arcade Academy - Learn Python]: https://learn.arcade.academy
@@ -35,8 +37,6 @@ Read the stable documentation at https://api.arcade.academy or use these quick l
 
 | [Install Arcade][] | [Example Code][] | [API Reference][] | [API Search][] | [Release Notes][] |
 |--------------------|------------------|-------------------|----------------|-------------------|
-
-For games made with Arcade, see  https://api.arcade.academy/en/latest/sample_games.html
 
 > [!NOTE]
 > This version does will not add support for Python 3.12. See the Development Preview below.

--- a/README.md
+++ b/README.md
@@ -15,18 +15,35 @@ Arcade is built on top of Pyglet and OpenGL.
 
 ![MIT License](https://img.shields.io/pypi/l/arcade)
 
-## Documentation
 
-* For full documentation see https://api.arcade.academy
-* For installation: https://api.arcade.academy/en/latest/install/index.html
+## Stable Documentation
+
+The latest stable release is best for following the paired Python tutorial.
+
+To read the stable documentation, see latest release at https://api.arcade.academy
+or the following quick links:
+
+* To install, see: https://api.arcade.academy/en/latest/install/index.html
 * For example code that uses the Arcade library see: https://api.arcade.academy/en/latest/examples/index.html
 * For API documentation see: https://api.arcade.academy/en/latest/quick_index.html
 * Learn Arcade AND how to program: https://learn.arcade.academy
+* For games made with the stable version, see  https://api.arcade.academy/en/latest/sample_games.html
 * Release notes: https://api.arcade.academy/en/latest/development/release_notes.html
 
-## Games Using Arcade
+> [!NOTE]
+> This version does will not add support for Python 3.12. See the Development Preview below
 
-See: https://api.arcade.academy/en/latest/sample_games.html
+
+## Development Previews
+
+To help test the work-in-progress 3.0 release, see https://api.arcade.academy/en/development/
+
+This updates every time this repository's `development` branch is updated. You may
+prefer this version if:
+
+* You are familiar with Python and want the latest features
+* You want to the work of updating when Arcade 3.0 releases
+* You have no choice but to use Python 3.12
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Read the stable documentation at https://api.arcade.academy or use these quick l
 
 ## Development Previews
 
-To help test the work-in-progress 3.0 release, see https://api.arcade.academy/en/development/
+To help test Arcade's work-in-progress 3.0 version, see https://api.arcade.academy/en/development/
 
 This updates every time this repository's `development` branch is updated. You may
 prefer this version if:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is ideal for beginning programmers, or programmers who want to create
 [pyglet]: https://github.com/pyglet/pyglet
 [Games Made with Arcade]: https://api.arcade.academy/en/latest/sample_games.html
 Arcade is built on top of [pyglet][] and OpenGL. See [Games Made with Arcade][]
-for game jam entries and more.
+for example game jam entries and more.
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ For games made with Arcade, see  https://api.arcade.academy/en/latest/sample_gam
 
 [Arcade Academy - Learn Python]: https://learn.arcade.academy
 
-The latest stable release is best for learning to program by
-reading [Arcade Academy - Learn Python][].
+The current stable release is best for following [Arcade Academy - Learn Python][].
 
 Read the stable documentation at https://api.arcade.academy or use these quick links:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or the following quick links:
 * Release notes: https://api.arcade.academy/en/latest/development/release_notes.html
 
 > [!NOTE]
-> This version does will not add support for Python 3.12. See the Development Preview below
+> This version does will not add support for Python 3.12. See the Development Preview below.
 
 
 ## Development Previews

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Read the stable documentation at https://api.arcade.academy.
 
 ## Development Previews
 
-For an unfinished preview of the next release, see https://api.arcade.academy/en/development/.
+Preview the unfinished next release at https://api.arcade.academy/en/development/.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ prefer this version if:
 
 * You are familiar with Python and want the latest features
 * You want to the work of updating when Arcade 3.0 releases
-* You have no choice but to use Python 3.12
+* You need to use Python 3.12
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Welcome to The Arcade Library!
 
+![MIT License](https://img.shields.io/pypi/l/arcade)
+[<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
+[<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
+
 Arcade is an easy-to-learn Python library for creating 2D video games.
 It is ideal for beginning programmers, or programmers who want to create
 2D games without learning a complex framework.
@@ -8,14 +12,9 @@ Arcade is built on top of Pyglet and OpenGL.
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 
-[<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
-[<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
-
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
-
 ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/pythonarcade/arcade)
 
-![MIT License](https://img.shields.io/pypi/l/arcade)
 
 For examples of games made Arcade, please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Arcade is built on top of Pyglet and OpenGL.
 ![MIT License](https://img.shields.io/pypi/l/arcade)
 
 
-For games made with Arcade, see  https://api.arcade.academy/en/latest/sample_games.html
+For games made with Arcade, see the [sample games](https://api.arcade.academy/en/latest/sample_games.html).
 
 ## Stable Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Arcade is an easy-to-learn Python library for creating 2D video games.
 It is ideal for beginning programmers, or programmers who want to create
 2D games without learning a complex framework.
 
-Arcade is built on top of Pyglet and OpenGL. For examples of games made Arcade,
+[pyglet]: https://github.com/pyglet/pyglet
+
+Arcade is built on top of [pyglet][] and OpenGL. For examples of games made Arcade,
 please see [Games Made with Arcade](https://api.arcade.academy/en/latest/sample_games.html).
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Arcade is built on top of Pyglet and OpenGL.
 
 [<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
 [<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
-[<img src="https://discord.com/api/guilds/458662222697070613/widget.png?style=shield" alt="Discord Shield"/>][Arcade Discord Server]
 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Read the stable documentation at https://api.arcade.academy or use these quick l
 |--------------------|------------------|-------------------|----------------|-------------------|
 
 > [!NOTE]
-> This version does will not add support for Python 3.12. See the Development Preview below.
-
+> This version does not support Python 3.12. See the Development Previews section below.
 
 ## Development Previews
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It is ideal for beginning programmers, or programmers who want to create
 
 Arcade is built on top of Pyglet and OpenGL.
 
+[Arcade Discord Server]: https://discord.gg/ZjGDqMp
+
 [<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
 [<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
 
@@ -62,6 +64,6 @@ prefer this version if:
 ## Contact the Maintainers
 
 The best way to contact and chat with the maintainers is on the
-[Python Arcade Discord channel](https://discord.gg/ZjGDqMp).
+[Arcade Discord Server][].
 
 paul@cravenfamily.com

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Read the stable documentation at https://api.arcade.academy.
 
 ## Development Previews
 
-Preview the unfinished next release at https://api.arcade.academy/en/development/.
+Preview the next release at https://api.arcade.academy/en/development/.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,23 @@ Arcade is built on top of Pyglet and OpenGL.
 
 ## Stable Documentation
 
-The latest stable release is best for following the paired Python tutorial.
+[Arcade Academy - Learn Python]: https://learn.arcade.academy
 
-To read the stable documentation, see latest release at https://api.arcade.academy
-or the following quick links:
+The latest stable release is best for learning to program by
+reading [Arcade Academy - Learn Python][].
 
-* To install, see: https://api.arcade.academy/en/latest/install/index.html
-* For example code that uses the Arcade library see: https://api.arcade.academy/en/latest/examples/index.html
-* For API documentation see: https://api.arcade.academy/en/latest/quick_index.html
-* Learn Arcade AND how to program: https://learn.arcade.academy
-* For games made with the stable version, see  https://api.arcade.academy/en/latest/sample_games.html
-* Release notes: https://api.arcade.academy/en/latest/development/release_notes.html
+Read the stable documentation at https://api.arcade.academy or use these quick links:
+
+[Install Arcade]: https://api.arcade.academy/en/latest/install/index.html
+[Example Code]: https://api.arcade.academy/en/latest/examples/index.html
+[API Reference]: https://api.arcade.academy/en/latest/arcade.html
+[API Search]: https://api.arcade.academy/en/latest/quick_index.html
+[Release Notes]: https://api.arcade.academy/en/latest/development/release_notes.html
+
+| [Install Arcade][] | [Example Code][] | [API Reference][] | [API Search][] | [Release Notes][] |
+|--------------------|------------------|-------------------|----------------|-------------------|
+
+For games made with Arcade, see  https://api.arcade.academy/en/latest/sample_games.html
 
 > [!NOTE]
 > This version does will not add support for Python 3.12. See the Development Preview below.


### PR DESCRIPTION
### Changes

1. Add both doc links per ytty #5713's suggestion
    * Explain stable vs dev
    * Move the games made with Arcade link into the stable section
 2. Make the Discord invite link a re-usable definition
 3. Cut down the quick links per einarf's feedback
 
### Follow-up work

1. fix broken links on games preview page on `development`
2. try to get Discord shield embed working