### PR TITLE
Docs: Fix a copy-paste error in 'Fastest Text Drawing' example

### DIFF
--- a/doc/example_code/drawing_text_objects_batch.rst
+++ b/doc/example_code/drawing_text_objects_batch.rst
@@ -17,6 +17,6 @@ same as the :ref:`drawing_text_objects` example.
 
 For a much simpler and slower approach,  see :ref:`drawing_text`.
 
-.. literalinclude:: ../../arcade/examples/drawing_text_objects.py
+.. literalinclude:: ../../arcade/examples/drawing_text_objects_batch.py
     :caption: drawing_text_objects.py
     :linenos:


### PR DESCRIPTION
Essentially this made the example code exactly the same as in the 'Better Text Drawing' example.