### PR TITLE
Fix example nav sidebar stickiness

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {
     'display_version': True,
     'logo_only': False,
     'sticky_navigation': True,
-    'navigation_depth': 3,
+    'navigation_depth': 4,
     'collapse_navigation': False,
 }
 

--- a/doc/example_code/array_backed_grid.rst
+++ b/doc/example_code/array_backed_grid.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _array_backed_grid:
 
 Array-Backed Grid

--- a/doc/example_code/array_backed_grid_buffered.rst
+++ b/doc/example_code/array_backed_grid_buffered.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _array_backed_grid_buffered:
 
 Array-Backed Grid Buffered

--- a/doc/example_code/array_backed_grid_sprites_1.rst
+++ b/doc/example_code/array_backed_grid_sprites_1.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _array_backed_grid_sprites_1:
 
 Grid Using Sprites v1

--- a/doc/example_code/array_backed_grid_sprites_2.rst
+++ b/doc/example_code/array_backed_grid_sprites_2.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _array_backed_grid_sprites_2:
 
 Grid Using Sprites v2

--- a/doc/example_code/astar_pathfinding.rst
+++ b/doc/example_code/astar_pathfinding.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _astar_pathfinding:
 
 A-Star Path Finding

--- a/doc/example_code/asteroid_smasher.rst
+++ b/doc/example_code/asteroid_smasher.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _asteroid_smasher:
 
 Asteroid Smasher

--- a/doc/example_code/background_parallax.rst
+++ b/doc/example_code/background_parallax.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _background_parallax:
 
 Parallax

--- a/doc/example_code/bouncing_rectangle.rst
+++ b/doc/example_code/bouncing_rectangle.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _bouncing_rectangle:
 
 Bouncing Rectangle

--- a/doc/example_code/camera_platform.rst
+++ b/doc/example_code/camera_platform.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _camera_platform:
 
 Camera Use in a Platformer

--- a/doc/example_code/controller.rst
+++ b/doc/example_code/controller.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _controller:
 
 How To Get Connected Controllers

--- a/doc/example_code/conway_alpha.rst
+++ b/doc/example_code/conway_alpha.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _conway_alpha:
 
 Conway's Game of Life

--- a/doc/example_code/drawing_primitives.rst
+++ b/doc/example_code/drawing_primitives.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _drawing_primitives:
 
 Drawing Primitives

--- a/doc/example_code/drawing_text.rst
+++ b/doc/example_code/drawing_text.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _drawing_text:
 
 Slow but Easy Text Drawing

--- a/doc/example_code/drawing_text_objects.rst
+++ b/doc/example_code/drawing_text_objects.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _drawing_text_objects:
 
 Better Text Drawing with Text Objects

--- a/doc/example_code/drawing_text_objects_batch.rst
+++ b/doc/example_code/drawing_text_objects_batch.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _drawing_text_objects_batch:
 
 The Fastest Text Drawing: pyglet Batches

--- a/doc/example_code/dual_stick_shooter.rst
+++ b/doc/example_code/dual_stick_shooter.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _dual_stick_shooter:
 
 Dual Stick Shooter

--- a/doc/example_code/easing_example_1.rst
+++ b/doc/example_code/easing_example_1.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _easing_example_1:
 
 Easing Example 1

--- a/doc/example_code/easing_example_2.rst
+++ b/doc/example_code/easing_example_2.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _easing_example_2:
 
 Easing Example 2

--- a/doc/example_code/follow_path.rst
+++ b/doc/example_code/follow_path.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _follow_path:
 
 Sprites That Follow a Path

--- a/doc/example_code/full_screen_example.rst
+++ b/doc/example_code/full_screen_example.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _full_screen_example:
 
 Full Screen Example

--- a/doc/example_code/game_of_life_fbo.rst
+++ b/doc/example_code/game_of_life_fbo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _game_of_life_fbo:
 
 Game of Life with Frame Buffers

--- a/doc/example_code/gradients.rst
+++ b/doc/example_code/gradients.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gradients:
 
 Gradients Example

--- a/doc/example_code/gui_flat_button.rst
+++ b/doc/example_code/gui_flat_button.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_flat_button:
 
 Flat Text Buttons

--- a/doc/example_code/gui_flat_button_styled.rst
+++ b/doc/example_code/gui_flat_button_styled.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_flat_button_styled:
 
 Flat Text Button Styled

--- a/doc/example_code/gui_ok_messagebox.rst
+++ b/doc/example_code/gui_ok_messagebox.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_ok_messagebox:
 
 OK Message Box

--- a/doc/example_code/gui_scrollable_text.rst
+++ b/doc/example_code/gui_scrollable_text.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_scrollable_text:
 
 GUI Scrollable Text

--- a/doc/example_code/gui_slider.rst
+++ b/doc/example_code/gui_slider.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_slider:
 
 GUI Slider

--- a/doc/example_code/gui_widgets.rst
+++ b/doc/example_code/gui_widgets.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gui_widgets:
 
 GUI Widgets

--- a/doc/example_code/happy_face.rst
+++ b/doc/example_code/happy_face.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _happy_face:
 
 Happy Face

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -30,11 +30,11 @@ Starting Templates
 
    :ref:`template_platformer`
 
-Primitives
-----------
+Drawing Shapes
+--------------
 
-Drawing Primitives
-^^^^^^^^^^^^^^^^^^
+Basic Shape Drawing
+^^^^^^^^^^^^^^^^^^^
 
 .. figure:: images/thumbs/happy_face.png
    :figwidth: 170px
@@ -66,8 +66,8 @@ Drawing Primitives
 
    :ref:`drawing_text_objects_batch`
 
-Animating Drawing Primitives
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Animating Basic Shape Drawing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. figure:: images/thumbs/bouncing_rectangle.png
    :figwidth: 170px
@@ -95,8 +95,8 @@ Animating Drawing Primitives
 
 .. _shape-element-lists:
 
-Faster Drawing with ShapeElementLists
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Faster Shapes with ShapeElementLists
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. figure:: images/thumbs/shape_list_demo.png
    :figwidth: 170px

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -9,6 +9,7 @@ Examples
 .. toctree::
    :glob:
    :hidden:
+   :max-depth: 1
 
    [a-h]*
    [j-z]*

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -4,9 +4,7 @@ Examples
 ========
 
 .. Partly solve https://github.com/pythonarcade/arcade/issues/2274
-.. through shell globbing support in Sphinx toctrees. We use two
-.. ranges to exclude the index.rst from itself. See the following
-.. to learn more: https://mywiki.wooledge.org/glob
+.. via globbing support in Sphinx toctrees to exclude this file
 
 .. toctree::
    :glob:

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -9,7 +9,7 @@ Examples
 .. toctree::
    :glob:
    :hidden:
-   :max-depth: 1
+   :maxdepth: 1
 
    [a-h]*
    [j-z]*

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -3,6 +3,35 @@
 Examples
 ========
 
+.. Solve https://github.com/pythonarcade/arcade/issues/2274
+.. through the simplest brute-force approach which works since there's
+.. there's no good way built-in to exclude the index.rst from itself
+
+.. toctree::
+   :glob:
+   :hidden:
+
+   a*
+   b*
+   c*
+   d*
+   e*
+   f*
+   g*
+   h*
+
+   l*
+   m*
+   n*
+
+   p*
+
+   r*
+   s*
+   t*
+
+   v*
+
 
 Starting Templates
 ------------------

--- a/doc/example_code/index.rst
+++ b/doc/example_code/index.rst
@@ -3,34 +3,17 @@
 Examples
 ========
 
-.. Solve https://github.com/pythonarcade/arcade/issues/2274
-.. through the simplest brute-force approach which works since there's
-.. there's no good way built-in to exclude the index.rst from itself
+.. Partly solve https://github.com/pythonarcade/arcade/issues/2274
+.. through shell globbing support in Sphinx toctrees. We use two
+.. ranges to exclude the index.rst from itself. See the following
+.. to learn more: https://mywiki.wooledge.org/glob
 
 .. toctree::
    :glob:
    :hidden:
 
-   a*
-   b*
-   c*
-   d*
-   e*
-   f*
-   g*
-   h*
-
-   l*
-   m*
-   n*
-
-   p*
-
-   r*
-   s*
-   t*
-
-   v*
+   [a-h]*
+   [j-z]*
 
 
 Starting Templates

--- a/doc/example_code/light_demo.rst
+++ b/doc/example_code/light_demo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _light_demo:
 
 Lighting Demo

--- a/doc/example_code/line_of_sight.rst
+++ b/doc/example_code/line_of_sight.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _line_of_sight:
 
 Line of Sight

--- a/doc/example_code/lines_buffered.rst
+++ b/doc/example_code/lines_buffered.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _lines_buffered:
 
 Using a Vertex Buffer Object With Lines

--- a/doc/example_code/maze_depth_first.rst
+++ b/doc/example_code/maze_depth_first.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _maze_depth_first:
 
 Creating a Depth First Maze

--- a/doc/example_code/maze_recursive.rst
+++ b/doc/example_code/maze_recursive.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _maze_recursive:
 
 Creating a Recursive Maze

--- a/doc/example_code/minimap.rst
+++ b/doc/example_code/minimap.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _minimap:
 
 Mini-Map

--- a/doc/example_code/music_control_demo.rst
+++ b/doc/example_code/music_control_demo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _music_control_demo:
 
 Music Control Demo

--- a/doc/example_code/normal_mapping.rst
+++ b/doc/example_code/normal_mapping.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _normal_mapping:
 
 Normal Mapping

--- a/doc/example_code/particle_fireworks.rst
+++ b/doc/example_code/particle_fireworks.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _particle_fireworks:
 
 Particle System - Fireworks

--- a/doc/example_code/particle_systems.rst
+++ b/doc/example_code/particle_systems.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _particle_systems:
 
 Particle Systems

--- a/doc/example_code/performance_statistics.rst
+++ b/doc/example_code/performance_statistics.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _performance_statistics_example:
 
 Performance Statistics

--- a/doc/example_code/perspective.rst
+++ b/doc/example_code/perspective.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _perspective:
 
 Perspective

--- a/doc/example_code/procedural_caves_bsp.rst
+++ b/doc/example_code/procedural_caves_bsp.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _procedural_caves_bsp:
 
 Procedural Caves - Binary Space Partitioning

--- a/doc/example_code/procedural_caves_cellular.rst
+++ b/doc/example_code/procedural_caves_cellular.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _procedural_caves_cellular:
 
 Procedural Caves - Cellular Automata

--- a/doc/example_code/pymunk_box_stacks.rst
+++ b/doc/example_code/pymunk_box_stacks.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _pymunk_box_stacks:
 
 Pymunk Physics Engine - Stacks of Boxes

--- a/doc/example_code/pymunk_demo_top_down.rst
+++ b/doc/example_code/pymunk_demo_top_down.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _pymunk_demo_top_down:
 
 Pymunk Demo - Top Down

--- a/doc/example_code/pymunk_joint_builder.rst
+++ b/doc/example_code/pymunk_joint_builder.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _pymunk_joint_builder:
 
 Pymunk Physics Engine - Joint Builder

--- a/doc/example_code/pymunk_pegboard.rst
+++ b/doc/example_code/pymunk_pegboard.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _pymunk_pegboard:
 
 Pymunk Physics Engine - Pegboard

--- a/doc/example_code/radar_sweep.rst
+++ b/doc/example_code/radar_sweep.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _radar_sweep:
 
 Radar Sweep

--- a/doc/example_code/resizable_window.rst
+++ b/doc/example_code/resizable_window.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _resizable_window:
 
 Resizable Window

--- a/doc/example_code/sections_demo_1.rst
+++ b/doc/example_code/sections_demo_1.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sections_demo_1:
 
 Sections Demo 1

--- a/doc/example_code/sections_demo_2.rst
+++ b/doc/example_code/sections_demo_2.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sections_demo_2:
 
 Sections Demo 2

--- a/doc/example_code/sections_demo_3.rst
+++ b/doc/example_code/sections_demo_3.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sections_demo_3:
 
 Sections Demo 3

--- a/doc/example_code/shape_list_demo.rst
+++ b/doc/example_code/shape_list_demo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _shape_list_demo:
 
 ShapeElementList Explanation

--- a/doc/example_code/shape_list_demo_skylines.rst
+++ b/doc/example_code/shape_list_demo_skylines.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _shape_list_demo_skylines:
 
 Shape List - Skylines

--- a/doc/example_code/shapes.rst
+++ b/doc/example_code/shapes.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _shapes-slow:
 
 Bouncing Shapes

--- a/doc/example_code/slime_invaders.rst
+++ b/doc/example_code/slime_invaders.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _slime_invaders:
 
 Slime Invaders

--- a/doc/example_code/snow.rst
+++ b/doc/example_code/snow.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _snow:
 
 Falling Snow

--- a/doc/example_code/sound_demo.rst
+++ b/doc/example_code/sound_demo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sound_demo:
 
 Sound Demo

--- a/doc/example_code/sound_speed_demo.rst
+++ b/doc/example_code/sound_speed_demo.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sound_speed_demo:
 
 Sound Speed Demo

--- a/doc/example_code/sprite_bouncing_coins.rst
+++ b/doc/example_code/sprite_bouncing_coins.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bouncing_coins:
 
 Sprite Bouncing Coins

--- a/doc/example_code/sprite_bullets.rst
+++ b/doc/example_code/sprite_bullets.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bullets:
 
 Shoot Bullets Upwards

--- a/doc/example_code/sprite_bullets_aimed.rst
+++ b/doc/example_code/sprite_bullets_aimed.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bullets_aimed:
 
 Aim and Shoot Bullets

--- a/doc/example_code/sprite_bullets_enemy_aims.rst
+++ b/doc/example_code/sprite_bullets_enemy_aims.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bullets_enemy_aims:
 
 Have Enemies Aim at Player

--- a/doc/example_code/sprite_bullets_periodic.rst
+++ b/doc/example_code/sprite_bullets_periodic.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bullets_periodic:
 
 Have Enemies Periodically Shoot

--- a/doc/example_code/sprite_bullets_random.rst
+++ b/doc/example_code/sprite_bullets_random.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_bullets_random:
 
 Have Enemies Randomly Shoot

--- a/doc/example_code/sprite_change_coins.rst
+++ b/doc/example_code/sprite_change_coins.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_change_coins:
 
 Change coins

--- a/doc/example_code/sprite_collect_coins.rst
+++ b/doc/example_code/sprite_collect_coins.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_coins:
 
 Move By Mouse

--- a/doc/example_code/sprite_collect_coins_background.rst
+++ b/doc/example_code/sprite_collect_coins_background.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_coins_background:
 
 Using a Background Image

--- a/doc/example_code/sprite_collect_coins_diff_levels.rst
+++ b/doc/example_code/sprite_collect_coins_diff_levels.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _example-sprite-collect-coins-diff-levels:
 
 Different Levels of Clearing Coins

--- a/doc/example_code/sprite_collect_coins_move_bouncing.rst
+++ b/doc/example_code/sprite_collect_coins_move_bouncing.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_coins_move_bouncing:
 
 Collect Coins that are Bouncing

--- a/doc/example_code/sprite_collect_coins_move_circle.rst
+++ b/doc/example_code/sprite_collect_coins_move_circle.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_coins_move_circle:
 
 Collect Coins that are Moving in a Circle

--- a/doc/example_code/sprite_collect_coins_move_down.rst
+++ b/doc/example_code/sprite_collect_coins_move_down.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_coins_move_down:
 
 Collect Coins Moving Down

--- a/doc/example_code/sprite_collect_rotating.rst
+++ b/doc/example_code/sprite_collect_rotating.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_collect_rotating:
 
 Animated Sprites

--- a/doc/example_code/sprite_enemies_in_platformer.rst
+++ b/doc/example_code/sprite_enemies_in_platformer.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_enemies_in_platformer:
 
 Platformer With Enemies

--- a/doc/example_code/sprite_explosion_bitmapped.rst
+++ b/doc/example_code/sprite_explosion_bitmapped.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_explosion_bitmapped:
 
 Sprite Explosions Bitmapped

--- a/doc/example_code/sprite_explosion_particles.rst
+++ b/doc/example_code/sprite_explosion_particles.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_explosion_particles:
 
 Sprite Explosions Particles

--- a/doc/example_code/sprite_face_left_or_right.rst
+++ b/doc/example_code/sprite_face_left_or_right.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_face_left_or_right:
 
 Sprite: Face Left or Right

--- a/doc/example_code/sprite_follow_simple.rst
+++ b/doc/example_code/sprite_follow_simple.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_follow_simple:
 
 Sprites That Follow The Player

--- a/doc/example_code/sprite_follow_simple_2.rst
+++ b/doc/example_code/sprite_follow_simple_2.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_follow_simple_2:
 
 Sprites That Follow The Player 2

--- a/doc/example_code/sprite_health.rst
+++ b/doc/example_code/sprite_health.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_health:
 
 Hit Points and Health Bars

--- a/doc/example_code/sprite_move_angle.rst
+++ b/doc/example_code/sprite_move_angle.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_angle:
 
 Move By Turning

--- a/doc/example_code/sprite_move_animation.rst
+++ b/doc/example_code/sprite_move_animation.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_animation:
 
 Move with a Sprite Animation

--- a/doc/example_code/sprite_move_controller.rst
+++ b/doc/example_code/sprite_move_controller.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_controller:
 
 Game Controller

--- a/doc/example_code/sprite_move_keyboard.rst
+++ b/doc/example_code/sprite_move_keyboard.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_keyboard:
 
 Move By Keyboard

--- a/doc/example_code/sprite_move_keyboard_accel.rst
+++ b/doc/example_code/sprite_move_keyboard_accel.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_keyboard_accel:
 
 Acceleration and Friction

--- a/doc/example_code/sprite_move_keyboard_better.rst
+++ b/doc/example_code/sprite_move_keyboard_better.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_keyboard_better:
 
 Better Move By Keyboard

--- a/doc/example_code/sprite_move_scrolling.rst
+++ b/doc/example_code/sprite_move_scrolling.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_scrolling:
 
 Move with a Scrolling Screen - Centered

--- a/doc/example_code/sprite_move_scrolling_box.rst
+++ b/doc/example_code/sprite_move_scrolling_box.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_scrolling_box:
 
 Move with a Scrolling Screen - Margins

--- a/doc/example_code/sprite_move_scrolling_shake.rst
+++ b/doc/example_code/sprite_move_scrolling_shake.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_scrolling_shake:
 
 Camera Shake

--- a/doc/example_code/sprite_move_walls.rst
+++ b/doc/example_code/sprite_move_walls.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_move_walls:
 
 Move with Walls

--- a/doc/example_code/sprite_moving_platforms.rst
+++ b/doc/example_code/sprite_moving_platforms.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_moving_platforms:
 
 Moving Platforms

--- a/doc/example_code/sprite_no_coins_on_walls.rst
+++ b/doc/example_code/sprite_no_coins_on_walls.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_no_coins_on_walls:
 
 Randomly Place Coins, But Away From Walls And Other Coins

--- a/doc/example_code/sprite_properties.rst
+++ b/doc/example_code/sprite_properties.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_properties:
 
 Sprite Properties

--- a/doc/example_code/sprite_rooms.rst
+++ b/doc/example_code/sprite_rooms.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_rooms:
 
 Moving Between Different Rooms

--- a/doc/example_code/sprite_rotate_around_point.rst
+++ b/doc/example_code/sprite_rotate_around_point.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_rotate_around_point:
 
 Sprite Rotation Around a Point

--- a/doc/example_code/sprite_rotate_around_tank.rst
+++ b/doc/example_code/sprite_rotate_around_tank.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_rotate_around_tank:
 
 Move By Keyboard, Fire Towards Mouse

--- a/doc/example_code/sprite_tiled_map.rst
+++ b/doc/example_code/sprite_tiled_map.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_tiled_map:
 
 Work with loading in a Tiled map file

--- a/doc/example_code/sprite_tiled_map_with_levels.rst
+++ b/doc/example_code/sprite_tiled_map_with_levels.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _sprite_tiled_map_with_levels:
 
 Work with levels and a tiled map

--- a/doc/example_code/spritelist_interaction_visualize_dist_los.rst
+++ b/doc/example_code/spritelist_interaction_visualize_dist_los.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _spritelist_interaction_visualize_dist_los:
 
 GPU Based Line of Sight

--- a/doc/example_code/starting_template.rst
+++ b/doc/example_code/starting_template.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _starting_template:
 
 Starting Template Using Window Class

--- a/doc/example_code/stress_test_collision.rst
+++ b/doc/example_code/stress_test_collision.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _stress_test_collision:
 
 Collision Stress Test

--- a/doc/example_code/stress_test_draw_moving.rst
+++ b/doc/example_code/stress_test_draw_moving.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _stress_test_draw_moving:
 
 Draw Moving Sprites Stress Test

--- a/doc/example_code/template_platformer.rst
+++ b/doc/example_code/template_platformer.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _template_platformer:
 
 Platformer Template

--- a/doc/example_code/tetris.rst
+++ b/doc/example_code/tetris.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _tetris:
 
 Tetris

--- a/doc/example_code/text_loc_example.rst
+++ b/doc/example_code/text_loc_example.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _text_loc_example:
 
 Text Localization

--- a/doc/example_code/timer.rst
+++ b/doc/example_code/timer.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _timer:
 
 On-Screen Timer

--- a/doc/example_code/transform_feedback.rst
+++ b/doc/example_code/transform_feedback.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _transform_feedback:
 
 Transform Feedback

--- a/doc/example_code/transitions.rst
+++ b/doc/example_code/transitions.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _transitions:
 
 Fade In/Out of Views

--- a/doc/example_code/turn_and_move.rst
+++ b/doc/example_code/turn_and_move.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _turn_and_move:
 
 Move to Mouse Click

--- a/doc/example_code/view_instructions_and_game_over.rst
+++ b/doc/example_code/view_instructions_and_game_over.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _view_instructions_and_game_over:
 
 Using Views for Instruction and Game Over Screens

--- a/doc/example_code/view_pause_screen.rst
+++ b/doc/example_code/view_pause_screen.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _view_pause_screen:
 
 Using Views for a Pause Screen

--- a/doc/example_code/view_screens_minimal.rst
+++ b/doc/example_code/view_screens_minimal.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _view_screens_minimal:
 
 Minimal Views Example


### PR DESCRIPTION
Partial but incomplete fix for #2274 

### Changes

* Remove :orphan: from examples
* Add hidden expamples toctree with nasty alphabet globbing trick
* Deepen sidebar nav to 4

### Follow-up Work

Figure out how to deal with tutorials & sidebar ordering for diff listings.