### PR TITLE
Make doc build CI versions consistent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,12 +83,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # python-version in must be kept in sync with .readthedocs.yaml
-        #
-        # Why 3.9?
-        #  1. It's the lowest version compatible w/ Sphinx 7.2.2, a doc build dependency
-        #  2. Better doc build accessibility for contributors who may have trouble
-        #     setting up newer Python versions (Debian, etc).
-        python-version: ['3.9']
+        python-version: ['3.10']  # July 2024 | Match our contributor dev version; see pyproject.toml
         architecture: ['x64']
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,7 @@ build:
   tools:
     # If you change this, you also need to update .github/workflows/test.yml
     # to make sure doc test builds run on the same version.
-    #
-    # Why 3.9?
-    #  1. It's the lowest version compatible w/ Sphinx 7.2.2, a doc build dependency
-    #  2. Better doc build accessibility for contributors who may have trouble
-    #     setting up newer Python versions (Debian, etc).
-    python: "3.9"
+    python: "3.10"  # July 2024 | See autobuild info in pyproject.toml's dev dependencies
 
 python:
   install:


### PR DESCRIPTION
We require 3.10+ for doc build, so this PR:

* Update test workflow to use 3.10 as the build version
* Update `.readthedocs.yaml` to use 3.10 as the Python version