### PR TITLE
Fix pyglet interpshinx refs by using pyglet 2.1 in intersphinx_mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,7 +168,7 @@ html_baseurl = 'https://api.arcade.academy/'
 # Configuration for intersphinx enabling linking other projects
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'pyglet': ('https://pyglet.readthedocs.io/en/latest/', None),
+    'pyglet': ('https://pyglet.readthedocs.io/en/development/', None),
     'PIL': ('https://pillow.readthedocs.io/en/stable', None),
     'pymunk': ('https://www.pymunk.org/en/latest/', None),
 }


### PR DESCRIPTION
**TL;DR:** Our current `conf.py` points at 2.0.X's doc, but we use 2.1 dev previews

I took a close look at our build config while converting to Google-style docstrings. This should head off a bunch of potential weird behavior for others. :rocket: