### PR TITLE
Fix small GUI example and doc issues

### DIFF
--- a/arcade/examples/gui_widgets.py
+++ b/arcade/examples/gui_widgets.py
@@ -10,7 +10,7 @@ import arcade.gui.widgets.buttons
 import arcade.gui.widgets.layout
 import arcade.gui.widgets.text
 
-# Load fonts bumbled with arcade such as the Kenney fonts
+# Load fonts bundled with arcade such as the Kenney fonts
 arcade.resources.load_system_fonts()
 
 

--- a/arcade/examples/gui_widgets.py
+++ b/arcade/examples/gui_widgets.py
@@ -27,7 +27,7 @@ class MyView(arcade.View):
         # Create a text label
         ui_text_label = arcade.gui.widgets.text.UITextArea(
             text="This is a Text Widget",
-            width=450,
+            width=600,
             height=40,
             font_size=24,
             font_name="Kenney Future",


### PR DESCRIPTION
TL;DR: Two small papercuts found while reading the doc and examples

1. Fix cut-off "Widget" part of "This is a Text Widget"
2. Fix typo in comment at top

More to come based on what I saw during #2308 