### PR TITLE
Attempt to fix doc build broken by #2304

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Sphinx configuration file"""
-from typing import Any
+from functools import cache
+from typing import Any, NamedTuple
 import docutils.nodes
 import os
 import re
@@ -265,16 +266,35 @@ def generate_color_table(filename, source):
     source[0] += append_text
 
 
+@cache
+def get_module_root(doc_confdir):  # pending: revert #2304 or figure out a better solution
+    """Temp fix since RTD doesn't use our make.py and offers no clean way to set build dir
+
+    1. https://github.com/pythonarcade/arcade/pull/2304/ tried to change the build dir in make.py
+    2. The readthedocs config does not use make.py
+    3. They don't seem to offer any support for non-default build locations
+    4. Instead, the options seem to be:
+       * Weird environment variable API that's managed from their admin console (bus factor++)
+       * Overwrite the entire build process https://blog.readthedocs.com/build-customization/
+    """
+    return doc_confdir.parent / "arcade"
+
+
 def source_read_handler(_app, doc_name: str, source):
     """
     Event handler for source-read event.
     Where we can modify the source of a document before it is parsed.
     """
+    def _get_dir(app, path):
+        path = get_module_root(_app.confdir) / path
+        print(f"Generated corrected module path: {path!r}")
+        return path
+
     # Inject the color tables into the source
     if doc_name == "api_docs/arcade.color":
-        generate_color_table("arcade/color/__init__.py", source)
+        generate_color_table(_get_dir(_app, "color/__init__.py"), source)
     elif doc_name == "api_docs/arcade.csscolor":
-        generate_color_table("arcade/csscolor/__init__.py", source)
+        generate_color_table(_get_dir(_app, "csscolor/__init__.py"), source)
 
 
 def on_autodoc_process_bases(app, name, obj, options, bases):
@@ -282,7 +302,27 @@ def on_autodoc_process_bases(app, name, obj, options, bases):
     bases[:] = [base for base in bases if base is not object]
 
 
+
+class A(NamedTuple):
+    dirname: str
+    comment: str = ""
+
+
+APP_CONFIG_DIRS = (
+    A('outdir'),
+    A('srcdir', 'NOTE: This is reST source, not Python source!'),
+    A('confdir'),
+    A('doctreedir'),
+)
+
 def setup(app):
+    print("Diagnostic info since readthedocs doesn't use our make.py:")
+    for attr, comment in APP_CONFIG_DIRS:
+        val = getattr(app, attr, None)
+        print(f"  {attr}: {val!r}")
+        if comment:
+            print(f"    {comment}")
+
     # Separate stylesheets loosely by category.
     app.add_css_file("css/colors.css")
     app.add_css_file("css/layout.css")


### PR DESCRIPTION
**TL;DR** #2304 broke readthedocs because it doesn't use make.py nor allow a good way to do so

### What broke?

Color lookup filename read since we don't set the relative path: https://readthedocs.org/projects/arcade-library/builds/25093429/

1. #2304 alters `make.py` to set the build directory
2. It does not update `readthedocs.yaml`
3. This doesn't matter since the only real control rtd offers comes in the form of:
    1. An environment variable control panel (aka bus factor) if it even works
    2. [Overriding the entire build process](https://blog.readthedocs.com/build-customization/) :upside_down_face: 

### Changes

1. Try to extract the root dir from the Sphinx object
3. Convert to absolute path
4. Pass the new path to the color table generation function instead
5. Explain why further in the source
6. Add some diagnostic printout with comments
