### PR TITLE
Unify text input events onto a base class and rename UITextEvent

### DIFF
--- a/arcade/gui/__init__.py
+++ b/arcade/gui/__init__.py
@@ -15,7 +15,7 @@ from arcade.gui.events import UIOnActionEvent
 from arcade.gui.events import UIOnChangeEvent
 from arcade.gui.events import UIOnClickEvent
 from arcade.gui.events import UIOnUpdateEvent
-from arcade.gui.events import UITextEvent
+from arcade.gui.events import UITextInputEvent
 from arcade.gui.events import UITextMotionEvent
 from arcade.gui.events import UITextMotionSelectEvent
 from arcade.gui.mixins import UIDraggableMixin
@@ -87,7 +87,7 @@ __all__ = [
     "UISpace",
     "UISpriteWidget",
     "UITextArea",
-    "UITextEvent",
+    "UITextInputEvent",
     "UITextMotionEvent",
     "UITextMotionSelectEvent",
     "UITextureButton",

--- a/arcade/gui/events.py
+++ b/arcade/gui/events.py
@@ -94,7 +94,7 @@ class UIKeyReleaseEvent(UIKeyEvent):
 
 
 @dataclass
-class UITextEvent(UIEvent):
+class UITextInputEvent(UIEvent):
     """Triggered whenever the user inputs any text.
 
     Usually, this will be after :py:class:`UIKeyPressEvent` and before a

--- a/arcade/gui/events.py
+++ b/arcade/gui/events.py
@@ -92,9 +92,17 @@ class UIKeyReleaseEvent(UIKeyEvent):
 
     pass
 
+@dataclass
+class UITextEvent(UIEvent):
+    """Base class for text-related events.
+
+    It holds no data of its own.
+    """
+    ...
+
 
 @dataclass
-class UITextInputEvent(UIEvent):
+class UITextInputEvent(UITextEvent):
     """Triggered whenever the user inputs any text.
 
     Usually, this will be after :py:class:`UIKeyPressEvent` and before a
@@ -110,14 +118,14 @@ class UITextInputEvent(UIEvent):
 
 
 @dataclass
-class UITextMotionEvent(UIEvent):
+class UITextMotionEvent(UITextEvent):
     """Triggered when text cursor moves."""
 
     motion: Any
 
 
 @dataclass
-class UITextMotionSelectEvent(UIEvent):
+class UITextMotionSelectEvent(UITextEvent):
     """Triggered when the text cursor moves selecting the text with it."""
 
     selection: Any

--- a/arcade/gui/events.py
+++ b/arcade/gui/events.py
@@ -95,7 +95,16 @@ class UIKeyReleaseEvent(UIKeyEvent):
 
 @dataclass
 class UITextEvent(UIEvent):
-    """Covers all the text cursor event."""
+    """Triggered whenever the user inputs any text.
+
+    Usually, this will be after :py:class:`UIKeyPressEvent` and before a
+    :py:class:`UIKeyReleaseEvent`. It may also occur when:
+
+    * the user holds down a key to repeat letters or spaces
+    * a platform-specific input method, such as pen input on a tablet PC
+
+    To learn more, see pyglet's `relevant documentation <https://pyglet.readthedocs.io/en/development/modules/window.html#pyglet.window.Window.on_text>`_.
+    """
 
     text: str
 

--- a/arcade/gui/events.py
+++ b/arcade/gui/events.py
@@ -92,13 +92,15 @@ class UIKeyReleaseEvent(UIKeyEvent):
 
     pass
 
+
 @dataclass
 class UITextEvent(UIEvent):
     """Base class for text-related events.
 
     It holds no data of its own.
     """
-    ...
+
+    pass
 
 
 @dataclass

--- a/arcade/gui/experimental/password_input.py
+++ b/arcade/gui/experimental/password_input.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from arcade.gui import Surface, UIEvent, UIInputText, UITextEvent
+from arcade.gui import Surface, UIEvent, UIInputText, UITextInputEvent
 
 
 class UIPasswordInput(UIInputText):
     """A password input field. The text is hidden with asterisks."""
 
     def on_event(self, event: UIEvent) -> Optional[bool]:
-        if isinstance(event, UITextEvent):
+        if isinstance(event, UITextInputEvent):
             event.text = event.text.replace("\n", "").replace("\r", "")  # remove new lines!
         return super().on_event(event)
 

--- a/arcade/gui/experimental/typed_text_input.py
+++ b/arcade/gui/experimental/typed_text_input.py
@@ -4,7 +4,7 @@ from typing import Callable, Generic, Optional, Type, TypeVar, cast
 
 import arcade
 from arcade.color import BLACK, RED, WHITE
-from arcade.gui import UIEvent, UIInputText, UILabel, UITextEvent
+from arcade.gui import UIEvent, UIInputText, UILabel, UITextInputEvent
 from arcade.types import Color, RGBOrA255
 from arcade.utils import type_name
 
@@ -150,7 +150,7 @@ class UITypedTextInput(UIInputText, Generic[T]):
 
     def on_event(self, event: UIEvent) -> Optional[bool]:
         # print(f"In {type_name(event)}")
-        if isinstance(event, UITextEvent) and self._active:
+        if isinstance(event, UITextInputEvent) and self._active:
             text = event.text.replace("\r", "").replace("\r", "")
             event.text = text
 

--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -27,7 +27,7 @@ from arcade.gui.events import (
     UIMouseReleaseEvent,
     UIMouseScrollEvent,
     UIOnUpdateEvent,
-    UITextEvent,
+    UITextInputEvent,
     UITextMotionEvent,
     UITextMotionSelectEvent,
 )
@@ -402,7 +402,7 @@ class UIManager(EventDispatcher):
         return self.dispatch_ui_event(UIKeyReleaseEvent(self, symbol, modifiers))  # type: ignore
 
     def on_text(self, text):
-        return self.dispatch_ui_event(UITextEvent(self, text))
+        return self.dispatch_ui_event(UITextInputEvent(self, text))
 
     def on_text_motion(self, motion):
         return self.dispatch_ui_event(UITextMotionEvent(self, motion))

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -14,7 +14,7 @@ from arcade.gui.events import (
     UIMouseEvent,
     UIMousePressEvent,
     UIMouseScrollEvent,
-    UITextEvent,
+    UITextInputEvent,
     UITextMotionEvent,
     UITextMotionSelectEvent,
 )
@@ -449,7 +449,7 @@ class UIInputText(UIWidget):
         # If active pass all non press events to caret
         if self._active:
             # Act on events if active
-            if isinstance(event, UITextEvent):
+            if isinstance(event, UITextInputEvent):
                 self.caret.on_text(event.text)
                 self.trigger_full_render()
             elif isinstance(event, UITextMotionEvent):

--- a/tests/unit/gui/test_uimanager_callbacks.py
+++ b/tests/unit/gui/test_uimanager_callbacks.py
@@ -4,7 +4,7 @@ from arcade.gui.events import (
     UIMouseScrollEvent,
     UIMouseMovementEvent,
     UIKeyPressEvent,
-    UITextEvent,
+    UITextInputEvent,
     UITextMotionEvent,
     UITextMotionSelectEvent,
 )
@@ -100,7 +100,7 @@ def test_on_text_passes_an_event(uimanager):
         uimanager.on_text("a")
 
     event = records[-1]
-    assert isinstance(event, UITextEvent)
+    assert isinstance(event, UITextInputEvent)
     assert event.text == "a"
 
 


### PR DESCRIPTION

* Rename `UITextEvent` to less misleading `UITextInputEvent`
* Add a `UITextEvent` baseclass as in mouse events
  * Instead of holding data, it allows responding to text input field events
  * It holds no data, but that's okay
* Document what `UITextInputEvent` actually does with a link to pyglet

Intersphinx is being annoying and my local Sphinx is acting up, so I'm linking the ugly way for now since it helps ship 3.0 faster.