### PR TITLE
"Fix" password blinking but break alignment and efficiency

### DIFF
--- a/arcade/gui/experimental/password_input.py
+++ b/arcade/gui/experimental/password_input.py
@@ -2,11 +2,60 @@ from __future__ import annotations
 
 from typing import Optional
 
+import arcade.color
 from arcade.gui import Surface, UIEvent, UIInputText, UITextInputEvent
+from arcade.types import RGBOrA255, Color
 
 
 class UIPasswordInput(UIInputText):
     """A password input field. The text is hidden with asterisks."""
+
+    def __init__(
+            self,
+            *,
+            x: float = 0,
+            y: float = 0,
+            width: float = 100,
+            height: float = 24,
+            text: str = "",
+            font_name=("Arial",),
+            font_size: float = 12,
+            text_color: RGBOrA255 = (0, 0, 0, 255),
+            multiline=False,
+            caret_color: RGBOrA255 = (0, 0, 0, 255),
+            size_hint=None,
+            size_hint_min=None,
+            size_hint_max=None,
+            **kwargs,
+    ):
+        replaced = '*' * len(text)
+        super().__init__(
+            x=x,
+            y=y,
+            width=width,
+            height=height,
+            text=replaced,
+            font_name=font_name,
+            font_size=font_size,
+            text_color=arcade.color.TRANSPARENT_BLACK,
+            multiline=multiline,
+            caret_color=caret_color,
+            size_hint=size_hint,
+            size_hint_min=size_hint_min,
+            size_hint_max=size_hint_max,
+            **kwargs
+        )
+        self._font_name=font_name
+        self._font_size=font_size
+        self._asterisk_color = Color.from_iterable(text_color)
+
+    @property
+    def text_color(self) -> Color:
+        return self._asterisk_color
+
+    @text_color.setter
+    def text_color(self, new_value: RGBOrA255):
+        self._asterisk_color = Color.from_iterable(new_value)
 
     def on_event(self, event: UIEvent) -> Optional[bool]:
         """Remove new lines from the input, which are not allowed in passwords."""
@@ -16,11 +65,20 @@ class UIPasswordInput(UIInputText):
 
     def do_render(self, surface: Surface):
         """Override to render the text as asterisks."""
-        self.layout.begin_update()
-        position = self.caret.position
-        text = self.text
-        self.text = "*" * len(self.text)
+        asterisks = "*" * len(self.text)
+        # FIXME: I fixed blinking, but broke efficiency and alignment :D
+        with surface.activate():
+            arcade.draw_text(
+                asterisks,
+                x=self.rect.left,
+                y=self.rect.bottom,
+                anchor_x="left",
+                anchor_y="bottom",
+                align="left",
+                width=self.width,
+                font_name=self._font_name,
+                font_size=self._font_size,
+                color=self._asterisk_color,
+            )
         super().do_render(surface)
-        self.text = text
-        self.caret.position = position
-        self.layout.end_update()
+

--- a/arcade/gui/experimental/password_input.py
+++ b/arcade/gui/experimental/password_input.py
@@ -4,31 +4,31 @@ from typing import Optional
 
 import arcade.color
 from arcade.gui import Surface, UIEvent, UIInputText, UITextInputEvent
-from arcade.types import RGBOrA255, Color
+from arcade.types import Color, RGBOrA255
 
 
 class UIPasswordInput(UIInputText):
     """A password input field. The text is hidden with asterisks."""
 
     def __init__(
-            self,
-            *,
-            x: float = 0,
-            y: float = 0,
-            width: float = 100,
-            height: float = 24,
-            text: str = "",
-            font_name=("Arial",),
-            font_size: float = 12,
-            text_color: RGBOrA255 = (0, 0, 0, 255),
-            multiline=False,
-            caret_color: RGBOrA255 = (0, 0, 0, 255),
-            size_hint=None,
-            size_hint_min=None,
-            size_hint_max=None,
-            **kwargs,
+        self,
+        *,
+        x: float = 0,
+        y: float = 0,
+        width: float = 100,
+        height: float = 24,
+        text: str = "",
+        font_name=("Arial",),
+        font_size: float = 12,
+        text_color: RGBOrA255 = (0, 0, 0, 255),
+        multiline=False,
+        caret_color: RGBOrA255 = (0, 0, 0, 255),
+        size_hint=None,
+        size_hint_min=None,
+        size_hint_max=None,
+        **kwargs,
     ):
-        replaced = '*' * len(text)
+        replaced = "*" * len(text)
         super().__init__(
             x=x,
             y=y,
@@ -43,10 +43,10 @@ class UIPasswordInput(UIInputText):
             size_hint=size_hint,
             size_hint_min=size_hint_min,
             size_hint_max=size_hint_max,
-            **kwargs
+            **kwargs,
         )
-        self._font_name=font_name
-        self._font_size=font_size
+        self._font_name = font_name
+        self._font_size = font_size
         self._asterisk_color = Color.from_iterable(text_color)
 
     @property
@@ -81,4 +81,3 @@ class UIPasswordInput(UIInputText):
                 color=self._asterisk_color,
             )
         super().do_render(surface)
-

--- a/arcade/gui/experimental/password_input.py
+++ b/arcade/gui/experimental/password_input.py
@@ -75,7 +75,7 @@ class UIPasswordInput(UIInputText):
                 anchor_x="left",
                 anchor_y="bottom",
                 align="left",
-                width=self.width,
+                width=int(self.width),
                 font_name=self._font_name,
                 font_size=self._font_size,
                 color=self._asterisk_color,

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -494,6 +494,8 @@ class UIInputText(UIWidget):
         if self._active:
             # Act on events if active
             if isinstance(event, UITextInputEvent):
+                if not self.layout.multiline:
+                    event.text = event.text.replace("\r", "").replace("\n", "")
                 self.caret.on_text(event.text)
                 self.trigger_full_render()
             elif isinstance(event, UITextMotionEvent):


### PR DESCRIPTION
**TL;DR:** Prove it's something to do with layout / double-render trigger in the ugliest way possible. \:D

EDIT: this breaks the universe in a slightly different way. Editing the username now shows a cursor in both?

"Fix" #2120 by:
1. Draw the text as transparent
2. Remove layout manipulation during draw
3. Use `draw_text` + `Surface.activate` context manager to render badly over the surface

Anyone who wants to commit / PR into / replace this branch is welcome to.