### PR TITLE
add .tracking and px -> em conversion

### DIFF
--- a/arcade/text.py
+++ b/arcade/text.py
@@ -638,14 +638,14 @@ class Text:
     def em_to_px(self, em: float) -> float:
         """Convert from an em value to a pixel amount.
 
-        1em is defined as `font_size`pt.
+        1em is defined as ``font_size``pt.
         """
         return (em * self.font_size) * (4 / 3)
 
     def px_to_em(self, px: float) -> float:
-        """Convert from an em value to a pixel amount.
+        """Convert from a pixel amount to a value in ems.
 
-        1em is defined as `font_size`pt.
+        1em is defined as ``font_size``pt.
         """
         return px / (4 / 3) / self.font_size
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -616,36 +616,33 @@ class Text:
     @property
     def tracking(self) -> float | None:
         """
-        Get the tracking amount for this text object, or rather,
+        Get/set the tracking amount for this text object, or rather,
         the added space between each character.
 
-        Returns a pixel amount, or None if the tracking is inconsistent.
+        The value is an amount in pixels and can be negative.
+        To convert from the em unit, use Text.em_to_px().
+
+        Returns:
+            a pixel amount, or None if the tracking is inconsistent.
         """
         kerning = self._label.get_style("kerning")
         return kerning if kerning != pyglet.text.document.STYLE_INDETERMINATE else None
 
     @tracking.setter
     def tracking(self, value: float):
-        """
-        Get the tracking amount for this text object, or rather,
-        the added space between each character.
-
-        `value` is an amount in pixels and can be negative.
-        To convert from the em unit, use Text.em_to_px().
-        """
         self._label.set_style("kerning", value)
 
     def em_to_px(self, em: float) -> float:
         """Convert from an em value to a pixel amount.
 
-        1em is defined as ``font_size``pt.
+        1em is defined as ``font_size`` pt.
         """
         return (em * self.font_size) * (4 / 3)
 
     def px_to_em(self, px: float) -> float:
         """Convert from a pixel amount to a value in ems.
 
-        1em is defined as ``font_size``pt.
+        1em is defined as ``font_size`` pt.
         """
         return px / (4 / 3) / self.font_size
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -613,6 +613,42 @@ class Text:
         else:
             self._label.position = x, y, self._label.z
 
+    @property
+    def tracking(self) -> float | None:
+        """
+        Get the tracking amount for this text object, or rather,
+        the added space between each character.
+
+        Returns a pixel amount, or None if the tracking is inconsistent.
+        """
+        kerning = self._label.get_style("kerning")
+        return kerning if kerning != pyglet.text.document.STYLE_INDETERMINATE else None
+
+    @tracking.setter
+    def tracking(self, value: float):
+        """
+        Get the tracking amount for this text object, or rather,
+        the added space between each character.
+
+        `value` is an amount in pixels and can be negative.
+        To convert from the em unit, use Text.em_to_px().
+        """
+        self._label.set_style("kerning", value)
+
+    def em_to_px(self, em: float) -> float:
+        """Convert from an em value to a pixel amount.
+
+        1em is defined as `font_size`pt.
+        """
+        return (em * self.font_size) * (4 / 3)
+
+    def px_to_em(self, px: float) -> float:
+        """Convert from an em value to a pixel amount.
+
+        1em is defined as `font_size`pt.
+        """
+        return px / (4 / 3) / self.font_size
+
 
 def create_text_sprite(
     text: str,


### PR DESCRIPTION
Added `.tracking` getter/setter to `Text`, as well as `.em_to_px()` and `.px_to_em()` for easy relative-to-font-size value conversion.

An example of why you may want this? To replicate setting this value in Photoshop:
![image](https://github.com/user-attachments/assets/040d408f-d018-4c4a-8584-368bb1f69f3c)
one could write the code:
```py
# Note the Photoshop deals in micro-em, not em.
text.tracking = text.em_to_px(-.120)
```

As you can see, this is needed for some fonts to look good:
![tracking_kerning_demo](https://github.com/user-attachments/assets/6f3545ef-a650-4a6a-9683-47c3d8713bb1)
