### PR TITLE
add __all__ to InputManger

### DIFF
--- a/arcade/future/input/__init__.py
+++ b/arcade/future/input/__init__.py
@@ -4,3 +4,17 @@
 from .inputs import ControllerAxes, ControllerButtons, Keys, MouseAxes, MouseButtons
 from .manager import ActionState, InputManager
 from .input_mapping import Action, ActionMapping, Axis, AxisMapping
+
+__all__ = [
+    "ControllerAxes",
+    "ControllerButtons",
+    "Keys",
+    "MouseAxes",
+    "MouseButtons",
+    "ActionState",
+    "InputManager",
+    "Action",
+    "ActionMapping",
+    "Axis",
+    "AxisMapping"
+]

--- a/arcade/future/input/__init__.py
+++ b/arcade/future/input/__init__.py
@@ -16,5 +16,5 @@ __all__ = [
     "Action",
     "ActionMapping",
     "Axis",
-    "AxisMapping"
+    "AxisMapping",
 ]


### PR DESCRIPTION
InputManager didn't have a `__all__` for some reason? It does now.