### PR TITLE
Bump pillow to 10.4.0 and mode check PyMunkHitBoxAlgorithm

### DIFF
--- a/arcade/context.py
+++ b/arcade/context.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 import pyglet
-
 from PIL import Image
 from pyglet import gl
 from pyglet.graphics.shader import UniformBufferObject

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 import pyglet
+
 from PIL import Image
 from pyglet import gl
 from pyglet.graphics.shader import UniformBufferObject
@@ -492,7 +493,7 @@ class ArcadeContext(Context):
 
         path = resolve(path)
 
-        image = Image.open(str(path))
+        image: Image.Image = Image.open(str(path))  # type: ignore
 
         if flip:
             image = image.transpose(Image.Transpose.FLIP_TOP_BOTTOM)

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -9,7 +9,7 @@ from pymunk.autogeometry import (
     simplify_curves,
 )
 
-from arcade.types import Point2, Point2List
+from arcade.types import Point2, Point2List, RGBA255
 
 from .base import HitBoxAlgorithm
 
@@ -92,18 +92,42 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
 
     def trace_image(self, image: Image) -> PolylineSet:
         """
-        Trace the image and return a list of line sets.
+        Trace the image and return a :py:class:~collections.abc.Sequence` of line sets.
 
-        These line sets represent the outline of the image or the outline of the
-        holes in the image. If more than one line set is returned it's important
-        to pick the one that covers the most of the image.
+        .. important:: The image :py:attr:`~PIL.Image.Image.mode` must be ``"RGBA"``!
+
+                       * This method raises a :py:class:`TypeError` when it isn't
+                       * Use :py:meth:`convert("RGBA") <PIL.Image.Image.convert>` to
+                         convert
+
+        The returned object will be a :py:mod:`pymunk`
+        :py:class:`~pymunk.autogeometry.PolylineSet`. Each
+        :py:class:`list` inside it will contain points as
+        :py:class:`pymunk.vec2d.Vec2d` instances. These lists
+        may represent:
+
+        * the outline of the image's contents
+        * the holes in the image
+
+        When this method returns more than one line set,
+        it's important to pick the one which covers the largest
+        portion of the image.
 
         Args:
-            image: Image to trace.
+            image: A :py:class:`PIL.Image.Image` to trace.
+
+        Returns:
+            A :py:mod:`pymunk` object which is a :py:class:`~collections.abc.Sequence`
+            of :py:class:`~pymunk.autogeometry.PolylineSet` of line sets.
         """
+        if image.mode != "RGBA":
+            raise ValueError(
+                "Image's mode!='RGBA'! Try using image.convert(\"RGBA\")."
+            )
 
         def sample_func(sample_point: Point2) -> int:
-            """Method used to sample image."""
+            """Function used to sample image."""
+            # Return 0 when outside of bounds
             if (
                 sample_point[0] < 0
                 or sample_point[1] < 0
@@ -113,7 +137,8 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
                 return 0
 
             point_tuple = int(sample_point[0]), int(sample_point[1])
-            color = image.getpixel(point_tuple)
+            color: RGBA255 = image.getpixel(point_tuple)  # type: ignore
+
             return 255 if color[3] > 0 else 0
 
         # Do a quick check if it is a full tile

--- a/arcade/hitbox/pymunk.py
+++ b/arcade/hitbox/pymunk.py
@@ -9,7 +9,7 @@ from pymunk.autogeometry import (
     simplify_curves,
 )
 
-from arcade.types import Point2, Point2List, RGBA255
+from arcade.types import RGBA255, Point2, Point2List
 
 from .base import HitBoxAlgorithm
 
@@ -121,9 +121,7 @@ class PymunkHitBoxAlgorithm(HitBoxAlgorithm):
             of :py:class:`~pymunk.autogeometry.PolylineSet` of line sets.
         """
         if image.mode != "RGBA":
-            raise ValueError(
-                "Image's mode!='RGBA'! Try using image.convert(\"RGBA\")."
-            )
+            raise ValueError("Image's mode!='RGBA'! Try using image.convert(\"RGBA\").")
 
         def sample_func(sample_point: Point2) -> int:
             """Function used to sample image."""

--- a/arcade/sprite/__init__.py
+++ b/arcade/sprite/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import PIL.Image
 
 from arcade.texture import Texture
@@ -22,9 +24,9 @@ from .enums import (
 )
 
 
-def load_animated_gif(resource_name) -> TextureAnimationSprite:
+def load_animated_gif(resource_name: str | Path) -> TextureAnimationSprite:
     """
-    Attempt to load an animated GIF as an :class:`TextureAnimationSprite`.
+    Attempt to load an animated GIF as a :class:`TextureAnimationSprite`.
 
     .. note::
 
@@ -33,6 +35,12 @@ def load_animated_gif(resource_name) -> TextureAnimationSprite:
         the format better, loading animated GIFs will be pretty buggy. A
         good workaround is loading GIFs in another program and exporting them
         as PNGs, either as sprite sheets or a frame per file.
+
+    Args:
+        resource_name: A path to a GIF as either a :py:class:`pathlib.Path`
+            or a :py:class:`str` which may include a
+            :ref:`resource handle <resource_handles>`.
+
     """
 
     file_name = resolve(resource_name)

--- a/arcade/sprite/__init__.py
+++ b/arcade/sprite/__init__.py
@@ -48,9 +48,8 @@ def load_animated_gif(resource_name: str | Path) -> TextureAnimationSprite:
 
     # Pillow doc recommends testing for the is_animated attribute as of 10.0.0
     # https://pillow.readthedocs.io/en/stable/deprecations.html#categories
-    if (
-        not getattr(image_object, "is_animated", False)
-        or not (n_frames := getattr(image_object, "n_frames", 0))
+    if not getattr(image_object, "is_animated", False) or not (
+        n_frames := getattr(image_object, "n_frames", 0)
     ):
         raise TypeError(f"The file {resource_name} is not an animated gif.")
 

--- a/arcade/sprite/__init__.py
+++ b/arcade/sprite/__init__.py
@@ -37,12 +37,18 @@ def load_animated_gif(resource_name) -> TextureAnimationSprite:
 
     file_name = resolve(resource_name)
     image_object = PIL.Image.open(file_name)
-    if not image_object.is_animated:
+
+    # Pillow doc recommends testing for the is_animated attribute as of 10.0.0
+    # https://pillow.readthedocs.io/en/stable/deprecations.html#categories
+    if (
+        not getattr(image_object, "is_animated", False)
+        or not (n_frames := getattr(image_object, "n_frames", 0))
+    ):
         raise TypeError(f"The file {resource_name} is not an animated gif.")
 
     sprite = TextureAnimationSprite()
     keyframes = []
-    for frame in range(image_object.n_frames):
+    for frame in range(n_frames):
         image_object.seek(frame)
         frame_duration = image_object.info["duration"]
         image = image_object.convert("RGBA")

--- a/arcade/texture/loading.py
+++ b/arcade/texture/loading.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import PIL.Image
+from PIL import Image
 
 from arcade.hitbox import HitBoxAlgorithm
 from arcade.resources import resolve
@@ -52,7 +52,7 @@ def load_texture(
     if isinstance(file_path, str):
         file_path = resolve(file_path)
 
-    im = PIL.Image.open(file_path)
+    im: Image.Image = Image.open(file_path)  # type: ignore
     if im.mode != "RGBA":
         im = im.convert("RGBA")
 
@@ -66,7 +66,7 @@ def load_image(
     file_path: str | Path,
     *,
     mode: str = "RGBA",
-) -> PIL.Image.Image:
+) -> Image.Image:
     """
     Load a Pillow image from disk (no caching).
 
@@ -86,9 +86,10 @@ def load_image(
     if isinstance(file_path, str):
         file_path = resolve(file_path)
 
-    im = PIL.Image.open(file_path)
+    im: Image.Image = Image.open(file_path)  # type: ignore
     if im.mode != mode:
         im = im.convert(mode)
+
     return im
 
 
@@ -103,7 +104,7 @@ def load_spritesheet(file_name: str | Path) -> SpriteSheet:
     if isinstance(file_name, str):
         file_name = resolve(file_name)
 
-    im = PIL.Image.open(file_name)
+    im: Image.Image = Image.open(file_name)
     if im.mode != "RGBA":
         im = im.convert("RGBA")
 

--- a/arcade/texture/spritesheet.py
+++ b/arcade/texture/spritesheet.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from PIL import Image
+from PIL.Image import Transpose
 
 from arcade.resources import resolve
 
@@ -91,14 +92,14 @@ class SpriteSheet:
         """
         Flips the internal image left to right.
         """
-        self._image = self._image.transpose(Image.FLIP_LEFT_RIGHT)
+        self._image = self._image.transpose(Transpose.FLIP_LEFT_RIGHT)
         self._flip_flags = (not self._flip_flags[0], self._flip_flags[1])
 
     def flip_top_bottom(self) -> None:
         """
         Flip the internal image top to bottom.
         """
-        self._image = self._image.transpose(Image.FLIP_TOP_BOTTOM)
+        self._image = self._image.transpose(Transpose.FLIP_TOP_BOTTOM)
         self._flip_flags = (self._flip_flags[0], not self._flip_flags[1])
 
     def get_image(

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -13,8 +13,8 @@ from typing import (
 from weakref import WeakSet, WeakValueDictionary, finalize
 
 import PIL.Image
-from PIL.Image import Resampling
 from PIL import Image, ImageDraw
+from PIL.Image import Resampling
 from pyglet.image.atlas import (
     Allocator,
     AllocatorException,

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -13,6 +13,7 @@ from typing import (
 from weakref import WeakSet, WeakValueDictionary, finalize
 
 import PIL.Image
+from PIL.Image import Resampling
 from PIL import Image, ImageDraw
 from pyglet.image.atlas import (
     Allocator,
@@ -504,10 +505,10 @@ class DefaultTextureAtlas(TextureAtlasBase):
 
             # Resize the strips to the border size if larger than 1
             if self._border > 1:
-                strip_top = strip_top.resize((image.width, self._border), Image.NEAREST)
-                strip_bottom = strip_bottom.resize((image.width, self._border), Image.NEAREST)
-                strip_left = strip_left.resize((self._border, image.height), Image.NEAREST)
-                strip_right = strip_right.resize((self._border, image.height), Image.NEAREST)
+                strip_top = strip_top.resize((image.width, self._border), Resampling.NEAREST)
+                strip_bottom = strip_bottom.resize((image.width, self._border), Resampling.NEAREST)
+                strip_left = strip_left.resize((self._border, image.height), Resampling.NEAREST)
+                strip_right = strip_right.resize((self._border, image.height), Resampling.NEAREST)
 
             tmp.paste(strip_top, (self._border, 0))
             tmp.paste(strip_bottom, (self._border, tmp.height - self._border))

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -13,6 +13,7 @@ import copy
 import math
 import os
 from collections import OrderedDict
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, cast
 
@@ -30,7 +31,7 @@ from arcade import (
     get_window,
 )
 from arcade.hitbox import HitBoxAlgorithm, RotatableHitBox
-from arcade.types import Color as ArcadeColor
+from arcade.types import Color as ArcadeColor, RGBA255
 
 if TYPE_CHECKING:
     from arcade import DefaultTextureAtlas, Texture
@@ -699,7 +700,8 @@ class TileMap:
         )
 
         if layer.transparent_color:
-            data = my_texture.image.getdata()
+            # Returned object is a sequence-like object per the pillow doc
+            data: Sequence[RGBA255] = my_texture.image.getdata()  # type:ignore
 
             target = layer.transparent_color
             new_data = []

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -700,7 +700,9 @@ class TileMap:
         )
 
         if layer.transparent_color:
-            # Returned object is a sequence-like object per the pillow doc
+            # The pillow source doesn't annotate a return type for this method, but:
+            # 1. The docstring does specify the returned object is sequence-like
+            # 2. We convert to RGBA mode implicitly in load_or_get_texture above
             data: Sequence[RGBA255] = my_texture.image.getdata()  # type:ignore
 
             target = layer.transparent_color

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -31,7 +31,8 @@ from arcade import (
     get_window,
 )
 from arcade.hitbox import HitBoxAlgorithm, RotatableHitBox
-from arcade.types import Color as ArcadeColor, RGBA255
+from arcade.types import RGBA255
+from arcade.types import Color as ArcadeColor
 
 if TYPE_CHECKING:
     from arcade import DefaultTextureAtlas, Texture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # "pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
     # Expected future dev preview release on PyPI (not yet released)
     'pyglet==2.1.dev5',
-    "pillow~=10.2.0",
+    "pillow~=10.4.0",
     "pymunk~=6.6.0",
     "pytiled-parser~=2.2.5",
 ]


### PR DESCRIPTION
**TL;DR:** Pull in various pillow fixes + update our typing / code

## Why
1. Help users with dependabot / vuln scanning (example: fixes a [buffer overflow](https://github.com/python-pillow/Pillow/pull/7928)
2. Help map out changes for the prospective EOL 2.6.18 release / #2358 
3. Various bug fixes

## Changes

1. Use the new `Transpose` and `Resampling` enums
4. Replace direct attribute access with `hasattr` tests recommended by Pillow doc
5. Cover image mode edge case in PyMunkHitBoxAlgorithm:
   * Raise a `ValueError` when passed a non-RGBA image
   * Add tests for this edge case
6. Fix minor typing issue in tilemap loading  
7. Silence mypy problems with 10.4.0:
    1. Opening an image file now returns an `ImageFile` subclass
    2. While pyright is fine with this, mypy is not
    3. `typing.cast` is slow, so we use an ugly little trick
8. Some drive-by doc changes which help understand how this works

## Follow-up Work
Continue the revision pass over texture atlas doc I have in git stash:
* I started it to help myself understand the code affected
* It'd be best to finish it