### PR TITLE
Fix Sprite init

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -57,7 +57,7 @@ class BasicSprite:
     def __init__(
         self,
         texture: Texture,
-        scale: float = 1.0,
+        scale: float | Point2 = 1.0,
         center_x: float = 0,
         center_y: float = 0,
         visible: bool = True,
@@ -67,9 +67,9 @@ class BasicSprite:
         self._depth = 0.0
         self._texture = texture
         width, height = texture.size
-        self._width = width * scale
-        self._height = height * scale
-        self._scale = (scale, scale)
+        self._scale = (scale, scale) if isinstance(scale, (float, int)) else scale
+        self._width = width * self._scale[0]
+        self._height = height * self._scale[1]
         self._visible = bool(visible)
         self._color: Color = WHITE
         self.sprite_lists: list["SpriteList"] = []


### PR DESCRIPTION
Sprite's `scale` property now takes either a scalar or a tuple correctly.

(It still returns a `Vec2` to support `Sprite.scale *= 2` for the time being; we can discuss changes to this later.)