### PR TITLE
Bump pymunk to 6.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Expected future dev preview release on PyPI (not yet released)
     'pyglet==2.1.dev5',
     "pillow~=10.4.0",
-    "pymunk~=6.6.0",
+    "pymunk~=6.8.1",
     "pytiled-parser~=2.2.5",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
**TL;DR:** They only host the latest doc so our cross-refs will be wrong unless we do this