### PR TITLE
Add enums for specific controller layouts

### DIFF
--- a/arcade/future/input/__init__.py
+++ b/arcade/future/input/__init__.py
@@ -1,13 +1,23 @@
 # ruff: noqa: F401
 #  type: ignore
 
-from .inputs import ControllerAxes, ControllerButtons, Keys, MouseAxes, MouseButtons
+from .inputs import (
+    ControllerAxes,
+    ControllerButtons,
+    XBoxControllerButtons,
+    PSControllerButtons,
+    Keys,
+    MouseAxes,
+    MouseButtons,
+)
 from .manager import ActionState, InputManager
 from .input_mapping import Action, ActionMapping, Axis, AxisMapping
 
 __all__ = [
     "ControllerAxes",
     "ControllerButtons",
+    "XBoxControllerButtons",
+    "PSControllerButtons",
     "Keys",
     "MouseAxes",
     "MouseButtons",

--- a/arcade/future/input/inputs.py
+++ b/arcade/future/input/inputs.py
@@ -75,6 +75,40 @@ class ControllerButtons(StrEnum):
     DPAD_UP = "dpup"
     DPAD_DOWN = "dpdown"
 
+class XBoxControllerButtons(StrEnum):
+    Y = ControllerButtons.TOP_FACE
+    B = ControllerButtons.RIGHT_FACE
+    X = ControllerButtons.LEFT_FACE
+    A = ControllerButtons.BOTTOM_FACE
+    LEFT_BUMPER = ControllerButtons.LEFT_SHOULDER
+    RIGHT_BUMPER = ControllerButtons.RIGHT_SHOULDER
+    START = ControllerButtons.START
+    SELECT = ControllerButtons.BACK
+    GUIDE = ControllerButtons.GUIDE
+    LEFT_STICK = ControllerButtons.LEFT_STICK
+    RIGHT_STICK = ControllerButtons.RIGHT_STICK
+    DPAD_LEFT = ControllerButtons.DPAD_LEFT
+    DPAD_RIGHT = ControllerButtons.DPAD_RIGHT
+    DPAD_UP = ControllerButtons.DPAD_UP
+    DPAD_DOWN = ControllerButtons.DPAD_DOWN
+
+class PSControllerButtons(StrEnum):
+    TRIANGLE = ControllerButtons.TOP_FACE
+    CIRCLE = ControllerButtons.RIGHT_FACE
+    SQUARE = ControllerButtons.LEFT_FACE
+    CROSS = ControllerButtons.BOTTOM_FACE
+    L1 = ControllerButtons.LEFT_SHOULDER
+    R1 = ControllerButtons.RIGHT_SHOULDER
+    START = ControllerButtons.START
+    SELECT = ControllerButtons.BACK
+    GUIDE = ControllerButtons.GUIDE
+    LEFT_STICK = ControllerButtons.LEFT_STICK
+    RIGHT_STICK = ControllerButtons.RIGHT_STICK
+    DPAD_LEFT = ControllerButtons.DPAD_LEFT
+    DPAD_RIGHT = ControllerButtons.DPAD_RIGHT
+    DPAD_UP = ControllerButtons.DPAD_UP
+    DPAD_DOWN = ControllerButtons.DPAD_DOWN
+
 
 class Keys(InputEnum):
     # Key modifiers

--- a/arcade/future/input/inputs.py
+++ b/arcade/future/input/inputs.py
@@ -75,6 +75,7 @@ class ControllerButtons(StrEnum):
     DPAD_UP = "dpup"
     DPAD_DOWN = "dpdown"
 
+
 class XBoxControllerButtons(StrEnum):
     Y = ControllerButtons.TOP_FACE
     B = ControllerButtons.RIGHT_FACE
@@ -91,6 +92,7 @@ class XBoxControllerButtons(StrEnum):
     DPAD_RIGHT = ControllerButtons.DPAD_RIGHT
     DPAD_UP = ControllerButtons.DPAD_UP
     DPAD_DOWN = ControllerButtons.DPAD_DOWN
+
 
 class PSControllerButtons(StrEnum):
     TRIANGLE = ControllerButtons.TOP_FACE


### PR DESCRIPTION
Adds `XBoxControllerButtons` and `PSControllerButtons` as helpful renames for `ControllerButtons` agnostic names.