### PR TITLE
Fix <No Title> on API ref breadcrumbs

### DIFF
--- a/doc/api_docs/arcade.rst
+++ b/doc/api_docs/arcade.rst
@@ -1,5 +1,8 @@
 .. _arcade-api:
 
+API Reference
+=============
+
 This page documents the Application Programming Interface (API)
 for the Python Arcade library. See also:
 


### PR DESCRIPTION
**TL;DR:** The page had no title, added one

Reported by @DragonMoffon and the fix is simple enough to not warrant an issue. It looked like this: 
![image](https://github.com/user-attachments/assets/9e032d97-6745-4ccb-a8f4-13d0317e16b1)
