### PR TITLE
Missing layout in the bindless_texture example.

### DIFF
--- a/arcade/examples/gl/bindless_texture.py
+++ b/arcade/examples/gl/bindless_texture.py
@@ -120,7 +120,7 @@ class BindlessTexture(arcade.Window):
             // The texture handles in the buffer are 64 bit integers and are
             // automatically converted into sampler objects for us.
             struct TextureRef {
-                sampler2D tex; // 64 bit integer
+                layout (bindless_sampler) sampler2D tex; // 64 bit integer
             };
 
             // Shader storage buffer with texture handles


### PR DESCRIPTION
This means the example should also work on intel
Xe and a generation before that (gma).