### PR TITLE
Fix math point types

### DIFF
--- a/arcade/math.py
+++ b/arcade/math.py
@@ -306,7 +306,7 @@ def rand_vec_magnitude(
     Returns a random vector, with random magnitude.
 
     Args:
-        angle (float): The vector angle
+        angle (float): The vector angle in radians
         lo_magnitude (float): The lower magnitude
         hi_magnitude (float): The higher magnitude
     """

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -303,7 +303,7 @@ def rand_vec_magnitude(
     hi_magnitude: float,
 ) -> Point2:
     """
-    Returns a random vector, with random magnitude.
+    Return a vector of randomized magnitude pointing in the given direction.
 
     Args:
         angle (float): The vector angle in radians

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -224,10 +224,7 @@ def rand_in_circle(center: Point2, radius: float) -> Point2:
     Generate a point in a circle, or can think of it as a vector pointing
     a random direction with a random magnitude <= radius.
 
-    Reference: https://stackoverflow.com/a/30564123
-
-    .. note:: This algorithm returns a higher concentration of points
-              around the center of the circle
+    Reference: https://stackoverflow.com/a/50746409
 
     Args:
         center (Point2): The center of the circle
@@ -236,7 +233,7 @@ def rand_in_circle(center: Point2, radius: float) -> Point2:
     # random angle
     angle = 2 * math.pi * random.random()
     # random radius
-    r = radius * random.random()
+    r = radius * math.sqrt(random.random())
     # calculating coordinates
     return (r * math.cos(angle) + center[0], r * math.sin(angle) + center[1])
 

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -303,10 +303,10 @@ def rand_vec_magnitude(
     hi_magnitude: float,
 ) -> Point2:
     """
-    Returns a random vector, within a spread of the given angle.
+    Returns a random vector, with random magnitude.
 
     Args:
-        angle (float): The angle to spread from
+        angle (float): The vector angle
         lo_magnitude (float): The lower magnitude
         hi_magnitude (float): The higher magnitude
     """

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -235,22 +235,19 @@ def rand_in_circle(center: Point2, radius: float) -> Point2:
     # random radius
     r = radius * math.sqrt(random.random())
     # calculating coordinates
-    return (r * math.cos(angle) + center[0], r * math.sin(angle) + center[1])
+    return r * math.cos(angle) + center[0], r * math.sin(angle) + center[1]
 
 
 def rand_on_circle(center: Point2, radius: float) -> Point2:
     """
     Generate a point on a circle.
 
-    .. note: by passing a random value in for float,
-             you can achieve what rand_in_circle() does
-
     Args:
         center (Point2): The center of the circle
         radius (float): The radius of the circle
     """
     angle = 2 * math.pi * random.random()
-    return (radius * math.cos(angle) + center[0], radius * math.sin(angle) + center[1])
+    return radius * math.cos(angle) + center[0], radius * math.sin(angle) + center[1]
 
 
 def rand_on_line(pos1: Point2, pos2: Point2) -> Point:
@@ -286,7 +283,7 @@ def rand_angle_spread_deg(angle: float, half_angle_spread: float) -> float:
 
 def rand_vec_spread_deg(
     angle: float, half_angle_spread: float, length: float
-) -> tuple[float, float]:
+) -> Point2:
     """
     Returns a random vector, within a spread of the given angle.
 
@@ -304,7 +301,7 @@ def rand_vec_magnitude(
     angle: float,
     lo_magnitude: float,
     hi_magnitude: float,
-) -> tuple[float, float]:
+) -> Point2:
     """
     Returns a random vector, within a spread of the given angle.
 

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -281,9 +281,7 @@ def rand_angle_spread_deg(angle: float, half_angle_spread: float) -> float:
     return angle + s
 
 
-def rand_vec_spread_deg(
-    angle: float, half_angle_spread: float, length: float
-) -> Point2:
+def rand_vec_spread_deg(angle: float, half_angle_spread: float, length: float) -> Point2:
     """
     Returns a random vector, within a spread of the given angle.
 


### PR DESCRIPTION
Changed functions' return type from `tuple[float, float]` to `Point2`.
Fixed documentation of `rand_vec_magnitude` and `rand_on_circle`.