### PR TITLE
Documentation - Fix a bunch of typos, and improve certain parts of the documentation

### DIFF
--- a/doc/get_started/arcade_book.rst
+++ b/doc/get_started/arcade_book.rst
@@ -10,7 +10,7 @@ The Arcade Book
 Installation
 ------------
 Arcade can be installed like any other Python
-Package. Arcade needs support for OpenGL 3.3+.
+Package. Your machine(s) need to support OpenGL 3.3+ for arcade to work.
 If you are familiar with Python package management you can just
 "pip install" Arcade.
 For more detailed instructions see :ref:`install`.

--- a/doc/get_started/install.rst
+++ b/doc/get_started/install.rst
@@ -11,25 +11,25 @@ Using pip
 
 .. Tip::
 
-    For beginners unfamiliar with python a more in depth guide to
+    For beginners unfamiliar with Python, a more in depth guide to
     installing Python and Arcade can be found in the :ref:`arcade_book`.
 
-The most common way to install Arcade is to use ``pip``.
+The most common way to install Arcade is to use the ``pip`` package manager.
 This will install the latest version of Arcade from `PyPI`_.
 
 .. code-block:: bash
 
     pip install arcade
 
-If you are installing Arcade directly into your system python meaning
-you are not using a virtual environment (or don't know that that is)
+If you are installing Arcade directly into your system Python, meaning
+you are not using a virtual environment (or don't know what that is),
 you may need to use the ``--user`` flag to install Arcade just for your user.
 
 .. code-block:: bash
 
     pip install arcade --user
 
-Upgrading an existing installation of Arcade can be done with the following command
+Upgrading an existing installation of Arcade can be done with the following command:
 
 .. code-block:: bash
 
@@ -49,7 +49,7 @@ If you prefer to install from git::
     cd arcade
     pip install -e .
 
-This installs Arcade in editable mode so you can make changes to the code and see the changes immediately.
+This installs Arcade in editable mode, so you can make changes to the code and see the changes immediately.
 Also consider forking the repository on github installing your fork instead.
 
 Running examples

--- a/doc/programming_guide/gui/own_layout.rst
+++ b/doc/programming_guide/gui/own_layout.rst
@@ -3,7 +3,7 @@
 Own Layout
 ----------
 
-Creating own layouts is the master class of creating own widgets.
+Creating your own layouts is the master class of creating own widgets.
 It allows you to create custom layouts that can be used in your application to position widgets.
 
 General use cases for own layouts are:
@@ -14,7 +14,7 @@ General use cases for own layouts are:
 Where to start
 ~~~~~~~~~~~~~~
 
-To create own layout, you need to create a new class that inherits from :class:`arcade.gui.UILayout`.
+To create your own layout, you need to create a new class that inherits from :class:`arcade.gui.UILayout`.
 
 The main method you need to implement is:
 

--- a/doc/programming_guide/gui/own_widgets.rst
+++ b/doc/programming_guide/gui/own_widgets.rst
@@ -3,7 +3,7 @@
 Own Widgets
 -----------
 
-Creating own widgets is a powerful feature of the GUI module.
+Creating your own widgets is a powerful feature of the GUI module.
 It allows you to create custom widgets that can be used in your application.
 
 In most cases this is even the easiest way to implement your desired interface.
@@ -15,7 +15,7 @@ The following sections will guide you through the process of creating own widget
 Where to start
 ~~~~~~~~~~~~~~
 
-To create own widgets, you need to create a new class that inherits from :class:`arcade.gui.UIWidget`.
+To create your own widgets, you need to create a new class that inherits from :class:`arcade.gui.UIWidget`.
 
 While inheriting from :class:`arcade.gui.UIWidget`, provides the highest flexibility.
 The main methods you need to implement are:

--- a/doc/programming_guide/opengl_notes.rst
+++ b/doc/programming_guide/opengl_notes.rst
@@ -3,9 +3,9 @@
 OpenGL
 ======
 
-Arcade is using OpenGL for the underlying rendering. OpenGL
-functionality is given to use through pyglet when a window
-is crated. The underlying representation of this is an
+Arcade uses OpenGL for the underlying rendering, and OpenGL
+functionality is used through pyglet when a window
+is cre    ated. The underlying representation of this is an
 OpenGL context. Arcade's representation of this context
 is the :py:attr:`arcade.Window.ctx`. This is an
 :py:class:`~arcade.ArcadeContext`.

--- a/doc/programming_guide/opengl_notes.rst
+++ b/doc/programming_guide/opengl_notes.rst
@@ -5,7 +5,7 @@ OpenGL
 
 Arcade uses OpenGL for the underlying rendering, and OpenGL
 functionality is used through pyglet when a window
-is cre    ated. The underlying representation of this is an
+is created. The underlying representation of this is an
 OpenGL context. Arcade's representation of this context
 is the :py:attr:`arcade.Window.ctx`. This is an
 :py:class:`~arcade.ArcadeContext`.

--- a/doc/programming_guide/sprites/advanced.rst
+++ b/doc/programming_guide/sprites/advanced.rst
@@ -45,7 +45,7 @@ see the following:
 Sorting SpriteLists
 """""""""""""""""""
 
-Although the alternative listed above are often better, sorting sprite lists to
+Although the alternatives listed above are often better, sorting sprite lists to
 control draw order can still be useful.
 
 Like Python's built-in :py:meth:`list.sort`, you can pass a


### PR DESCRIPTION
I went through almost the whole documentation, and fixed some typos, and rephrased in some places. This is my first contribution, so if i did anything wrong, please correct me.
Files modified:
```
- opengl_notes.rst
- arcade_book.rst
- install.rst
- own_layout.rst and own_widgets.rst
- sprites/advanced.rst
```