### PR TITLE
fix pyinstaller hook imports arcade

### DIFF
--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -12,15 +12,13 @@ https://api.arcade.academy/en/latest/tutorials/bundling_with_pyinstaller/index.h
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from pathlib import Path
 
-import pymunk
 from PyInstaller.compat import is_darwin, is_unix, is_win
 
-import arcade
-
-pymunk_path = Path(pymunk.__file__).parent
-arcade_path = Path(arcade.__file__).parent
+pymunk_path = Path(find_spec("pymunk").origin).parent
+arcade_path = Path(find_spec("arcade").origin).parent
 
 datas = [
     (

--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -17,35 +17,48 @@ from pathlib import Path
 
 from PyInstaller.compat import is_darwin, is_unix, is_win
 
-pymunk_path = Path(find_spec("pymunk").origin).parent
-arcade_path = Path(find_spec("arcade").origin).parent
-
-datas = [
-    (
-        arcade_path / "resources" / "system",
-        "./arcade/resources/system",
-    ),
-    (
-        arcade_path / "VERSION",
-        "./arcade/VERSION",
-    ),
-]
-
-if is_win:
-    binaries = [
-        (pymunk_path / "_chipmunk.pyd", "."),
-    ]
-elif is_darwin:
-    binaries = [
-        (pymunk_path / "_chipmunk.abi3.so", "."),
-        (arcade_path / "lib", "./arcade/lib"),
-    ]
-elif is_unix:
-    binaries = [
-        (pymunk_path / "_chipmunk.abi3.so", "."),
-    ]
-else:
+# check for supported operating systems
+if not is_win and not is_darwin and not is_unix:
     raise NotImplementedError(
         "You are running on an unsupported operating system. "
         "Only Linux, Mac, and Windows are supported."
     )
+
+datas = []
+binaries = []
+
+# Add Arcade resources
+arcade_spec = find_spec("arcade")
+if arcade_spec is None or arcade_spec.origin is None:
+    raise ImportError("Arcade is not installed. Cannot continue.")
+
+arcade_path = Path(arcade_spec.origin).parent
+datas.extend(
+    [
+        (
+            arcade_path / "resources" / "system",
+            "./arcade/resources/system",
+        ),
+        (
+            arcade_path / "VERSION",
+            "./arcade/VERSION",
+        ),
+    ]
+)
+
+if is_darwin:
+    binaries.append((arcade_path / "lib", "./arcade/lib"))
+
+# Add Pymunk resources
+pymunk_spec = find_spec("pymunk")
+if pymunk_spec is not None and pymunk_spec.origin is not None:
+    pymunk_path = Path(pymunk_spec.origin).parent
+
+    if is_win:
+        binaries.append((pymunk_path / "_chipmunk.pyd", "."))
+    elif is_darwin:
+        binaries.append((pymunk_path / "_chipmunk.abi3.so", "."))
+    elif is_unix:
+        binaries.append((pymunk_path / "_chipmunk.abi3.so", "."))
+else:
+    print("Pymunk is not available. Skipping Pymunk resources.")


### PR DESCRIPTION
which requires multiple dependencies to be available even, in headless mode (like EGL, etc)