### PR TITLE
Pull Request to Add Optional view Argument in Window.run()

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -402,15 +402,17 @@ class Window(pyglet.window.Window):
         """Return a Rect describing the size of the window."""
         return LBWH(0, 0, self.width, self.height)
 
-    def run(self) -> None:
-        """
-        Run the event loop.
+    from typing import Optional
 
-        After the window has been set up, and the event hooks are in place, this
-        is usually one of the last commands on the main program. This is a blocking
-        function starting pyglet's event loop meaning it will start to dispatch
-        events such as ``on_draw`` and ``on_update``.
+    def run(self, view: Optional[View] = None) -> None:
         """
+        Run the event loop. Optionally start with a specified view.
+
+        Args:
+            view (Optional[View]): The view to display when starting the run. Defaults to None.
+        """
+        if view is not None:
+            self.show_view(view)
         arcade.run()
 
     def close(self) -> None:

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -97,7 +97,7 @@ def close_window() -> None:
     gc.collect()
 
 
-def run():
+def run(view = None):
     """
     Run the main loop.
 
@@ -107,6 +107,10 @@ def run():
     it will start to dispatch events such as ``on_draw`` and ``on_update``.
     """
     window = get_window()
+
+    # Show the specific view if provided
+    if view is not None:
+        window.show_view(view)
 
     # Used in some unit test
     if os.environ.get("ARCADE_TEST"):

--- a/tests/unit/window/test_window_new.py
+++ b/tests/unit/window/test_window_new.py
@@ -1,0 +1,41 @@
+import pytest
+import arcade
+
+
+class TestView(arcade.View):
+    def __init__(self):
+        super().__init__()
+        self.on_show_called = False
+
+    def on_show_view(self):
+        self.on_show_called = True
+
+
+def test_window_with_view():
+    # Cria uma janela e uma view para o teste
+    window = arcade.Window(width=800, height=600, title="Window Test with View")
+    view = TestView()
+
+    # Executa o método run com a view
+    window.run(view=view)
+
+    # Verifica se a view foi mostrada automaticamente
+    assert window.current_view == view
+    assert view.on_show_called is True
+
+    # Fecha a janela ao finalizar o teste
+    window.close()
+
+
+def test_run_without_view():
+    # Cria uma janela e chama run sem uma view
+    window = arcade.Window(width=800, height=600, title="Window Test without View")
+    
+    # Executa o método run sem uma view
+    window.run()
+
+    # Verifica que não há uma view ativa
+    assert window.current_view is None
+
+    # Fecha a janela ao finalizar o teste
+    window.close()


### PR DESCRIPTION
PR Description

This pull request aims to add an optional view argument to the Window.run() and arcade.run() methods. This feature is designed to improve developer experience by promoting the use of subclassed views instead of direct window manipulation.

Implementations and Observations
->  Addition of view Argument:
- With this PR, the run() method now accepts an optional view argument and will automatically call Window.show_view.

-> Testing:
- Unfortunately, the full implementation of tests was affected by issues with the pyglet module, specifically regarding the import of pyglet.display.base.
- The required function to initialize the pyglet environment encountered module errors, preventing complete test execution.
- 
-> Suggestions for Future Implementations:
- While this PR provides a functional base, I suggest further investigation into compatibility with pyglet to complete the testing process.

Note

For technical details and context, refer to [Issue #2400](https://github.com/pythonarcade/arcade/issues/2400), where challenges and initial steps for this PR were discussed.