### PR TITLE
Add optional view argument to Window.run() and arcade.run()

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -402,7 +402,7 @@ class Window(pyglet.window.Window):
         """Return a Rect describing the size of the window."""
         return LBWH(0, 0, self.width, self.height)
 
-    def run(self) -> None:
+    def run(self, view=None) -> None:
         """
         Run the event loop.
 
@@ -411,7 +411,7 @@ class Window(pyglet.window.Window):
         function starting pyglet's event loop meaning it will start to dispatch
         events such as ``on_draw`` and ``on_update``.
         """
-        arcade.run()
+        arcade.run(view=view)
 
     def close(self) -> None:
         """Close the Window."""

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -97,7 +97,7 @@ def close_window() -> None:
     gc.collect()
 
 
-def run():
+def run(view=None):
     """
     Run the main loop.
 
@@ -107,6 +107,10 @@ def run():
     it will start to dispatch events such as ``on_draw`` and ``on_update``.
     """
     window = get_window()
+
+    # Show the provided view if specified
+    if view is not None:
+        window.show_view(view)
 
     # Used in some unit test
     if os.environ.get("ARCADE_TEST"):


### PR DESCRIPTION
This PR adds an optional view parameter to Window.run() and arcade.run(), allowing users to specify a view to display when starting the main event loop. This improves flexibility in displaying views directly.