### PR TITLE
Center shields.io elements in the README.md file and grammar fixes for multiple documents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Version 3.0.0 is a major update to Arcade. It breaks compatibility with the 2.6 
 These are the breaking API changes. Use this as a quick reference for updating 2.6 code. You can find more details in later sections. Lots of behavior has changed even if the interface hasn't. If you are porting old code, read through these logs thoroughly.
 
 * Dropped Python 3.8 support completely.
-* Texture management has completely changed in  3.0. In the past, we
+* Texture management has completely changed in 3.0. In the past, we
  cached everything, which caused issues for larger
  projects that needed memory management. Functions like `Arcade.load_texture` no longer cache textures.
 * Removed the poorly named `Window.set_viewport` and `set_viewport` methods.
@@ -234,7 +234,7 @@ These are the breaking API changes. Use this as a quick reference for updating 2
 ### Controller Input
 
 Previously, controllers were usable via the `Arcade.joysticks` module. This module is still available in 3.0.
-However, most people can treat it as depreciated. It is an alias to Pyglet's joysticks sub-module. There is now an `arcade.controller` module that is an alias to Pyglet's new Controller API. This change should make a more comprehensive selection of controllers usable with Arcade. The joystick module may still be helpful if you need specialty controllers such as racing wheels or flight sticks. The example code now uses the new controller AP.
+However, most people can treat it as depreciated. It is an alias to Pyglet's joysticks sub-module. There is now an `arcade.controller` module that is an alias to Pyglet's new Controller API. This change should make a more comprehensive choice of controllers usable with Arcade. The joystick module may still be helpful if you need specialty controllers such as racing wheels or flight sticks. The example code now uses the new controller AP.
 
 ### Text
 
@@ -320,7 +320,7 @@ We would also like to thank the contributors who spent their valuable time solvi
 #### Notable contributors:
 * [DarkLight1337](https://github.com/DarkLight1337) helped the team untangle type annotation issues for cameras
 * [Mohammad Ibrahim](https://github.com/Ibrahim2750mi) was a massive help with the GUI and various other parts of the library.
-* [ryyst](https://github.com/ryyst) completely revitalised the Arcade Docs.
+* [ryyst](https://github.com/ryyst) completely revitalized the Arcade Docs.
 
 #### Contributors
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,7 +28,7 @@ Examples of unacceptable behavior by participants include:
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conducts that could reasonably be considered inappropriate in a
+* Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
@@ -28,7 +28,7 @@ Examples of unacceptable behavior by participants include:
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+* Other conducts that could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -56,8 +56,7 @@ a project may be further defined and clarified by project maintainers.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at paul@cravenfamily.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+complaints will be reviewed and investigated and will result in a response deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Arcade welcomes contributions, including:
 If you're looking for a way to contribute, try checking
 [the currently active issues](https://github.com/pythonarcade/arcade/issues)
 for one that needs work. If you're new to programming or contributing, check for the
-label `good first issue`, these are issues which have been identified as good candidates for first time contributors.
+label `good first issue`, these are issues that have been identified as good candidates for first time contributors.
 
 Notifying us about issues in the code and documentation is also a valuable contribution.
 
@@ -112,11 +112,11 @@ Args:
 
 * `Args:` should be used for all parameters
 * `Returns:` can be used if the return value needs additional explanation outside
-   the current docstring. If the return type is already clear from type annotation it
+   the current docstring. If the return type is already clear from type annotation, it
    can be omitted.
 * `Raises:` can be used if the function raises exceptions that need to be documented
 * `Yields:` can be used if the function is a generator and yields values
-* `Attributes:` we should try to avoid and instead document the attributes in the code
+* `Attributes:` we should try to avoid it and instead document the attributes in the code
 * Types are visible in the api docs. It's not mandatory to include types in docstring,
   however, simple types like `int`, `str`, `float`, `bool` can be included.
 * Using `optional` is a good way to indicate that a parameter is optional.
@@ -145,8 +145,8 @@ more discussion on this topic.
 # type: ignore  # pending https://github.com/pyglet/pyglet/issues/843
 ```
 
-This links to an issue in the 3rd party library that is causing the type error.
-This oddly-specific syntax is compatible with both mypy and pyright.
+This links to an issue in the third party library that is causing the type error.
+This oddly specific syntax is compatible with both mypy and pyright.
 See [this issue](https://github.com/pythonarcade/arcade/issues/1789) for more information.
 
 ### Use pre-commit hooks to automatically run formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,14 +88,14 @@ See [this link](https://black.readthedocs.io/en/stable/integrations/editors.html
 Black integration for your specific editor.
 
 The following command will run black for you if you do not want to configure your editor to do it. It can be
-a good idea to run this command when you are finished working anyways, as our CI will use this to check that
+a good idea to run this command when you are finished working anyway, as our CI will use this to check that
 the formatting is correct.
 
 ```bash
 python make.py format
 ```
 
-In addition to Black, this will sort the imports using [Ruff](https://docs.astral.sh/ruff/). If you want to setup
+In addition to Black, this will sort the imports using [Ruff](https://docs.astral.sh/ruff/). If you want to set up
 your editor to run this, please see [this link](https://docs.astral.sh/ruff/integrations/) for more information on
 Ruff integration for your specific editor.
 
@@ -111,7 +111,7 @@ Args:
 ```
 
 * `Args:` should be used for all parameters
-* `Returns:` can be used if the return value needs additional explanation outside of
+* `Returns:` can be used if the return value needs additional explanation outside
    the current docstring. If the return type is already clear from type annotation it
    can be omitted.
 * `Raises:` can be used if the function raises exceptions that need to be documented
@@ -181,7 +181,7 @@ in this repo for current tests.
 
 First, run the below command to run our linting tools automatically. This will run Mypy
 and Ruff against Arcade. The first run of this may take some as MyPy will not have any
-caches built up. Sub-sequent runs will be much faster.
+caches built up. Subsequent runs will be much faster.
 
 ```bash
 python make.py lint
@@ -266,7 +266,7 @@ sudo apt install texlive-latex-extra
 To reduce the large (300 MB+) install size of the second package, you
 may be able to use the `--no-install-recommends` flag.
 
-Other platforms may require different install steps.
+Other platforms may require different installation steps.
 
 ##### Building
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## System Info
 
-Run this and paste the output here: python -m arcade
+Run `python -m arcade` and paste the output here.
 
 ### Actual behavior:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 Arcade is an easy-to-learn Python library for creating 2D video games.
-It is ideal for beginning programmers, or programmers who want to create
+It is ideal for beginning programmers or programmers who want to create
 2D games without learning a complex framework.
 
 [pyglet]: https://github.com/pyglet/pyglet

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Welcome to The Arcade Library!
 
-![MIT License](https://img.shields.io/pypi/l/arcade)
-[<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="Pull Requests Welcome">](http://makeapullrequest.com)
-[<img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt="First Timers Friendly">](http://www.firsttimersonly.com/)
+<p align="center">
+    <img src="https://img.shields.io/pypi/l/arcade">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="http://makeapullrequest.com">
+    <img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt=http://www.firsttimersonly.com/">
+</p>
 
 Arcade is an easy-to-learn Python library for creating 2D video games.
 It is ideal for beginning programmers, or programmers who want to create
@@ -15,8 +17,12 @@ for example game jam entries and more.
 
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 
-![PyPI - Downloads](https://img.shields.io/pypi/dm/arcade)
-![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/pythonarcade/arcade)
+<p align="center">
+    <img src="https://img.shields.io/pypi/dm/arcade">
+    <img src="https://img.shields.io/github/commit-activity/m/pythonarcade/arcade">
+    <img src="https://img.shields.io/github/contributors/pythonarcade/arcade">
+    <img src="https://img.shields.io/github/stars/pythonarcade/arcade">
+</p>
 
 ## Stable Documentation
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -11,10 +11,10 @@
 9. Update version number in `arcade/version.py`
 10. Update :ref:`release_notes` with release dates and any additional
    info needed.
-11. Make sure last check-in ran clean on github actions, viewable on Discord
+11. Make sure last check-in ran clean on GitHub actions, viewable on Discord
 12. Merge development branch into maintenance.
 13. Add label to release
-14. Push code. Check for clean compile on github.
+14. Push code. Check for clean compile on GitHub.
 15. Type `make clean`
 16. Type `make dist`
 17. Type `make deploy_pypi`

--- a/doc/about/faq.rst
+++ b/doc/about/faq.rst
@@ -24,6 +24,6 @@ Even adapted versions of Arcade or parts of it can be used in commercial project
 Can I use Arcade resources in my own educational materials?
 -----------------------------------------------------------
 
-Yes! Arcade was primarily developed for educational purposes.
-Use Arcade materials in any way you see fit. Original content
-or adapted versions of it.
+Of course! Arcade was built to support learning.
+You can use its materials however you need—
+whether you stick with the original content or make changes to suit your needs.

--- a/doc/about/intro.rst
+++ b/doc/about/intro.rst
@@ -21,7 +21,7 @@ Community driven
 ----------------
 
 Arcade is a community-driven project, and we rely on support from users like you.
-You don’t need to be an expert programmer or game developer to contribute.
+You don't need to be an expert programmer or game developer to contribute.
 
 * More information about ways to contribute: :ref:`how-to-contribute`.
 * Also see :ref:`community-locations` for more information about where to find the

--- a/doc/about/intro.rst
+++ b/doc/about/intro.rst
@@ -20,10 +20,9 @@ of resources to help you learn.
 Community driven
 ----------------
 
-Arcade is a community driven project. We cannot exist without the help of our users.
-You don't need to be an experienced programmer or a game developer to help us.
-You can help us by reporting bugs, suggesting improvements, pointing out issues
-in documentation or even by sharing your projects with us.
+Arcade is a community-driven project, and we rely on support from users like you.
+You don’t need to be an expert programmer or game developer to contribute.
+You can help by reporting bugs, suggesting improvements, identifying documentation issues, or sharing your projects with us.
 
 * More information about ways to contribute: :ref:`how-to-contribute`.
 * Also see :ref:`community-locations` for more information about where to find the

--- a/doc/about/intro.rst
+++ b/doc/about/intro.rst
@@ -22,7 +22,6 @@ Community driven
 
 Arcade is a community-driven project, and we rely on support from users like you.
 You don’t need to be an expert programmer or game developer to contribute.
-You can help by reporting bugs, suggesting improvements, identifying documentation issues, or sharing your projects with us.
 
 * More information about ways to contribute: :ref:`how-to-contribute`.
 * Also see :ref:`community-locations` for more information about where to find the


### PR DESCRIPTION
Shields.io elements are now centerized in README.md. 

Also made changes in multiple documents, changes include:
 - Grammar fixes
 - Spelling fixes
 - Rephrasing for clear message delivery and more clarity
 - Remove extra characters, such as blank spaces

Documents with changes mentioned above:
 - README.md 
 - CHANGELOG.md
 - CODE_OF_CONDUCT.md
 - CONTRIBUTING.md
 - ISSUE_TEMPLATE.md
 - RELEASE_CHECKLIST.md
 - doc/about/faq.rst
 - doc/about/intro.rst
 
Note: I may be missing some documents in the list above. I apologize if I am. 