### PR TITLE
Add cross-refs, annotation, and pyglet Weight to UILabel

### DIFF
--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -87,7 +87,7 @@ class UILabel(UIWidget):
         font_name=("calibri", "arial"),
         font_size: float = 12,
         text_color: RGBOrA255 = arcade.color.WHITE,
-        bold=False,
+        bold: str | bool = False,
         italic=False,
         align="left",
         multiline: bool = False,
@@ -235,7 +235,9 @@ class UILabel(UIWidget):
                 success.
             font_size: Font size of font.
             font_color: Color of the text.
-            bold: If enabled, the label's text will be in a **bold** style.
+            bold: May be any value in :py:obj:`pyglet.text.Weight`,
+                ``True`` (converts to ``"bold"``), or ``False``
+                (converts to ``"regular"``).
             italic: If enabled, the label's text will be in an *italic*
         """
         font_name = font_name or self._label.font_name


### PR DESCRIPTION
**TL;DR** Small for now, but may call for more changes here or elsewhere. Can merge soon if you want.

* Add type annotation update for bold
* Add cross-refs

I may expand this with more changes, but I'm mulling over whether font doc belongs over in pyglet, here, or the Programming Guide.