### PR TITLE
Temp fix decade-long Sphinx bug breaking our CSS during partial rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,6 @@ temp/
 
 .flake8
 
-# pending: Sphinx 8.1.4 + deps are verified as workin with arcade
-# this works around an annoying static copy issue
+# pending: Sphinx 8.1.4 + deps are verified as working with Arcade
+# see util/sphinx_static_file_temp_fix.py
 .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ temp/
 .python-version
 
 .flake8
+
+# pending: Sphinx 8.1.4 + deps are verified as workin with arcade
+# this works around an annoying static copy issue
+.ENABLE_DEVMACHINE_SPHINX_STATIC_FIX

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,28 +32,30 @@ HERE = Path(__file__).resolve()
 DOC_DIR = HERE.parent
 REPO_LOCAL_ROOT = DOC_DIR.parent
 
+# pending: Sphinx 8.1.4 + deps verified as compatible with Arcade to fix static copy
+# Make it move because Sphinx only fixed the copy issue as of a few days ago
+# https://github.com/sphinx-doc/sphinx/pull/13236
+# https://github.com/sphinx-doc/sphinx/issues/181
+ENABLE_DEVMACHINE_SPHINX_STATIC_FIX = REPO_LOCAL_ROOT / ".ENABLE_DEVMACHINE_SPHINX_STATIC_FIX"
 STATIC_SOURCE_DIR = DOC_DIR / "_static"
+
 ARCADE_MODULE = REPO_LOCAL_ROOT / "arcade"
 UTIL_DIR = REPO_LOCAL_ROOT / "util"
 BUILD_DIR = REPO_LOCAL_ROOT / "build"
 BUILD_HTML_DIR = BUILD_DIR / "html"
 BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
 
-
 log.info(f"Absolute path for our conf.py       : {str(HERE)!r}")
 log.info(f"Absolute path for the repo root     : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the arcade module : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the util dir      : {str(UTIL_DIR)!r}")
 
+
 STATIC_CSS_DIR = STATIC_SOURCE_DIR / "css"
-# Make it move because Sphinx only fixed the copy issue as of a few days ago
-# https://github.com/sphinx-doc/sphinx/pull/13236
-# https://github.com/sphinx-doc/sphinx/issues/1810
 force_copy_on_change = {  # pending: sphinx >= 8.1.4
     source_file: BUILD_STATIC_DIR / f"css/{source_file.name}"
     for source_file in STATIC_CSS_DIR.glob("*.css")
 }
-
 
 def force_sync(src, dest, dry: bool = False):
     if sphinx.__version__ >= '8.1.4':
@@ -75,12 +77,14 @@ def force_sync(src, dest, dry: bool = False):
         raise e
 
 
-if BUILD_HTML_DIR.exists():
+if not ENABLE_DEVMACHINE_SPHINX_STATIC_FIX.exists():
+    log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
+elif BUILD_HTML_DIR.exists():
+    log.info(f"SYNC: Force-sync enable file found")
     for src, dest in force_copy_on_change.items():
         force_sync(src, dest)
 else:
     log.info("Skipping force-sync due to no build dir")
-
 
 
 # _temp_version = (REPO_LOCAL_ROOT / "arcade" / "VERSION").read_text().replace("-",'')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """Sphinx configuration file"""
 from __future__ import annotations
-
-import shutil
 from functools import cache
 import logging
 from pathlib import Path
@@ -29,20 +27,15 @@ log = logging.getLogger('conf.py')
 logging.basicConfig(level=logging.INFO)
 
 HERE = Path(__file__).resolve()
-DOC_DIR = HERE.parent
-REPO_LOCAL_ROOT = DOC_DIR.parent
+REPO_LOCAL_ROOT = HERE.parent.parent
 
 ARCADE_MODULE = REPO_LOCAL_ROOT / "arcade"
 UTIL_DIR = REPO_LOCAL_ROOT / "util"
-BUILD_DIR = REPO_LOCAL_ROOT / "build"
-BUILD_HTML_DIR = BUILD_DIR / "html"
-
 
 log.info(f"Absolute path for our conf.py       : {str(HERE)!r}")
 log.info(f"Absolute path for the repo root     : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the arcade module : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the util dir      : {str(UTIL_DIR)!r}")
-
 
 # _temp_version = (REPO_LOCAL_ROOT / "arcade" / "VERSION").read_text().replace("-",'')
 
@@ -51,7 +44,6 @@ sys.path.insert(0, str(ARCADE_MODULE))
 log.info(f"Inserted elements in system path: First two are now:")
 for i in range(2):
     log.info(f"  {i}: {sys.path[i]!r}")
-
 
 # Don't change to
 # from arcade.version import VERSION
@@ -97,6 +89,8 @@ def run_util(filename, run_name="__main__", init_globals=None):
 
     runpy.run_path(full_str, **kwargs)
 
+# Temp fix for Sphinx not copying static files  # pending: post-3.0 refactor
+# Enable by creating a .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX
 run_util("sphinx_static_file_temp_fix.py")
 
 # Make thumbnails for the example code screenshots

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Sphinx configuration file"""
 from __future__ import annotations
+
+import shutil
 from functools import cache
 import logging
 from pathlib import Path
@@ -27,14 +29,59 @@ log = logging.getLogger('conf.py')
 logging.basicConfig(level=logging.INFO)
 
 HERE = Path(__file__).resolve()
-REPO_LOCAL_ROOT = HERE.parent.parent
+DOC_DIR = HERE.parent
+REPO_LOCAL_ROOT = DOC_DIR.parent
+
+STATIC_SOURCE_DIR = DOC_DIR / "_static"
 ARCADE_MODULE = REPO_LOCAL_ROOT / "arcade"
 UTIL_DIR = REPO_LOCAL_ROOT / "util"
+BUILD_DIR = REPO_LOCAL_ROOT / "build"
+BUILD_HTML_DIR = BUILD_DIR / "html"
+BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
+
 
 log.info(f"Absolute path for our conf.py       : {str(HERE)!r}")
 log.info(f"Absolute path for the repo root     : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the arcade module : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the util dir      : {str(UTIL_DIR)!r}")
+
+STATIC_CSS_DIR = STATIC_SOURCE_DIR / "css"
+# Make it move because Sphinx only fixed the copy issue as of a few days ago
+# https://github.com/sphinx-doc/sphinx/pull/13236
+# https://github.com/sphinx-doc/sphinx/issues/1810
+force_copy_on_change = {  # pending: sphinx >= 8.1.4
+    source_file: BUILD_STATIC_DIR / f"css/{source_file.name}"
+    for source_file in STATIC_CSS_DIR.glob("*.css")
+}
+
+
+def force_sync(src, dest, dry: bool = False):
+    if sphinx.__version__ >= '8.1.4':
+        log.warning(
+            'Sphinx >= 8.1.4 may patch broken _static copy\n'
+            '  (see https://github.com/sphinx-doc/sphinx/issues/1810)')
+    try:
+        if src.read_text() != dest.read_text():
+            if dry:
+                log.info(f" DRY : {src} was out of date, but dry run left it as-is!")
+            # shutil.copyfile(src, dest)
+            else:
+                log.info(f" SYNC: {src} was out of date!")
+
+        else:
+            log.info(f" SKIP: {src} is current!")
+    except Exception as e:
+        log.error(f" FAIL: {src} failed: {e}")
+        raise e
+
+
+if BUILD_HTML_DIR.exists():
+    for src, dest in force_copy_on_change.items():
+        force_sync(src, dest)
+else:
+    log.info("Skipping force-sync due to no build dir")
+
+
 
 # _temp_version = (REPO_LOCAL_ROOT / "arcade" / "VERSION").read_text().replace("-",'')
 
@@ -43,6 +90,7 @@ sys.path.insert(0, str(ARCADE_MODULE))
 log.info(f"Inserted elements in system path: First two are now:")
 for i in range(2):
     log.info(f"  {i}: {sys.path[i]!r}")
+
 
 # Don't change to
 # from arcade.version import VERSION

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,59 +32,16 @@ HERE = Path(__file__).resolve()
 DOC_DIR = HERE.parent
 REPO_LOCAL_ROOT = DOC_DIR.parent
 
-# pending: Sphinx 8.1.4 + deps verified as compatible with Arcade to fix static copy
-# Make it move because Sphinx only fixed the copy issue as of a few days ago
-# https://github.com/sphinx-doc/sphinx/pull/13236
-# https://github.com/sphinx-doc/sphinx/issues/181
-ENABLE_DEVMACHINE_SPHINX_STATIC_FIX = REPO_LOCAL_ROOT / ".ENABLE_DEVMACHINE_SPHINX_STATIC_FIX"
-STATIC_SOURCE_DIR = DOC_DIR / "_static"
-
 ARCADE_MODULE = REPO_LOCAL_ROOT / "arcade"
 UTIL_DIR = REPO_LOCAL_ROOT / "util"
 BUILD_DIR = REPO_LOCAL_ROOT / "build"
 BUILD_HTML_DIR = BUILD_DIR / "html"
-BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
+
 
 log.info(f"Absolute path for our conf.py       : {str(HERE)!r}")
 log.info(f"Absolute path for the repo root     : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the arcade module : {str(REPO_LOCAL_ROOT)!r}")
 log.info(f"Absolute path for the util dir      : {str(UTIL_DIR)!r}")
-
-
-STATIC_CSS_DIR = STATIC_SOURCE_DIR / "css"
-force_copy_on_change = {  # pending: sphinx >= 8.1.4
-    source_file: BUILD_STATIC_DIR / f"css/{source_file.name}"
-    for source_file in STATIC_CSS_DIR.glob("*.css")
-}
-
-def force_sync(src, dest, dry: bool = False):
-    if sphinx.__version__ >= '8.1.4':
-        log.warning(
-            'Sphinx >= 8.1.4 may patch broken _static copy\n'
-            '  (see https://github.com/sphinx-doc/sphinx/issues/1810)')
-    try:
-        if src.read_text() != dest.read_text():
-            if dry:
-                log.info(f" DRY : {src} was out of date, but dry run left it as-is!")
-            # shutil.copyfile(src, dest)
-            else:
-                log.info(f" SYNC: {src} was out of date!")
-
-        else:
-            log.info(f" SKIP: {src} is current!")
-    except Exception as e:
-        log.error(f" FAIL: {src} failed: {e}")
-        raise e
-
-
-if not ENABLE_DEVMACHINE_SPHINX_STATIC_FIX.exists():
-    log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
-elif BUILD_HTML_DIR.exists():
-    log.info(f"SYNC: Force-sync enable file found")
-    for src, dest in force_copy_on_change.items():
-        force_sync(src, dest)
-else:
-    log.info("Skipping force-sync due to no build dir")
 
 
 # _temp_version = (REPO_LOCAL_ROOT / "arcade" / "VERSION").read_text().replace("-",'')
@@ -140,13 +97,14 @@ def run_util(filename, run_name="__main__", init_globals=None):
 
     runpy.run_path(full_str, **kwargs)
 
+run_util("sphinx_static_file_temp_fix.py")
+
 # Make thumbnails for the example code screenshots
 run_util("generate_example_thumbnails.py")
 # Create a tabular representation of the resources with embeds
 run_util("create_resources_listing.py", init_globals=RESOURCE_GLOBALS)
 # Run the generate quick API index script
 run_util('../util/update_quick_index.py')
-
 
 autodoc_inherit_docstrings = False
 autodoc_default_options = {

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+A quick, ugly fix for a broken static file handler.
+
+This runs sync over static folders entries crucial for web dev
+which Sphinx <= 8.1.3 does not properly handle due to early exit
+checks. Keep the following in mind:
+
+1. It is not tested to work with sphinx-autobuild or ./make.py serve
+2. It was created for use with Arcade' ./make.py html
+
+To enable it on your system:
+
+1. cd to your repo root
+2. `touch  .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX`
+
+Removal requires:
+
+1. Sphinx 8.1.4 or another version ships the fixes:
+
+   * https://github.com/sphinx-doc/sphinx/pull/13236
+   * https://github.com/sphinx-doc/sphinx/issues/181
+
+2. We verify it as compatible with Arcade's dependencies
+
+
+"""
+
+import sys
+import logging
+from pathlib import Path
+from sphinx import __version__ as sphinx_version
+
+UTIL_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = UTIL_DIR.parent.resolve()
+# Ensure we get utility & Arcade imports first
+sys.path.insert(0, str(REPO_ROOT))
+
+log = logging.getLogger(__name__)
+
+DOC_DIR = REPO_ROOT / "doc"
+STATIC_SOURCE_DIR = DOC_DIR / "_static"
+
+ENABLE_DEVMACHINE_SPHINX_STATIC_FIX = REPO_ROOT / ".ENABLE_DEVMACHINE_SPHINX_STATIC_FIX"
+
+BUILD_DIR = REPO_ROOT / "build"
+BUILD_HTML_DIR = BUILD_DIR / "html"
+BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
+
+
+STATIC_CSS_DIR = STATIC_SOURCE_DIR / "css"
+force_copy_on_change = {  # pending: sphinx >= 8.1.4
+    source_file: BUILD_STATIC_DIR / f"css/{source_file.name}"
+    for source_file in STATIC_CSS_DIR.glob("*.css")
+}
+
+def force_sync(src, dest, dry: bool = False):
+    if sphinx_version >= '8.1.4':
+        log.warning(
+            'Sphinx >= 8.1.4 may patch broken _static copy\n'
+            '  (see https://github.com/sphinx-doc/sphinx/issues/1810)')
+    try:
+        if src.read_text() != dest.read_text():
+            if dry:
+                log.info(f" DRY : {src} was out of date, but dry run left it as-is!")
+            # shutil.copyfile(src, dest)
+            else:
+                log.info(f" SYNC: {src} was out of date!")
+
+        else:
+            log.info(f" SKIP: {src} is current!")
+    except Exception as e:
+        log.error(f" FAIL: {src} failed: {e}")
+        raise e
+
+
+def main():
+    if not ENABLE_DEVMACHINE_SPHINX_STATIC_FIX.exists():
+        log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
+    elif BUILD_HTML_DIR.exists():
+        log.info(f"SYNC: Force-sync enable file found")
+        for src, dest in force_copy_on_change.items():
+            force_sync(src, dest)
+    else:
+        log.info("Skipping force-sync due to no build dir")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -107,6 +107,7 @@ def force_sync(src: Path, dest: Path, dry: bool = False) -> None:
 def main():
     if not ENABLE_DEVMACHINE_SPHINX_STATIC_FIX.exists():
         log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
+        return
     elif BUILD_HTML_DIR.exists():
         log.info(f"SYNC: Force-sync enable file found")
         for src, dest in force_copy_on_change.items():

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -31,14 +31,14 @@ Keep the following in mind:
 ## What did Sphinx break this time?
 
 1. Sphinx has a long-standing bug which fails to copy static files
-   https://github.com/sphinx-doc/sphinx/issues/181
+   https://github.com/sphinx-doc/sphinx/issues/1810
 
-2. They only merged a PR for this into their dev branch on Jan 13, 2025:
+2. The fix is slated for 8.2.0 and the fix PR merged on Jan 13, 2025:
    https://github.com/sphinx-doc/sphinx/pull/13236
 
 3. No, Arcade 3.0 **will not wait** for the following:
 
-   1. Sphinx 3.1.4+ to ship the fix for the problem
+   1. Sphinx 3.2.0 to ship the fix for the problem
    2. Themes to become compatible
    3. Plugins to become compatible
    4. Our customizations to be tested with all of the above

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -6,13 +6,8 @@ IMPORTANT: ONLY LOCAL DEVELOPER MACHINES NEED THIS!
 
 ## Who should use this?
 
-Does `./make.py html` fail to copy modified CSS files on your dev machine?
-
-| Behavior                  | Action                             |
-|---------------------------|------------------------------------|
-| I use `./make.py serve`.  | Don't worry about it               |
-| It won't copy CSS changes.| Keep reading                       |
-| Works on my machine       | Check if you use `./make.py serve` |
+If `./make.py clean` seems like the only way to get `./make.py html` or
+`./make.py serve` to serve your modified CSS, then yes, it's for you.
 
 ## How do I use this?
 
@@ -24,11 +19,14 @@ Does `./make.py html` fail to copy modified CSS files on your dev machine?
 
 Keep the following in mind:
 
-1. It is not tested to work with sphinx-autobuild or `./make.py serve`
-2. It was created for use with Arcade's `./make.py html`
-3. No real config options atm (PRs welcome)
+1. It is a temp fix which *seems* to work with both:
 
-## What did Sphinx break this time?
+   * `./make.py html`
+   * `./make.py serve`
+
+3. No real config options other on/off via file presence
+
+## What's Broken in Sphinx?
 
 1. Sphinx has a long-standing bug which fails to copy static files
    https://github.com/sphinx-doc/sphinx/issues/1810
@@ -64,13 +62,13 @@ STATIC_SOURCE_DIR = DOC_DIR / "_static"
 ENABLE_DEVMACHINE_SPHINX_STATIC_FIX = REPO_ROOT / ".ENABLE_DEVMACHINE_SPHINX_STATIC_FIX"
 
 BUILD_DIR = REPO_ROOT / "build"
-BUILD_HTML_DIR = BUILD_DIR / "html"
+BUILD_HTML_DIR = BUILD_DIR / "html" / "doc"
 BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
-
+BUILD_CSS_DIR = BUILD_STATIC_DIR / "css"
 
 STATIC_CSS_DIR = STATIC_SOURCE_DIR / "css"
 force_copy_on_change = {  # pending: sphinx >= 8.1.4
-    source_file: BUILD_STATIC_DIR / f"css/{source_file.name}"
+    source_file: BUILD_CSS_DIR / source_file.name
     for source_file in STATIC_CSS_DIR.glob("*.css")
 }
 
@@ -108,12 +106,13 @@ def main():
     if not ENABLE_DEVMACHINE_SPHINX_STATIC_FIX.exists():
         log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
         return
-    elif BUILD_HTML_DIR.exists():
-        log.info(f"SYNC: Force-sync enable file found")
-        for src, dest in force_copy_on_change.items():
-            force_sync(src, dest)
-    else:
+    elif not BUILD_HTML_DIR.exists():
         log.info("Skipping force-sync due to no build dir")
+        return
+
+    log.info(f"SYNC: Force-sync enable file found")
+    for src, dest in force_copy_on_change.items():
+        force_sync(src, dest)
 
 
 if __name__ == "__main__":

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -1,28 +1,47 @@
 #!/usr/bin/env python3
 """
-A quick, ugly fix for a broken static file handler.
+Gets 3.0 out the door by temp fixing Sphinx rebuild not copying CSS.
 
-This runs sync over static folders entries crucial for web dev
-which Sphinx <= 8.1.3 does not properly handle due to early exit
-checks. Keep the following in mind:
+IMPORTANT: ONLY LOCAL DEVELOPER MACHINES NEED THIS!
 
-1. It is not tested to work with sphinx-autobuild or ./make.py serve
-2. It was created for use with Arcade' ./make.py html
+## Who should use this?
 
-To enable it on your system:
+Does `./make.py html` fail to copy modified CSS files on your dev machine?
 
-1. cd to your repo root
-2. `touch  .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX`
+| Behavior                  | Action                             |
+|---------------------------|------------------------------------|
+| I use `./make.py serve`.  | Don't worry about it               |
+| It won't copy CSS changes.| Keep reading                       |
+| Works on my machine       | Check if you use `./make.py serve` |
 
-Removal requires:
+## How do I use this?
 
-1. Sphinx 8.1.4 or another version ships the fixes:
+1. `cd` to the repo root
+2. `touch .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX`
+3. `./make.py html` with working CSS change updates copying
 
-   * https://github.com/sphinx-doc/sphinx/pull/13236
-   * https://github.com/sphinx-doc/sphinx/issues/181
+## When should I be careful?
 
-2. We verify it as compatible with Arcade's dependencies
+Keep the following in mind:
 
+1. It is not tested to work with sphinx-autobuild or `./make.py serve`
+2. It was created for use with Arcade's `./make.py html`
+3. No real config options atm (PRs welcome)
+
+## What did Sphinx break this time?
+
+1. Sphinx has a long-standing bug which fails to copy static files
+   https://github.com/sphinx-doc/sphinx/issues/181
+
+2. They only merged a PR for this into their dev branch on Jan 13, 2025:
+   https://github.com/sphinx-doc/sphinx/pull/13236
+
+3. No, Arcade 3.0 **will not wait** for the following:
+
+   1. Sphinx 3.1.4+ to ship the fix for the problem
+   2. Themes to become compatible
+   3. Plugins to become compatible
+   4. Our customizations to be tested with all of the above
 
 """
 
@@ -33,6 +52,7 @@ from sphinx import __version__ as sphinx_version
 
 UTIL_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = UTIL_DIR.parent.resolve()
+
 # Ensure we get utility & Arcade imports first
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -54,7 +74,17 @@ force_copy_on_change = {  # pending: sphinx >= 8.1.4
     for source_file in STATIC_CSS_DIR.glob("*.css")
 }
 
-def force_sync(src, dest, dry: bool = False):
+
+def force_sync(src: Path, dest: Path, dry: bool = False) -> None:
+    """Sync a single file from ``src`` to ``dest``.
+
+    Caveats:
+
+    1. Assumes both are `pathlib.Path` instances
+    2. Assumes both are small
+    3. Fails hard when a file isn't found
+
+    """
     if sphinx_version >= '8.1.4':
         log.warning(
             'Sphinx >= 8.1.4 may patch broken _static copy\n'

--- a/util/sphinx_static_file_temp_fix.py
+++ b/util/sphinx_static_file_temp_fix.py
@@ -62,7 +62,7 @@ STATIC_SOURCE_DIR = DOC_DIR / "_static"
 ENABLE_DEVMACHINE_SPHINX_STATIC_FIX = REPO_ROOT / ".ENABLE_DEVMACHINE_SPHINX_STATIC_FIX"
 
 BUILD_DIR = REPO_ROOT / "build"
-BUILD_HTML_DIR = BUILD_DIR / "html" / "doc"
+BUILD_HTML_DIR = BUILD_DIR / "html"
 BUILD_STATIC_DIR = BUILD_HTML_DIR / "_static"
 BUILD_CSS_DIR = BUILD_STATIC_DIR / "css"
 
@@ -107,7 +107,7 @@ def main():
         log.info(f"SKIP: Force-sync found no {ENABLE_DEVMACHINE_SPHINX_STATIC_FIX} file!")
         return
     elif not BUILD_HTML_DIR.exists():
-        log.info("Skipping force-sync due to no build dir")
+        log.info(f"SKIP: {BUILD_HTML_DIR} does not exist yet.")
         return
 
     log.info(f"SYNC: Force-sync enable file found")


### PR DESCRIPTION
# **TL;DR:** Ship 3.0 by letting you edit CSS without `./make.py clean` :scream:!

### How do I use this & When?

Does CSS not copy right on your local machine? Then:

1. `cd $ARCADE_DIR`
2. `touch .ENABLE_DEVMACHINE_SPHINX_STATIC_FIX`
3. `./make.py html` or `./make.py serve`as usual

### Why do this?

**TL;DR:** Debugging CSS is already hard enough

1. Sphinx's `_static` has been making CSS harder by being broken since at least 2015
2. This fixes it for both:
    * `./make.py html`
    * `./make.py serve` (it's based on `sphinx-autobuild`, [see this comment for more](https://github.com/sphinx-doc/sphinx-autobuild/issues/34#issuecomment-1805913774)).

### Technical Details
 
1. Sphinx rebuilds haven't copied updated CSS correctly since at least 2015 (https://github.com/sphinx-doc/sphinx/issues/1810)
4. The solutions have traditionally been:
    * The equivalent of our `./make.py clean` (slow, hurts)
    * Write your own awful kludge
5. There's a fix in the works upstream, but...
    * It's been broken since 2015
    * The PR got merged https://github.com/sphinx-doc/sphinx/pull/13236 on Jan 15th, 2025
    * It's slated for release in 8.2.0
    * Sphinx 8.2.0 may break:
       * our theme
       * plugins
       * customization kludges
       * etc
 
### Does this affect CI runs / readthedocs / code quality scans?

No.