### PR TITLE
update build prod workflows

### DIFF
--- a/.github/workflows/push_build_to_prod_pypi.yml
+++ b/.github/workflows/push_build_to_prod_pypi.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-tags: 'true'
       - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:

--- a/.github/workflows/push_build_to_test_pypi.yml
+++ b/.github/workflows/push_build_to_test_pypi.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-tags: 'true'
       - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:


### PR DESCRIPTION
This fixes #2495 as it makes sure the push to PyPI workflow fetches the last release tag instead of ignoring it.