### PR TITLE
Remove outdated comments in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # Fallback to use pyglet's development branch as a rolling release package
-    # at the cost of slow download and constant pip install -I -e .[dev]    
-    # "pyglet@git+https://github.com/pyglet/pyglet.git@development#egg=pyglet",
-    # Expected future dev preview release on PyPI (not yet released)
     "pyglet~=2.1.0",
     "pillow~=11.0.0",
     "pymunk~=6.9.0",
@@ -42,7 +38,6 @@ Book = "https://learn.arcade.academy"
 [project.optional-dependencies]
 # Used for dev work
 dev = [
-    # --- Documentation: Sphinx 7 based currently
     "sphinx==8.1.3",               # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
     "sphinx_rtd_theme==3.0.2",     # Nov 2024
     "sphinx-rtd-dark-mode==1.3.0",


### PR DESCRIPTION
@pushfoo - Looks like arcade now does link against a stable `pyglet` version and this comment in `pyproject.toml` is outdated? OK to remove? (see #2358)