### PR TITLE
Fix docstring args

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -1388,9 +1388,9 @@ class View:
                 Change in x since the last time this method was called
             dy:
                 Change in y since the last time this method was called
-            buttons:
+            _buttons:
                 Which button is pressed
-            modifiers:
+            _modifiers:
                 Bitwise 'and' of all modifiers (shift, ctrl, num lock)
                 active during this event. See :ref:`keyboard_modifiers`.
         """
@@ -1493,9 +1493,9 @@ class View:
         * Showing which keys are currently pressed down
 
         Args:
-            symbol:
+            _symbol:
                 Key that was released
-            modifiers:
+            _modifiers:
                 Bitwise 'and' of all modifiers (shift, ctrl, num lock) active
                 during this event. See :ref:`keyboard_modifiers`.
         """

--- a/arcade/cache/hit_box.py
+++ b/arcade/cache/hit_box.py
@@ -59,10 +59,8 @@ class HitBoxCache:
             points = cache.get("hash|(0, 1, 2, 3)|simple|")
 
         Args:
-            keys:
+            name_or_texture:
                 The texture or cache name to get the hit box for
-            hit_box_algorithm:
-                The hit box algorithm used
         """
         from arcade import Texture
 
@@ -85,7 +83,7 @@ class HitBoxCache:
             cache.put("my_custom_points", points)
 
         Args:
-            keys:
+            name_or_texture:
                 The texture or cache name to store the hit box for
             points:
                 The hit box points

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -343,13 +343,14 @@ class Camera2D:
         Should be called when the window is resized.
 
         Args:
-            and_projection: Flag whether to also equalize the projection to the viewport.
+            viewport: Flag whether to equalise the viewport to the value.
+            projection: Flag whether to also equalize the projection to the viewport.
                 On by default
-            and_scissor: Flag whether to also equalize the scissor box to the viewport.
+            scissor: Flag whether to also equalize the scissor box to the viewport.
                 On by default
-            and_position: Flag whether to also center the camera to the viewport.
+            position: Flag whether to also center the camera to the viewport.
                 Off by default
-            aspect_ratio: The ratio between width and height that the viewport should
+            aspect: The ratio between width and height that the viewport should
                 be constrained to. If unset then the viewport just matches the window
                 size. The aspect ratio describes how much larger the width should be
                 compared to the height. i.e. for an aspect ratio of ``4:3`` you should
@@ -383,7 +384,7 @@ class Camera2D:
             scissor: Flag whether to update the scissor value.
             position: Flag whether to also center the camera to the value.
                 Off by default
-            aspect_ratio: The ratio between width and height that the value should
+            aspect: The ratio between width and height that the value should
                 be constrained to. i.e. for an aspect ratio of ``4:3`` you should
                 input ``4.0/3.0`` or ``1.33333...``. Cannot be equal to zero.
                 If unset then the value will not be updated.
@@ -425,7 +426,7 @@ class Camera2D:
             scissor: Flag whether to update the scissor value.
             position: Flag whether to also center the camera to the value.
                 Off by default
-            aspect_ratio: The ratio between width and height that the value should
+            aspect: The ratio between width and height that the value should
                 be constrained to. i.e. for an aspect ratio of ``4:3`` you should
                 input ``4.0/3.0`` or ``1.33333...``. Cannot be equal to zero.
                 If unset then the value will not be updated.

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -450,8 +450,6 @@ class Projector(Protocol):
         Args:
             screen_coordinate: A 2D position in pixels should generally be inside
                 the range of the active viewport.
-            depth: The depth of the query. This can be though of how far along the forward vector
-                   the final coord will be.
         Returns:
             A 3D vector in world space.
         """

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -24,7 +24,7 @@ class ViewportProjector:
 
     Args:
         viewport: The viewport to project to.
-        window: The window to bind the camera to. Defaults to the currently active window.
+        context: The window context to bind the camera to. Defaults to the currently active window.
     """
 
     def __init__(
@@ -108,7 +108,7 @@ class DefaultProjector(ViewportProjector):
     no instance where a developer would want to use this class.
 
     Args:
-        window: The window to bind the camera to. Defaults to the currently active window.
+        context: The window context to bind the camera to. Defaults to the currently active window.
     """
 
     def __init__(self, *, context: ArcadeContext | None = None):

--- a/arcade/camera/orthographic.py
+++ b/arcade/camera/orthographic.py
@@ -181,11 +181,9 @@ class OrthographicProjector(Projector):
         Args:
             screen_coordinate: A 2D position in pixels from the bottom left of the screen.
                                This should ALWAYS be in the range of 0.0 - screen size.
-            depth: The depth of the query
         Returns:
             A 3D vector in world space.
         """
-
         _projection = generate_orthographic_matrix(self._projection, self._view.zoom)
         _view = generate_view_matrix(self._view)
         return unproject_orthographic(screen_coordinate, self.viewport.lbwh_int, _view, _projection)

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -207,9 +207,9 @@ def draw_lbwh_rectangle_outline(
     Draw a rectangle extending from bottom left to top right
 
     Args:
-        bottom_left_x:
+        left:
             The x coordinate of the left edge of the rectangle.
-        bottom_left_y:
+        bottom:
             The y coordinate of the bottom of the rectangle.
         width:
             The width of the rectangle.

--- a/arcade/future/light/lights.py
+++ b/arcade/future/light/lights.py
@@ -87,7 +87,8 @@ class LightLayer(RenderTargetTexture):
     The size of a layer should ideally be of the same size and the screen.
 
     Args:
-        size: Width and height of light layer
+        width: Width of light layer
+        height: Height of light layer
     """
 
     def __init__(self, width: int, height: int):

--- a/arcade/future/video/video_player.py
+++ b/arcade/future/video/video_player.py
@@ -41,7 +41,7 @@ class VideoPlayer:
 
         Args:
             size: Pass None as one of the elements if you want to use the
-            dimension(width, height) attribute.
+             dimension(width, height) attribute.
         """
         if size and len(size) == 2:
             self._width = size[0] or self.width

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -347,8 +347,6 @@ class Framebuffer:
                 A 3 or 4 component tuple containing the color in normalized form
             depth:
                 Value to clear the depth buffer (unused)
-            normalized:
-                If the color values are normalized or not
             viewport:
                 The viewport range to clear
         """

--- a/arcade/gl/glsl.py
+++ b/arcade/gl/glsl.py
@@ -32,8 +32,6 @@ class ShaderSource:
             Common source code to inject
         source_type:
             The shader type
-        depth_attachment:
-            A depth attachment (optional)
     """
 
     def __init__(

--- a/arcade/gui/surface.py
+++ b/arcade/gui/surface.py
@@ -229,7 +229,6 @@ class Surface:
         Args:
             area: Limit the area in the surface we're drawing
                 (l, b, w, h)
-            pixelated: If True, the texture will be rendered pixelated
         """
         # Set blend function
         blend_func = self.ctx.blend_func

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -253,9 +253,6 @@ class AStarBarrierList:
             Bottom of playing field
         top (int):
             Top of playing field
-        barrier_list:
-            SpriteList of barriers to use in _AStarSearch,
-            ``None`` if not recalculated
 
     Attributes:
         grid_size:

--- a/arcade/sections.py
+++ b/arcade/sections.py
@@ -425,8 +425,8 @@ class Section:
         Called when the user releases a key.
 
         Args:
-            symbol: the key released
-            modifiers: the modifiers pressed
+            _symbol: the key released
+            _modifiers: the modifiers pressed
         """
         pass
 

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -247,7 +247,6 @@ def create_lines(
     Args:
         point_list: A list of points that make up the shape.
         color: A color such as a :py:class:`~arcade.types.Color`
-        line_width: Width of the line
     """
     return create_line_generic(point_list, color, gl.GL_LINES)
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -317,7 +317,7 @@ def play_sound(
     try:
         return sound.play(volume, pan, loop, speed)
     except Exception as ex:
-        logger.warn("Error playing sound.", ex)
+        logger.warning("Error playing sound.", ex)
         return None
 
 

--- a/arcade/sprite/animated.py
+++ b/arcade/sprite/animated.py
@@ -52,8 +52,6 @@ class TextureAnimation:
     Args:
         keyframes:
             List of keyframes for the animation.
-        loop:
-            If the animation should loop.
     """
 
     __slots__ = ("_keyframes", "_duration_ms", "_timeline")
@@ -358,7 +356,7 @@ class AnimatedWalkingSprite(Sprite):
             self.texture = texture_list[self.cur_texture_index]
 
         if self._texture is None:
-            logger.warn("Error, no texture set")
+            logger.warning("Error, no texture set")
         else:
             self.width = self._texture.width * self.scale_x
             self.height = self._texture.height * self.scale_x

--- a/arcade/texture/manager.py
+++ b/arcade/texture/manager.py
@@ -133,7 +133,7 @@ class TextureCacheManager:
         hit_box_algorithm: hitbox.HitBoxAlgorithm | None = None,
     ) -> Texture:
         """
-        Slice out a a texture at x, y, width, height from a sprite sheet.
+        Slice out a texture slice from a sprite sheet.
 
         * If the spritesheet is not already loaded, it will be loaded and cached.
         * If the sliced texture is already cached, it will be returned instead.
@@ -141,14 +141,8 @@ class TextureCacheManager:
         Args:
             path:
                 Path to the sprite sheet image
-            x:
-                X position of the texture in the sprite sheet
-            y:
-                Y position of the texture in the sprite sheet
-            width:
-                Width of the texture
-            height:
-                Height of the texture
+            rect:
+                Slice of the texture in the sprite sheet.
             hit_box_algorithm (optional):
                 Hit box algorithm to use. If not specified, the global default will be used.
         """
@@ -188,9 +182,6 @@ class TextureCacheManager:
                 Path of the file to load.
             hash:
                 Optional override for image hash
-            cache:
-                If ``True``, the image will be cached. If ``False``, the
-                image will not be cached or returned from the cache.
             mode:
                 The mode to use for the image. Default is "RGBA".
         """
@@ -223,7 +214,7 @@ class TextureCacheManager:
         entire image is loaded.
 
         Args:
-            file_name:
+            file_path:
                 Path to the image file.
             x (optional):
                 X coordinate of the texture in the image.

--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -605,7 +605,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
         Get the internal id for a Texture in the atlas
 
         Args:
-            atlas_name: The name of the texture in the atlas
+            texture: The texture to get.
         """
         return self._texture_uvs.get_slot_or_raise(texture.atlas_name)
 
@@ -883,7 +883,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
                 Number of components. (3 = RGB, 4 = RGBA)
             draw_borders:
                 Draw region borders into image
-            color:
+            border_color:
                 RGB color of the borders
         Returns:
             A pillow image containing the atlas texture
@@ -931,7 +931,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
                 Number of components. (3 = RGB, 4 = RGBA)
             draw_borders:
                 Draw region borders into image
-            color:
+            border_color:
                 RGB color of the borders
         """
         self.to_image(
@@ -962,7 +962,9 @@ class DefaultTextureAtlas(TextureAtlasBase):
                 Flip the image horizontally
             components:
                 Number of components. (3 = RGB, 4 = RGBA)
-            color:
+            draw_borders:
+                Draw region borders into image
+            border_color:
                 RGB color of the borders
         """
         self.to_image(

--- a/arcade/texture_atlas/base.py
+++ b/arcade/texture_atlas/base.py
@@ -207,7 +207,7 @@ class TextureAtlasBase(abc.ABC):
         Get the internal id for a Texture in the atlas
 
         Args:
-            atlas_name: The name of the texture in the atlas
+            texture: The texture to get
         """
         ...
 
@@ -364,7 +364,7 @@ class TextureAtlasBase(abc.ABC):
                 Number of components. (3 = RGB, 4 = RGBA)
             draw_borders:
                 Draw region borders into image
-            color:
+            border_color:
                 RGB color of the borders
         Returns:
             A pillow image containing the atlas texture
@@ -392,7 +392,7 @@ class TextureAtlasBase(abc.ABC):
                 Number of components. (3 = RGB, 4 = RGBA)
             draw_borders:
                 Draw region borders into image
-            color:
+            border_color:
                 RGB color of the borders
         """
         self.to_image(
@@ -425,7 +425,9 @@ class TextureAtlasBase(abc.ABC):
                 Flip the image horizontally
             components:
                 Number of components. (3 = RGB, 4 = RGBA)
-            color:
+            draw_borders:
+                Draw region borders into image
+            border_color:
                 RGB color of the borders
         """
 

--- a/arcade/texture_atlas/region.py
+++ b/arcade/texture_atlas/region.py
@@ -40,8 +40,6 @@ class AtlasRegion:
     Args:
         atlas:
             The atlas this region belongs to
-        texture:
-            The Arcade texture
         x:
             The x position of the texture
         y:


### PR DESCRIPTION
Here I fixed some mismatches of docstring args vs function signatures pointed out by PyCharm.

I assumed function signatures should remain as-is in all cases and didn't touch them.