### PR TITLE
Small docs and example cleanup

### DIFF
--- a/arcade/context.py
+++ b/arcade/context.py
@@ -495,6 +495,9 @@ class ArcadeContext(Context):
             internal_format (optional):
                 The internal format of the texture. This can be used to override
                 the default internal format when using sRGBA or compressed textures.
+            immutable (optional):
+                Make the storage (not the contents) immutable. This can sometimes be
+                required when using textures with compute shaders.
             compressed (optional):
                 If the internal format is a compressed format meaning your
                 texture will be compressed by the GPU.

--- a/arcade/examples/light_demo.py
+++ b/arcade/examples/light_demo.py
@@ -47,7 +47,7 @@ class GameView(arcade.View):
         self.physics_engine = None
 
         # Camera
-        self.cam: arcade.camera.Camera2D = None
+        self.camera: arcade.camera.Camera2D = None
 
         # --- Light related ---
         # List of all the lights

--- a/arcade/examples/line_of_sight.py
+++ b/arcade/examples/line_of_sight.py
@@ -120,31 +120,27 @@ class GameView(arcade.View):
         """
         Render the screen.
         """
-        try:
-            # This command has to happen before we start drawing
-            self.clear()
+        # This command has to happen before we start drawing
+        self.clear()
 
-            # Draw all the sprites.
-            self.player_list.draw()
-            self.wall_list.draw()
-            self.enemy_list.draw()
+        # Draw all the sprites.
+        self.player_list.draw()
+        self.wall_list.draw()
+        self.enemy_list.draw()
 
-            for enemy in self.enemy_list:
-                if arcade.has_line_of_sight(
-                    self.player.position, enemy.position, self.wall_list
-                ):
-                    color = arcade.color.RED
-                else:
-                    color = arcade.color.WHITE
-                arcade.draw_line(self.player.center_x,
-                                 self.player.center_y,
-                                 enemy.center_x,
-                                 enemy.center_y,
-                                 color,
-                                 2)
-
-        except Exception as e:
-            print(e)
+        for enemy in self.enemy_list:
+            if arcade.has_line_of_sight(
+                self.player.position, enemy.position, self.wall_list
+            ):
+                color = arcade.color.RED
+            else:
+                color = arcade.color.WHITE
+            arcade.draw_line(self.player.center_x,
+                             self.player.center_y,
+                             enemy.center_x,
+                             enemy.center_y,
+                             color,
+                             2)
 
     def on_update(self, delta_time):
         """ Movement and game logic """

--- a/arcade/experimental/shadertoy.py
+++ b/arcade/experimental/shadertoy.py
@@ -278,6 +278,8 @@ class ShadertoyBase:
                 Override the size
             frame:
                 Override frame
+            frame_rate:
+                Override frame_rate
         """
         self._time = time if time is not None else self._time
         self._time_delta = time_delta if time_delta is not None else self._time_delta

--- a/arcade/texture/spritesheet.py
+++ b/arcade/texture/spritesheet.py
@@ -147,6 +147,9 @@ class SpriteSheet:
             hit_box_algorithm:
                 Hit box algorithm to use for the texture.
                 If not provided, the default hit box algorithm will be used.
+            y_up:
+                Sets the coordinate space of the image to assert (0, 0)
+                in the bottom left.
         """
         im = self.get_image(rect, y_up)
         texture = Texture(im, hit_box_algorithm=hit_box_algorithm)

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -1062,6 +1062,9 @@ def load_tilemap(
             Can be used to offset the position of all sprites and objects
             within the map. This will be applied in addition to any offsets from Tiled. This value
             can be overridden with the layer_options dict.
+        texture_atlas:
+            A default texture atlas to use for the SpriteLists created by this map.
+            If not supplied the global default atlas will be used.
         lazy:
             SpriteLists will be created lazily.
     """

--- a/doc/tutorials/platform_tutorial/step_12.rst
+++ b/doc/tutorials/platform_tutorial/step_12.rst
@@ -89,7 +89,7 @@ at this stage is ready for drawing and we don't need to do anything else to it(o
     ``layer_options`` is a special dictionary that can be provided to the ``load_tilemap`` function. This will
     send special options for each layer into the map loader. In this example our map has a layer called
     ``Platforms``, and we want to enable spatial hashing on it. Much like we did for our ``wall`` SpriteList
-    before. For more info on the layer options dictionary and the available keys, check out :class`arcade.TileMap`
+    before. For more info on the layer options dictionary and the available keys, check out :class:`arcade.TileMap`
 
 At this point we only have one piece of code left to change. In switching to our new map, you may have noticed by
 the ``layer_options`` dictionary that we now have a layer named ``Platforms``. Previously in our Scene we were calling


### PR DESCRIPTION
Some more docstring arg / function signature mismatches pointed out by PyCharm.

Remove big try/except in `line_of_sight.py` in the `on_draw`. Works fine for me. Not clear why it would be there.
