### PR TITLE
Fix pytest.skip for MacOS in test_tutorials.py

### DIFF
--- a/tests/integration/tutorials/test_tutorials.py
+++ b/tests/integration/tutorials/test_tutorials.py
@@ -1,12 +1,12 @@
 """
-FInd and run all tutorials in the doc/tutorials directory
+Find and run all tutorials in the doc/tutorials directory
 """
 import io
 import os
 import contextlib
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
-import platform
+import sys
 
 import pytest
 import arcade
@@ -16,18 +16,10 @@ ALLOW_STDOUT = {}
 
 
 def find_tutorials():
-    # Loop the directory of tutorials dirs
-    for dir in TUTORIAL_DIR.iterdir():
-        if not dir.is_dir():
+    for path in TUTORIAL_DIR.rglob("*.py"):
+        if path.stem.startswith("_"):
             continue
-
-        print(dir)
-        # Find python files in each tutorial dir
-        for file in dir.glob("*.py"):
-            if file.stem.startswith("_"):
-                continue
-            # print("->", file)
-            yield file, file.stem in ALLOW_STDOUT
+        yield path, path.stem in ALLOW_STDOUT
 
 
 @pytest.mark.parametrize(
@@ -36,8 +28,8 @@ def find_tutorials():
 )
 def test_tutorials(window_proxy, file_path, allow_stdout):
     """Run all tutorials"""
-    if "compute_shader" in str(file_path) and platform.system() == "darwin":
-        raise pytest.skip(f"compute_shader tutorial not working on OS X")
+    if file_path.parent.name == "compute_shader" and sys.platform == "darwin":
+        raise pytest.skip("compute_shader tutorial not working on MacOS")
 
     os.environ["ARCADE_TEST"] = "TRUE"
     stdout = io.StringIO()


### PR DESCRIPTION
Follow-up to #2542 to address #2534

@einarf - I changed to check `sys.platform` since it's consistently used in the Arcade package and tests.

You were using `platform.system()` which is recommended here
https://stackoverflow.com/questions/1854/how-to-identify-which-os-python-is-running-on
but it wasn't working on my Mac because it requires "Darwin" with capital "D" and you had used the lower-case "darwin" that `sys.platform` uses.

This should be OK now.

