### PR TITLE
Switch from black to ruff format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,14 @@ jobs:
         id: wheel
         run: |
           python -m pip install -e .[dev]
+      - name: "code-inspection: formatting"
+        if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
+        run: |
+          python ./make.py format --check
+      - name: "code-inspection: ruff-check"
+        if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
+        run: | 
+          python ./make.py ruff-check
       - name: "code-inspection: mypy"
         if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
         run: | 
@@ -44,14 +52,6 @@ jobs:
         if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
         run: | 
           python ./make.py pyright
-      - name: "code-inspection: ruff"
-        if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
-        run: | 
-          python ./make.py ruff
-      - name: "code-inspection: formatting"
-        if: ${{ (success() || failure()) && steps.wheel.outcome == 'success' }}
-        run: |
-          python ./make.py format --check
       # Prepare the Pull Request Payload artifact. If this fails,
       # we fail silently using the `continue-on-error` option. It's
       # nice if this succeeds, but if it fails for any reason, it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,23 +81,19 @@ steps at the end of this document.
 
 ## Formatting
 
-Arcade uses [Black](https://black.readthedocs.io/en/stable) for autoformatting our code.
+Arcade uses [ruff format](https://docs.astral.sh/ruff/formatter/) for autoformatting our code
+as well as sorting imports.
 
 This can be run both with our `make.py` script, as well as setup for your editor to run it automatically.
-See [this link](https://black.readthedocs.io/en/stable/integrations/editors.html) for more information on
-Black integration for your specific editor.
+See [this link](https://docs.astral.sh/ruff/editors/) for more information on ruff editor integration.
 
-The following command will run black for you if you do not want to configure your editor to do it. It can be
-a good idea to run this command when you are finished working anyway, as our CI will use this to check that
-the formatting is correct.
+The following command will run ``ruff format`` for you if you do not want to configure your editor to do it.
+It can be  a good idea to run this command when you are finished working anyway,
+as our CI will use this to check that the formatting is correct.
 
 ```bash
 python make.py format
 ```
-
-In addition to Black, this will sort the imports using [Ruff](https://docs.astral.sh/ruff/). If you want to set up
-your editor to run this, please see [this link](https://docs.astral.sh/ruff/integrations/) for more information on
-Ruff integration for your specific editor.
 
 Docstring should be formatted using [Google Style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 

--- a/arcade/application.py
+++ b/arcade/application.py
@@ -962,7 +962,7 @@ class Window(pyglet.window.Window):
         """
         if not isinstance(new_view, View):
             raise TypeError(
-                f"Window.show_view() takes an arcade.View," f"but it got a {type(new_view)}."
+                f"Window.show_view() takes an arcade.View, but it got a {type(new_view)}."
             )
 
         self._ctx.screen.use()

--- a/arcade/camera/camera_2d.py
+++ b/arcade/camera/camera_2d.py
@@ -124,15 +124,15 @@ class Camera2D:
         if projection is not None:
             if left == right:
                 raise ZeroProjectionDimension(
-                    (f"projection width is 0 due to equal {left=}" f"and {right=} values")
+                    f"projection width is 0 due to equal {left=} and {right=} values"
                 )
             if bottom == top:
                 raise ZeroProjectionDimension(
-                    (f"projection height is 0 due to equal {bottom=}" f"and {top=}")
+                    f"projection height is 0 due to equal {bottom=} and {top=}"
                 )
         if near == far:
             raise ZeroProjectionDimension(
-                f"projection depth is 0 due to equal {near=}" f"and {far=} values"
+                f"projection depth is 0 due to equal {near=} and {far=} values"
             )
 
         pos_x = position[0] if position is not None else half_width
@@ -223,17 +223,17 @@ class Camera2D:
             left, right = projection_data.left, projection_data.right
             if projection_data.left == projection_data.right:
                 raise ZeroProjectionDimension(
-                    (f"projection width is 0 due to equal {left=}" f"and {right=} values")
+                    (f"projection width is 0 due to equal {left=}and {right=} values")
                 )
             bottom, top = projection_data.bottom, projection_data.top
             if bottom == top:
                 raise ZeroProjectionDimension(
-                    (f"projection height is 0 due to equal {bottom=}" f"and {top=}")
+                    (f"projection height is 0 due to equal {bottom=}and {top=}")
                 )
             near, far = projection_data.near, projection_data.far
             if near == far:
                 raise ZeroProjectionDimension(
-                    f"projection depth is 0 due to equal {near=}" f"and {far=} values"
+                    f"projection depth is 0 due to equal {near=}and {far=} values"
                 )
 
         # build a new camera with defaults and then apply the provided camera objects.

--- a/arcade/camera/data_types.py
+++ b/arcade/camera/data_types.py
@@ -84,7 +84,6 @@ class CameraData:
         forward: Point3 = (0.0, 0.0, -1.0),
         zoom: float = 1.0,
     ):
-
         self.position: tuple[float, float, float] = position
         """A 3D vector which describes where the camera is located."""
 
@@ -260,9 +259,7 @@ class OrthographicProjectionData:
         self.rect = LRBT(*new_lrbt)
 
     def __str__(self):
-        return (
-            f"OrthographicProjection<" f"LRBT={self.rect.lrbt}, " f"{self.near=}, " f"{self.far=}"
-        )
+        return f"OrthographicProjection<LRBT={self.rect.lrbt}, {self.near=}, {self.far=}>"
 
     def __repr__(self):
         return self.__str__()

--- a/arcade/camera/static.py
+++ b/arcade/camera/static.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 
 class _StaticCamera:
-
     def __init__(
         self,
         view_matrix: Mat4,

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -187,10 +187,10 @@ def draw_lrbt_rectangle_outline(
         ValueError: Raised if left > right or top < bottom.
     """
     if left > right:
-        raise ValueError("Left coordinate must be less than or equal to " "the right coordinate")
+        raise ValueError("Left coordinate must be less than or equal to the right coordinate")
 
     if bottom > top:
-        raise ValueError("Bottom coordinate must be less than or equal to " "the top coordinate")
+        raise ValueError("Bottom coordinate must be less than or equal to the top coordinate")
 
     draw_rect_outline(LRBT(left, right, bottom, top), color, border_width)
 

--- a/arcade/experimental/atlas_render_into.py
+++ b/arcade/experimental/atlas_render_into.py
@@ -10,7 +10,6 @@ import arcade
 
 
 class AtlasRenderDemo(arcade.Window):
-
     def __init__(self):
         super().__init__(1280, 720, "Atlas Render Demo")
         self.atlas = arcade.DefaultTextureAtlas((600, 600))

--- a/arcade/experimental/atlas_replace_image.py
+++ b/arcade/experimental/atlas_replace_image.py
@@ -68,7 +68,6 @@ TEXTURE_PATHS = [
 
 
 class AtlasReplaceImage(arcade.Window):
-
     def __init__(self):
         super().__init__(800, 600, "Replacing images in atlas")
         self.sprite_1 = arcade.Sprite(TEXTURE_PATHS[-1], center_x=200, center_y=300)

--- a/arcade/experimental/geo_culling_check.py
+++ b/arcade/experimental/geo_culling_check.py
@@ -16,7 +16,6 @@ from arcade.sprite import Sprite
 
 
 class GeoCullingTest(arcade.Window):
-
     def __init__(self):
         super().__init__(1280, 720, "Cull test", resizable=True)
         self.proj = 0, self.width, 0, self.height

--- a/arcade/experimental/perspective_parallax.py
+++ b/arcade/experimental/perspective_parallax.py
@@ -20,7 +20,6 @@ LAYERS = (
 
 
 class PerspectiveParallax(arcade.Window):
-
     def __init__(self):
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Perspective Parallax")
         self.t = 0.0

--- a/arcade/experimental/postprocessing.py
+++ b/arcade/experimental/postprocessing.py
@@ -54,7 +54,6 @@ class PostProcessing:
 
 
 class GaussianBlurPass(PostProcessing):
-
     def __init__(self, size, kernel_size=5, sigma=2, multiplier=0, step=1):
         super().__init__(size)
         self._kernel_size = kernel_size

--- a/arcade/experimental/query_demo.py
+++ b/arcade/experimental/query_demo.py
@@ -12,7 +12,6 @@ SCREEN_TITLE = "Basic Renderer"
 
 
 class MyGame(arcade.Window):
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title)
         # vsync must be off when measuring rendering calls

--- a/arcade/experimental/render_offscreen_animated.py
+++ b/arcade/experimental/render_offscreen_animated.py
@@ -63,7 +63,6 @@ def make_skyline(
     color_list = []
 
     while building_center_x < width:
-
         # Is there a gap between the buildings?
         if random.random() < gap_chance:
             gap_width = random.randrange(10, 50)

--- a/arcade/experimental/shadertoy_demo.py
+++ b/arcade/experimental/shadertoy_demo.py
@@ -7,7 +7,6 @@ from arcade.experimental.shadertoy import Shadertoy
 
 
 class MyGame(arcade.Window):
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title, resizable=True)
         self.shadertoy = Shadertoy.create_from_file(

--- a/arcade/experimental/shadertoy_demo_simple.py
+++ b/arcade/experimental/shadertoy_demo_simple.py
@@ -10,7 +10,6 @@ SCREEN_TITLE = "ShaderToy Demo"
 
 
 class MyGame(arcade.Window):
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title, resizable=True)
         self.shadertoy = Shadertoy(

--- a/arcade/experimental/shadertoy_textures.py
+++ b/arcade/experimental/shadertoy_textures.py
@@ -15,7 +15,6 @@ SCREEN_TITLE = "ShaderToy Texture Layers"
 
 
 class MyGame(arcade.Window):
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title, resizable=True)
         self.shadertoy = Shadertoy(

--- a/arcade/experimental/shapes_perf.py
+++ b/arcade/experimental/shapes_perf.py
@@ -76,7 +76,6 @@ def random_radius(start=5, end=25):
 
 
 class GameWindow(arcade.Window):
-
     def __init__(self, width, height, title):
         super().__init__(width, height, title, antialiasing=True, resizable=True)
         self.set_vsync(False)

--- a/arcade/experimental/texture_transforms.py
+++ b/arcade/experimental/texture_transforms.py
@@ -18,7 +18,6 @@ TRANSFORMS = [
 
 
 class App(arcade.Window):
-
     def __init__(self):
         super().__init__(1200, 600, "Atlas Revamp Check")
         paths = [

--- a/arcade/future/background/__init__.py
+++ b/arcade/future/background/__init__.py
@@ -55,7 +55,6 @@ def background_from_file(
     shader: gl.Program | None = None,
     geometry: gl.Geometry | None = None,
 ) -> Background:
-
     texture = BackgroundTexture.from_file(tex_src, offset, scale, angle, filters)
     if size is None:
         size = texture.texture.size

--- a/arcade/future/input/input_manager_example.py
+++ b/arcade/future/input/input_manager_example.py
@@ -25,7 +25,6 @@ DEFAULT_TEXTURES = (
 
 
 class Player(arcade.Sprite):
-
     def __init__(
         self,
         texture,
@@ -58,7 +57,6 @@ class Player(arcade.Sprite):
 
 
 class Game(arcade.Window):
-
     def __init__(
         self,
         player_textures: Sequence[str] = DEFAULT_TEXTURES,
@@ -76,7 +74,7 @@ class Game(arcade.Window):
 
         self._max_players = max_players
         self.key_to_player_index: dict[Keys, int] = {
-            getattr(Keys, f"KEY_{i + 1 }"): i for i in range(0, max_players)
+            getattr(Keys, f"KEY_{i + 1}"): i for i in range(0, max_players)
         }
 
         self.players: list[Player | None] = []
@@ -201,7 +199,6 @@ class Game(arcade.Window):
         self.device_labels_batch.draw()
 
     def on_key_press(self, key, modifiers):
-
         player_index = self.key_to_player_index.get(Keys(key), None)
         if player_index is None or player_index >= len(self.players):
             return

--- a/arcade/future/input/input_mapping.py
+++ b/arcade/future/input/input_mapping.py
@@ -7,7 +7,6 @@ from arcade.future.input.raw_dicts import RawAction, RawActionMapping, RawAxis, 
 
 
 class Action:
-
     def __init__(self, name: str) -> None:
         self.name = name
         self._mappings: set[ActionMapping] = set()
@@ -20,7 +19,6 @@ class Action:
 
 
 class Axis:
-
     def __init__(self, name: str) -> None:
         self.name = name
         self._mappings: set[AxisMapping] = set()
@@ -51,7 +49,6 @@ class InputMapping:
 
 
 class ActionMapping(InputMapping):
-
     def __init__(
         self,
         input: inputs.InputEnum,
@@ -71,7 +68,6 @@ class ActionMapping(InputMapping):
 
 
 class AxisMapping(InputMapping):
-
     def __init__(self, input: inputs.InputEnum, scale: float):
         super().__init__(input)
         self._scale = scale

--- a/arcade/future/input/manager.py
+++ b/arcade/future/input/manager.py
@@ -64,7 +64,6 @@ class InputDevice(Enum):
 
 
 class InputManager:
-
     def __init__(
         self,
         controller: Controller | None = None,

--- a/arcade/gl/buffer.py
+++ b/arcade/gl/buffer.py
@@ -56,7 +56,6 @@ class Buffer:
         reserve: int = 0,
         usage: str = "static",
     ):
-
         self._ctx = ctx
         self._glo = glo = gl.GLuint()
         self._size = -1

--- a/arcade/isometric.py
+++ b/arcade/isometric.py
@@ -33,7 +33,6 @@ def screen_to_isometric_grid(
 def create_isometric_grid_lines(
     width: int, height: int, tile_width: int, tile_height: int, color: RGBA255, line_width: int
 ) -> ShapeElementList:
-
     # Grid lines 1
     shape_list: ShapeElementList = ShapeElementList()
 

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -388,8 +388,7 @@ def rescale_relative_to_point(source: Point2, target: Point2, factor: AsFloat | 
                 return target
         except ValueError:
             raise ValueError(
-                "factor must be a float, int, or tuple-like "
-                "which unpacks as two float-like values"
+                "factor must be a float, int, or tuple-like which unpacks as two float-like values"
             )
         except TypeError:
             raise TypeError(

--- a/arcade/perf_graph.py
+++ b/arcade/perf_graph.py
@@ -320,7 +320,6 @@ class PerfGraph(arcade.Sprite):
         # Render to the internal texture
         # This ugly spacing is intentional to make type checking work.
         with atlas.render_into(self.minimap_texture, projection=self.proj) as fbo:  # type: ignore
-
             # Set the background color
             fbo.clear(color=self.background_color)
 

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -115,7 +115,6 @@ def _move_sprite(
     # --- Rotate
     rotating_hit_list = []
     if moving_sprite.change_angle:
-
         # Rotate
         moving_sprite.angle += moving_sprite.change_angle
 
@@ -123,7 +122,6 @@ def _move_sprite(
         rotating_hit_list = check_for_collision_with_lists(moving_sprite, can_collide)
 
         if len(rotating_hit_list) > 0:
-
             max_distance = (moving_sprite.width + moving_sprite.height) / 2
 
             # Resolve any collisions by this weird kludge
@@ -199,7 +197,6 @@ def _move_sprite(
 
         exit_loop = False
         while not exit_loop:
-
             loop_count += 1
             # print(f"{cur_x_change=}, {upper_bound=}, {lower_bound=}, {loop_count=}")
 
@@ -782,7 +779,6 @@ class PhysicsEnginePlatformer:
         for platform_list in self.platforms:
             for platform in platform_list:
                 if platform.change_x != 0 or platform.change_y != 0:
-
                     # Check x boundaries and move the platform in x direction
                     if platform.boundary_left and platform.left <= platform.boundary_left:
                         platform.left = platform.boundary_left

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -469,7 +469,6 @@ def create_rectangle(
     if filled:
         data[-2:] = reversed(data[-2:])
     else:
-
         i_lb = (
             center_x - width / 2 + border_width / 2,
             center_y - height / 2 + border_width / 2,

--- a/arcade/texture/texture.py
+++ b/arcade/texture/texture.py
@@ -170,7 +170,7 @@ class Texture:
             self._image_data = image
         else:
             raise TypeError(
-                "image must be an instance of PIL.Image.Image or ImageData, " f"not {type(image)}"
+                f"image must be an instance of PIL.Image.Image or ImageData, not {type(image)}"
             )
 
         # Set the size of the texture since this is immutable

--- a/arcade/texture_atlas/uv_data.py
+++ b/arcade/texture_atlas/uv_data.py
@@ -124,7 +124,7 @@ class UVData:
             return slot
         except IndexError:
             raise Exception(
-                ("No more free slots in the UV texture. " f"Max number of slots: {self._num_slots}")
+                f"No more free slots in the UV texture. Max number of slots: {self._num_slots}"
             )
 
     def free_slot_by_name(self, name: str) -> None:

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -3,6 +3,7 @@ Various utility functions.
 
 IMPORTANT: These should be standalone and not rely on any Arcade imports
 """
+
 from __future__ import annotations
 
 import platform
@@ -23,7 +24,7 @@ __all__ = [
     "is_str_or_noniterable",
     "grow_sequence",
     "is_raspberry_pi",
-    "get_raspberry_pi_info"
+    "get_raspberry_pi_info",
 ]
 
 # Since this module forbids importing from the rest of
@@ -45,6 +46,7 @@ class Chain(Generic[_T]):
     Arguments:
         components: The sequences of items to join.
     """
+
     def __init__(self, *components: Sequence[_T]):
         self.components: list[Sequence[_T]] = list(components)
 
@@ -151,9 +153,9 @@ def is_str_or_noniterable(item: Any) -> bool:
 
 
 def grow_sequence(
-        destination: MutableSequence[_T],
-        source: _T | Iterable[_T],
-        append_if: Callable[[_T | Iterable[_T]], bool] = is_str_or_noniterable
+    destination: MutableSequence[_T],
+    source: _T | Iterable[_T],
+    append_if: Callable[[_T | Iterable[_T]], bool] = is_str_or_noniterable,
 ) -> None:
     """Append when ``append_if(to_add)`` is ``True``, extend otherwise.
 
@@ -235,18 +237,21 @@ def copy_dunders_unimplemented(decorated_type: _TType) -> _TType:
        this_line_raises = copy.deepcopy(instance)
        this_line_also_raises = copy.copy(instance)
     """
+
     def __copy__(self):  # noqa
-       raise NotImplementedError(
-           f"{self.__class__.__name__} does not implement __copy__, but"
-           f"you may implement it on a custom subclass."
-       )
-    decorated_type.__copy__ =  __copy__
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement __copy__, but"
+            f"you may implement it on a custom subclass."
+        )
+
+    decorated_type.__copy__ = __copy__
 
     def __deepcopy__(self, memo):  # noqa
-       raise NotImplementedError(
-           f"{self.__class__.__name__} does not implement __deepcopy__,"
-           f" but you may implement it on a custom subclass."
-       )
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement __deepcopy__,"
+            f" but you may implement it on a custom subclass."
+        )
+
     decorated_type.__deepcopy__ = __deepcopy__
 
     return decorated_type
@@ -310,8 +315,7 @@ def unpack_asfloat_or_point(value: AsFloat | Point2) -> Point2:
             x, y = value
         except ValueError:
             raise ValueError(
-                "value must be a float, int, or tuple-like "
-                "which unpacks as two float-like values"
+                "value must be a float, int, or tuple-like which unpacks as two float-like values"
             )
         except TypeError:
             raise TypeError(

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -59,9 +59,7 @@ def get_window() -> "Window":
     :return: Handle to the current window.
     """
     if _window is None:
-        raise RuntimeError(
-            ("No window is active. " "It has not been created yet, or it was closed.")
-        )
+        raise RuntimeError("No window is active. It has not been created yet, or it was closed.")
 
     return _window
 

--- a/make.py
+++ b/make.py
@@ -11,6 +11,7 @@ For help, see the following:
 * CONTRIBUTING.md
 * The output of python make.py --help
 """
+
 from __future__ import annotations
 
 import os
@@ -51,9 +52,6 @@ MYPY = "mypy"
 MYPYOPTS = ["arcade"]
 PYRIGHT = "pyright"
 PYRIGHTOPTS = []
-BLACK = "black"
-BLACKOPTS = ["arcade"]
-ISORTOPTS = ["check", "--select", "I"]
 
 # Testing
 PYTEST = "pytest"
@@ -90,7 +88,6 @@ for library in libraries:
             return True
         except:
             pass
-
 
     not_found = [library for library in libraries if not find(library)]
     if not_found:
@@ -146,7 +143,7 @@ def run(args: str | list[str], cd: PathLike | None = None) -> None:
         args: the command to run.
         cd: a directory to switch into beforehand, if any.
     """
-    cmd = ' '.join(args)
+    cmd = " ".join(args)
     print(">> Running command:", cmd)
     if cd is not None:
         with cd_context(_resolve(cd, strict=True)):
@@ -430,38 +427,39 @@ def lint():
     """
     Run tasks: ruff, mypy, and pyright (Run this before making a pull request!)
     """
-    ruff()
+    ruff_check()
     mypy()
     pyright()
 
 
 @app.command(rich_help_panel="Code Quality")
-def ruff():
+def ruff_check():
     """Run ruff check for code quality"""
     run([RUFF, *RUFFOPTS, RUFFOPTS_PACKAGE])
 
 
 @app.command(rich_help_panel="Code Quality")
 def format(check: bool = False):
-    """Format code using black and sort imports with ruff"""
-    black(check)
-    isort(check)
+    """Format code and sort imports with ruff"""
+    ruff_format(check)
+    ruff_isort(check)
 
 
 @app.command(rich_help_panel="Code Quality")
-def isort(check: bool = False):
+def ruff_format(check: bool = False):
+    """Format code using ruff"""
+    ruff_fmt = [RUFF, "format"]
+    if check:
+        ruff_fmt.append("--check")
+    run(ruff_fmt)
+
+
+@app.command(rich_help_panel="Code Quality")
+def ruff_isort(check: bool = False):
     """Sort imports with ruff"""
     if not check:
         RUFFOPTS_ISORT.append("--fix")
     run([RUFF, *RUFFOPTS_ISORT, RUFFOPTS_PACKAGE])
-
-
-@app.command(rich_help_panel="Code Quality")
-def black(check: bool = False):
-    """Format code using black"""
-    if check:
-        BLACKOPTS.append("--check")
-    run([BLACK, *BLACKOPTS])
 
 
 @app.command(rich_help_panel="Code Quality")

--- a/make.py
+++ b/make.py
@@ -29,7 +29,6 @@ def _resolve(p: PathLike, strict: bool = False) -> Path:
 
 PROJECT_ROOT = _resolve(Path(__file__).parent, strict=True)
 
-
 # General sphinx state / options
 SPHINX_OPTS = []
 SPHINX_BUILD = "sphinx-build"
@@ -38,12 +37,10 @@ PAPER_SIZE = None
 DOC_DIR = "doc"
 BUILD_DIR = "build"
 
-
 # Used for user output; relative to project root
 FULL_DOC_DIR = PROJECT_ROOT / DOC_DIR
 # FULL_BUILD_PREFIX = f"{DOCDIR}/{BUILDDIR}"
 FULL_BUILD_DIR = PROJECT_ROOT / BUILD_DIR
-
 
 # Linting
 RUFF = "ruff"
@@ -75,7 +72,6 @@ SPHINXAUTOBUILDOPTS = ["--watch", "../arcade", "--ignore", "./example_code/how_t
 # This allows for internationalization / localization of doc.
 I18NSPHINXOPTS = [*PAPER_SIZE_OPTS[PAPER_SIZE], *SPHINX_OPTS, "."]
 
-
 # User-friendly check for dependencies and binaries
 binaries = ["sphinx-build", "sphinx-autobuild"]
 libraries = ["typer"]
@@ -83,9 +79,8 @@ for binary in binaries:
     not_found = [binary for binary in binaries if which(binary) is None]
     if not_found:
         print("Command-line tools not found: " + ", ".join(not_found))
-        print(
-            "Did you forget to install them with `pip`?  See CONTRIBUTING.md file for instructions."
-        )
+        print("Did you forget to install them with `pip`?")
+        print("See CONTRIBUTING.md file for instructions.")
         exit(1)
 for library in libraries:
 
@@ -96,14 +91,13 @@ for library in libraries:
         except:
             pass
 
+
     not_found = [library for library in libraries if not find(library)]
     if not_found:
         print("Python dependencies not found: " + ", ".join(not_found))
-        print(
-            "Did you forget to install them with `pip`?  See CONTRIBUTING.md file for instructions."
-        )
+        print("Did you forget to install them with `pip`?")
+        print("See CONTRIBUTING.md file for instructions.")
         exit(1)
-
 
 import typer
 
@@ -152,12 +146,17 @@ def run(args: str | list[str], cd: PathLike | None = None) -> None:
         args: the command to run.
         cd: a directory to switch into beforehand, if any.
     """
+    cmd = ' '.join(args)
+    print(">> Running command:", cmd)
     if cd is not None:
         with cd_context(_resolve(cd, strict=True)):
             result = subprocess.run(args)
     else:
         result = subprocess.run(args)
 
+    print(">> Command finished:", cmd, "\n")
+
+    # TODO: Should we exit here? Or continue to let other commands run also?
     if result.returncode != 0:
         exit(result.returncode)
 
@@ -196,7 +195,20 @@ def serve():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs")
+def linkcheck():
+    """
+    to check all external links for integrity
+    """
+    run_doc([SPHINX_BUILD, "-b", "linkcheck", *ALLSPHINXOPTS, f"{BUILD_DIR}/linkcheck"])
+    print()
+    print(
+        "Link check complete; look for any errors in the above output "
+        + f"or in {FULL_BUILD_DIR}/linkcheck/output.txt."
+    )
+
+
+@app.command(rich_help_panel="Docs Extra Formats")
 def dirhtml():
     """
     to make HTML files named index.html in directories
@@ -206,7 +218,7 @@ def dirhtml():
     print(f"Build finished. The HTML pages are in {FULL_BUILD_DIR}/dirhtml.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def singlehtml():
     """
     to make a single large HTML file
@@ -216,7 +228,7 @@ def singlehtml():
     print(f"Build finished. The HTML page is in {FULL_BUILD_DIR}/singlehtml.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def pickle():
     """
     to make pickle files
@@ -226,7 +238,7 @@ def pickle():
     print("Build finished; now you can process the pickle files.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def json():
     """
     to make JSON files
@@ -236,7 +248,7 @@ def json():
     print("Build finished; now you can process the JSON files.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def htmlhelp():
     """
     to make HTML files and a HTML help project
@@ -249,38 +261,7 @@ def htmlhelp():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
-def qthelp():
-    """
-    to make HTML files and a qthelp project
-    """
-    run_doc([SPHINX_BUILD, "-b", "qthelp", *ALLSPHINXOPTS, f"{BUILD_DIR}/qthelp"])
-    print()
-    print(
-        'Build finished; now you can run "qcollectiongenerator" with the'
-        + f".qhcp project file in {FULL_BUILD_DIR}/qthelp, like this:"
-    )
-    print(f"# qcollectiongenerator {FULL_BUILD_DIR}/qthelp/Arcade.qhcp")
-    print("To view the help file:")
-    print(f"# assistant -collectionFile {FULL_BUILD_DIR}/qthelp/Arcade.qhc")
-
-
-@app.command(rich_help_panel="Additional Doc Formats")
-def applehelp():
-    """
-    to make an Apple Help Book
-    """
-    run_doc([SPHINX_BUILD, "-b", "applehelp", *ALLSPHINXOPTS, f"{BUILD_DIR}/applehelp"])
-    print()
-    print(f"Build finished. The help book is in {FULL_BUILD_DIR}/applehelp.")
-    print(
-        "N.B. You won't be able to view it unless you put it in"
-        + "~/Library/Documentation/Help or install it in your application"
-        + "bundle."
-    )
-
-
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def devhelp():
     """
     to make HTML files and a Devhelp project
@@ -295,7 +276,7 @@ def devhelp():
     print("# devhelp")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def epub():
     """
     to make an epub
@@ -305,7 +286,7 @@ def epub():
     print(f"Build finished. The epub file is in {FULL_BUILD_DIR}/epub.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def latex():
     """
     to make LaTeX files, you can set PAPER_SIZE=a4 or PAPER_SIZE=letter
@@ -319,7 +300,7 @@ def latex():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def latexpdf():
     """
     to make LaTeX files and run them through pdflatex
@@ -330,7 +311,7 @@ def latexpdf():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_DIR}/latex.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def latexpdfja():
     """
     to make LaTeX files and run them through platex/dvipdfmx
@@ -341,7 +322,7 @@ def latexpdfja():
     print(f"pdflatex finished; the PDF files are in {FULL_BUILD_DIR}/latex.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def text():
     """
     to make text files
@@ -351,7 +332,7 @@ def text():
     print(f"Build finished. The text files are in {FULL_BUILD_DIR}/text.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def man():
     """
     to make manual pages
@@ -361,7 +342,7 @@ def man():
     print(f"Build finished. The manual pages are in {FULL_BUILD_DIR}/man.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def texinfo():
     """
     to make Texinfo files
@@ -375,7 +356,7 @@ def texinfo():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def info():
     """
     to make Texinfo files and run them through makeinfo
@@ -386,7 +367,7 @@ def info():
     print(f"makeinfo finished; the Info files are in {FULL_BUILD_DIR}/texinfo.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def gettext():
     """
     to make PO message catalogs
@@ -396,7 +377,7 @@ def gettext():
     print(f"Build finished. The message catalogs are in {FULL_BUILD_DIR}/locale.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def changes():
     """
     to make an overview of all changed/added/deprecated items
@@ -406,20 +387,7 @@ def changes():
     print(f"The overview file is in {FULL_BUILD_DIR}/changes.")
 
 
-@app.command(rich_help_panel="Code Quality")
-def linkcheck():
-    """
-    to check all external links for integrity
-    """
-    run_doc([SPHINX_BUILD, "-b", "linkcheck", *ALLSPHINXOPTS, f"{BUILD_DIR}/linkcheck"])
-    print()
-    print(
-        "Link check complete; look for any errors in the above output "
-        + f"or in {FULL_BUILD_DIR}/linkcheck/output.txt."
-    )
-
-
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def doctest():
     """
     to run all doctests embedded in the documentation (if enabled)
@@ -431,7 +399,7 @@ def doctest():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def coverage():
     """
     to run coverage check of the documentation (if enabled)
@@ -443,14 +411,14 @@ def coverage():
     )
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def xml():
     run_doc([SPHINX_BUILD, "-b", "xml", *ALLSPHINXOPTS, f"{BUILD_DIR}/xml"])
     print()
     print(f"Build finished. The XML files are in {FULL_BUILD_DIR}/xml.")
 
 
-@app.command(rich_help_panel="Additional Doc Formats")
+@app.command(rich_help_panel="Docs Extra Formats")
 def pseudoxml():
     run_doc([SPHINX_BUILD, "-b", "pseudoxml", *ALLSPHINXOPTS, f"{BUILD_DIR}/pseudoxml"])
     print()
@@ -460,45 +428,29 @@ def pseudoxml():
 @app.command(rich_help_panel="Code Quality")
 def lint():
     """
-    Run all linting tasks: ruff, mypy, and pyright (Run this before making a pull request!)
+    Run tasks: ruff, mypy, and pyright (Run this before making a pull request!)
     """
     ruff()
     mypy()
     pyright()
-    print("Linting Complete.")
 
 
 @app.command(rich_help_panel="Code Quality")
 def ruff():
+    """Run ruff check for code quality"""
     run([RUFF, *RUFFOPTS, RUFFOPTS_PACKAGE])
-    print("Ruff Finished.")
-
-
-@app.command(rich_help_panel="Code Quality")
-def mypy():
-    "Typecheck using mypy"
-    run([MYPY, *MYPYOPTS])
-    print("MyPy Finished.")
-
-
-@app.command(rich_help_panel="Code Quality")
-def pyright():
-    "Typecheck using pyright"
-    run([PYRIGHT, *PYRIGHTOPTS])
-    print("Pyright Finished.")
 
 
 @app.command(rich_help_panel="Code Quality")
 def format(check: bool = False):
-    "Format code using black"
+    """Format code using black and sort imports with ruff"""
     black(check)
     isort(check)
-    print("Formatting Complete.")
 
 
 @app.command(rich_help_panel="Code Quality")
 def isort(check: bool = False):
-    "Format code using isort(actually ruff)"
+    """Sort imports with ruff"""
     if not check:
         RUFFOPTS_ISORT.append("--fix")
     run([RUFF, *RUFFOPTS_ISORT, RUFFOPTS_PACKAGE])
@@ -506,15 +458,27 @@ def isort(check: bool = False):
 
 @app.command(rich_help_panel="Code Quality")
 def black(check: bool = False):
-    "Format code using black"
+    """Format code using black"""
     if check:
         BLACKOPTS.append("--check")
     run([BLACK, *BLACKOPTS])
-    print("Black Finished.")
+
+
+@app.command(rich_help_panel="Code Quality")
+def mypy():
+    """Typecheck using mypy"""
+    run([MYPY, *MYPYOPTS])
+
+
+@app.command(rich_help_panel="Code Quality")
+def pyright():
+    """Typecheck using pyright"""
+    run([PYRIGHT, *PYRIGHTOPTS])
 
 
 @app.command(rich_help_panel="Code Quality")
 def test_full():
+    """Run all tests"""
     run([PYTEST, TESTDIR])
 
 
@@ -524,17 +488,14 @@ def test():
     run([PYTEST, UNITTESTS])
 
 
-SHELLS_WITH_AUTOCOMPLETE = ("bash", "zsh", "fish", "powershell", "powersh")
-
-
 @app.command(rich_help_panel="Shell Completion")
 def whichshell():
-    """to find out which shell your system seems to be running"""
-
+    """Find out which shell your system seems to be running"""
     shell_name = Path(os.environ.get("SHELL")).stem
     print(f"Your default shell appears to be: {shell_name}")
 
-    if shell_name in SHELLS_WITH_AUTOCOMPLETE:
+    shells = ("bash", "zsh", "fish", "powershell", "powersh")
+    if shell_name in shells:
         print("This shell is known to support tab-completion!")
         print("See CONTRIBUTING.md for more information on how to enable it.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,6 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.ruff]
-# --- Description of what we ignore ---
-#
-# E731 do not assign a lambda expression, use a def
-# E741 Ambiguous variable name
-# F811: redefinition
 line-length = 100
 output-format = "full"
 exclude = [
@@ -103,7 +98,12 @@ exclude = [
     "bugs",
     "arcade/examples/platform_tutorial",
 ]
-lint.ignore = ["E731", "E741"]
+lint.ignore = [
+    "E731", # E731 do not assign a lambda expression, use a def
+    "E741", # E741 Ambiguous variable name
+    # F811: redefinition
+]
+
 lint.select = [
     "E",
     "F",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dev = [
     "pytest-mock",
     "coverage",
     "coveralls",          # Do we really need this?
-    "black",
     "ruff",
     "mypy",
     "pyright==1.1.387",
@@ -110,6 +109,13 @@ lint.select = [
     # Whitespace linting must be re-enabled manually for ruff
     # see https://beta.ruff.rs/docs/configuration/#using-pyprojecttoml
     "W",
+]
+
+[tool.ruff.format]
+docstring-code-format = false
+exclude = [
+    "arcade/examples/*",
+    "benchmarks/*",
 ]
 
 # This ignores __init__.py files and examples for import sorting
@@ -169,19 +175,6 @@ omit = [
     "./doc/*",
     "./Win*/*",
 ]
-
-[tool.black]
-line-length = 100
-force-exclude = '''
-(
-  doc
-  | arcade/examples
-  | arcade/gui/examples
-  | tests
-  | util
-  | benchmarks
-)
-'''
 
 [[tool.mypy.overrides]]
 module = "pyglet.*"


### PR DESCRIPTION
This PR has three commits that are best reviewed one by one:

* 5f03082ad14bf14fb05be3b68109f1d5bcea4543 improves make.py a bit
* 226e4e5e226ff89faf7bb31ac62fca1a60e87991 has some ruff format changes on arcade (not many changes, and very little ones removing empty lines or adding trailing commas mostly)
* c1ac6965eba6f683a36a1734eeb7ffd6eafefa3a switches make.py, pyproject.toml and CONTRIBUTING.md from black to ruff format

Related: #2139, #2165, #2214

Looks like `.pre-commit-config.yaml` already only runs `ruff format`, no `black`.
So overall I think this is almost a drop-on replacement, just with some small gains in simplicity / consistency / speed.

Thoughts?


