### PR TITLE
Small UI docs and example cleanup

### DIFF
--- a/arcade/examples/gui/0_basic_setup.py
+++ b/arcade/examples/gui/0_basic_setup.py
@@ -33,7 +33,7 @@ class GreenView(arcade.View):
         # Create a UIManager
         self.ui = UIManager()
 
-        # Create a anchor layout, which can be used to position widgets on screen
+        # Create an anchor layout, which can be used to position widgets on screen
         anchor = self.ui.add(UIAnchorLayout())
 
         # Add a button switch to the other View.
@@ -43,7 +43,6 @@ class GreenView(arcade.View):
                 texture=TEX_RED_BUTTON_NORMAL,
                 texture_hovered=TEX_RED_BUTTON_HOVER,
                 texture_pressed=TEX_RED_BUTTON_PRESS,
-                on_click=lambda: self.window.show_view(self.window.views["other"]),
             )
         )
 
@@ -78,7 +77,7 @@ class BlueView(UIView):
         super().__init__()
         self.background_color = arcade.uicolor.BLUE_PETER_RIVER
 
-        # Create a anchor layout, which can be used to position widgets on screen
+        # Create an anchor layout, which can be used to position widgets on screen
         anchor = self.add_widget(UIAnchorLayout())
 
         # Add a button switch to the other View.
@@ -88,7 +87,6 @@ class BlueView(UIView):
                 texture=TEX_RED_BUTTON_NORMAL,
                 texture_hovered=TEX_RED_BUTTON_HOVER,
                 texture_pressed=TEX_RED_BUTTON_PRESS,
-                on_click=lambda: self.window.show_view(self.window.views["my"]),
             )
         )
 

--- a/arcade/gui/view.py
+++ b/arcade/gui/view.py
@@ -21,7 +21,7 @@ class UIView(View):
     The screen is cleared before on_draw_before_ui is called
     with the background color of the window.
 
-    If you override ``on_show_view`` or ``on_show_view``,
+    If you override ``on_show_view`` or ``on_hide_view``,
     don't forget to call super().on_show_view() or super().on_hide_view().
 
     """

--- a/doc/programming_guide/gui/concepts.rst
+++ b/doc/programming_guide/gui/concepts.rst
@@ -35,8 +35,8 @@ And disable it with :py:meth:`~arcade.gui.UIManager.disable()` within :py:meth:`
 
 To draw the GUI, call :py:meth:`~arcade.gui.UIManager.draw` within the :py:meth:`~arcade.View.on_draw` method.
 
-The :py:class`~arcade.gui.UIView` class is a subclass of :py:class:`~arcade.View` and provides
-a convenient way to use the GUI. It instanciates a :py:class:`~arcade.gui.UIManager` which can be accessed
+The :py:class:`~arcade.gui.UIView` class is a subclass of :py:class:`~arcade.View` and provides
+a convenient way to use the GUI. It instantiates a :py:class:`~arcade.gui.UIManager` which can be accessed
 via the :py:attr:`~arcade.gui.UIView.ui` attribute.
 It automatically enables and disables the
 :py:class:`~arcade.gui.UIManager` when the view is shown or hidden.


### PR DESCRIPTION
Mainly a fix in `arcade/examples/gui/0_basic_setup.py` removing two broken `on_click` handlers were attached that then were overwritten and unused.