### PR TITLE
Fix Kenney.nl links in permissive licensing page

### DIFF
--- a/doc/_includes/links.rst
+++ b/doc/_includes/links.rst
@@ -24,7 +24,8 @@
 .. Arcade-related community engagement stuff
 .. _PyWeek: https://pyweek.org/
 .. _The Python Discord: https://www.pythondiscord.com/
-.. _Kenney_nl: https://kenney.nl/
+.. Sphinx does not like the _ if we write Kenney_nl.
+.. _Kenney.nl: https://kenney.nl/
 
 .. Concepts
 .. _CC0: https://creativecommons.org/publicdomain/#publicdomain-cc0-10

--- a/doc/about/permissive_licensing.rst
+++ b/doc/about/permissive_licensing.rst
@@ -91,7 +91,7 @@ If something requires special handling, we'll warn you about it.
 Where are all these assets from?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Mostly from `Kenney.nl <Kenney_nl>`_. Kenny is famous for creating a repository of free, high-quality
+Mostly from `Kenney.nl`_. Kenney is famous for creating a repository of free, high-quality
 `CC0`_ (public domain) game assets. His work is funded by donations and
 `Kenney's Patreon <https://www.patreon.com/kenney>`_.
 
@@ -102,7 +102,7 @@ It's the lawyer version saying the following:
 
    <blockquote><i>"I give permission to everyone to use this for whatever. Go make something cool!"</i></blockquote>
 
-Although Arcade includes a few bundled assets which aren't from `Kenny.nl <Kenney_nl>`_, we've made sure
+Although Arcade includes a few bundled assets which aren't by `Kenney.nl`_, we've made sure
 they're released under a similar license.
 
 

--- a/doc/about/permissive_licensing.rst
+++ b/doc/about/permissive_licensing.rst
@@ -102,7 +102,7 @@ It's the lawyer version saying the following:
 
    <blockquote><i>"I give permission to everyone to use this for whatever. Go make something cool!"</i></blockquote>
 
-Although Arcade includes a few bundled assets which aren't by `Kenney.nl`_, we've made sure
+Although Arcade includes a few bundled assets which aren't from `Kenney.nl`_, we've made sure
 they're released under a similar license.
 
 

--- a/util/create_resources_listing.py
+++ b/util/create_resources_listing.py
@@ -804,7 +804,7 @@ def resources():
               # pending: post-3.0 cleanup # Why does it refuse to accept external links definitions? Who knows?
               "are specifically released under `CC0  <https://creativecommons.org/publicdomain/#publicdomain-cc0-10>`_"
               " or similar terms.\n")
-    out.write("Most are from `Kenney.nl <https://kenney.nl/>`_.\n") # pending: post-3.0 cleanup.
+    out.write("Most are from `Kenney.nl`_.\n") # pending: post-3.0 cleanup.
     logo = html.escape("'logo.png'")
     do_heading(out, 1, "How do I use these?")
     out.write(

--- a/util/create_resources_listing.py
+++ b/util/create_resources_listing.py
@@ -802,8 +802,7 @@ def resources():
     out.write("That's a good question and one you should always ask when searching for assets online.\n"
               "To help users get started quickly, the Arcade team makes sure to only bundle assets which\n"
               # pending: post-3.0 cleanup # Why does it refuse to accept external links definitions? Who knows?
-              "are specifically released under `CC0  <https://creativecommons.org/publicdomain/#publicdomain-cc0-10>`_"
-              " or similar terms.\n")
+              "are specifically released under `CC0`_ or similar terms.\n")
     out.write("Most are from `Kenney.nl`_.\n") # pending: post-3.0 cleanup.
     logo = html.escape("'logo.png'")
     do_heading(out, 1, "How do I use these?")


### PR DESCRIPTION
* Use Kenney.nl instead of Kenney_nl for ref name
* Fix typo (s/Kenny/Kenney/ on resources page)
* Update the permissive licensing page and resource listing page for consistency
* Use ref targets declared in links.rst in resources listing