### PR TITLE
Fix arcade.version.VERSION conversion from GitHub CI format

### DIFF
--- a/arcade/version.py
+++ b/arcade/version.py
@@ -79,23 +79,24 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
     Returns:
         A Python-friendly version string.
     """
-    # Extract our raw data
+    # Quick preflight check: we don't support tuple format here!
     if not isinstance(version_for_github_actions, str):
         raise TypeError(
             f"Expected a string of the format MAJOR.MINOR.POINT or MAJOR.MINOR.POINT-dev.DEV_PREVIEW,"
-            f"not {version_for_github_actions!r}"
-        )
+            f"not {version_for_github_actions!r}")
 
+    # Attemppt to extract our raw data
     match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
     if match is None:
         raise ValueError(f"String does not appear to be a version number: {version_for_github_actions!r}")
 
+    # Make sure no mandatory fields are missing
     group_dict = match.groupdict()
     for name in ('major', 'minor', 'point'):
         if group_dict[name] is None:
             raise ValueError(f"Couldn't parse {name} from {version_for_github_actions!r}")
 
-    # Append an optional Python-friendly dev preview version
+    # Build final output, optionally adding a dev version
     major, minor, point, dev_preview = group_dict.values()
     parts = [major, minor, point]
     if dev_preview is not None:
@@ -129,8 +130,9 @@ def _parse_py_version_from_github_ci_file(
     try:
         raw = Path(version_path).resolve().read_text().strip()
         data = _parse_python_friendly_version(raw)
-    except Exception as _:
-        print(f"ERROR: Unable to load version number via '{str(version_path)}'.", file=write_errors_to)
+    except Exception as e:
+        print(f"ERROR: Unable to load version number via '{str(version_path)}': "
+              f"{e}", file=write_errors_to)
 
     return data
 

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -92,12 +92,6 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
     if match is None:
         raise ValueError(f"String does not appear to be a version number: {version_for_github_actions!r}")
 
-    # Make sure no mandatory fields are missing
-    group_dict = match.groupdict()
-    for name in ('major', 'minor', 'point'):
-        if group_dict[name] is None:
-            raise ValueError(f"Couldn't parse {name} from {version_for_github_actions!r}")
-
     # Build final output, optionally adding a dev version
     major, minor, point, dev_preview = group_dict.values()
     parts = [major, minor, point]

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -80,13 +80,26 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
         A Python-friendly version string.
     """
     # Extract our raw data
+    if not isinstance(version_for_github_actions, str):
+        raise TypeError(
+            f"Expected a string of the format MAJOR.MINOR.POINT or MAJOR.MINOR.POINT-dev.DEV_PREVIEW,"
+            f"not {version_for_github_actions!r}"
+        )
+
     match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
-    major, minor, patch, dev = tuple(match.groupdict().values())
+    if match is None:
+        raise ValueError(f"String does not appear to be a version number: {version_for_github_actions!r}")
+
+    group_dict = match.groupdict()
+    for name in ('major', 'minor', 'point'):
+        if group_dict[name] is None:
+            raise ValueError(f"Couldn't parse {name} from {version_for_github_actions!r}")
 
     # Append an optional Python-friendly dev preview version
-    parts = [major, minor, patch]
-    if dev is not None:
-        parts.append(f"dev{dev}")
+    major, minor, point, dev_preview = group_dict.values()
+    parts = [major, minor, point]
+    if dev_preview is not None:
+        parts.append(f"dev{dev_preview}")
     joined = ".".join(parts)
 
     return joined

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -1,48 +1,125 @@
 """
-Version
+Loads the Arcade version into a Python-readable VERSION string.
 
-We are using a github action to bump the VERSION file versions.
+For everyday use in your projects, you may want to use the ``VERSION``
+string from the :py:mod:`arcade` module's top level instead:
 
-2.7.3-dev.5
-will go to:
-2.7.3-dev.6
+.. code-block:: python
 
-Problem is, python doesn't like that last period:
-2.7.3-dev.5
-should be
-2.7.3.dev5
-...and our github action doesn't like that pattern.
-So this will delete that last period and flip around the dash.
+   import arcade
 
-ALSO note that this bumps the version AFTER the deploy.
-So if we are at version 2.7.3.dev5 that's the version deploy. Bump will bump it to dev6.
+   if arcade.version < "3.0.0":
+       print("This game requires Arcade 3.0.0+ to run1")
+
+This loads and converts the ``VERSION`` file's contents before storing
+them in the ``VERSION`` attribute. We have convert it because we use a
+GitHub Action to auto-bump our version after making a release.
+
+When a release build succeeds, our GitHub CI then does the following:
+
+#. Pushes the package files to PyPI
+#. Calls the ``remorses/bump-version@js`` action to bump Arcade's version
+   on the development branch
+
+The auto-bump action is configured by the following file:
+https://github.com/pythonarcade/arcade/blob/development/.github/workflows/bump_version.yml
+
+Python expects a different format than the GH action does for dev previews.
+
+Python expects the following format:
+
+.. code-block::
+
+   3.1.0.dev6
+
+However, the GH action bumps the following preview format after a
+release succeeds:
+
+.. code-block::
+
+   3.1.0-dev.5
+
+...to this:
+
+.. code-block::
+
+   3.1.0-dev.6
+
+The functions in this file convert and load the data to ``VERSION`` so
+we can import it in the top-level ``__init__.py`` file.
 """
-
 from __future__ import annotations
 
-import os
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+
+# Grab version numbers + optional dev point preview
+# Assumes $MAJOR.$MINOR.$POINT format with optional -dev$DEV_PREVIEW
+_VERSION_REGEX = re.compile(
+    r"""
+    (?P<major>[0-9]+)
+    \.(?P<minor>[0-9]+)
+    \.(?P<point>[0-9]+)
+    (?:
+        -dev              # Dev prefix read as a literal
+        \.(?P<dev>[0-9]+) # Dev preview point number
+    )?
+    """, re.X)
 
 
-def _rreplace(s, old, new, occurrence):
-    li = s.rsplit(old, occurrence)
-    return new.join(li)
+def _parse_python_friendly_version(version_for_github_actions: str) -> str:
+    """Convert a GitHub CI version string to a Python-friendly one.
+
+    Args:
+        version_for_github_actions:
+            A raw GitHub CI version string, as read from a file.
+    Returns:
+        A Python-friendly version string.
+    """
+    # Extract our raw data
+    match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
+    major, minor, patch, dev = tuple(match.groupdict().values())
+
+    # Append an optional Python-friendly dev preview version
+    parts = [major, minor, patch]
+    if dev is not None:
+        parts.append(f"dev{dev}")
+    joined = ".".join(parts)
+
+    return joined
 
 
-def _get_version():
-    dirname = os.path.dirname(__file__) or "."
-    my_path = f"{dirname}/VERSION"
+def _parse_py_version_from_github_ci_file(
+        version_path: str | Path = _HERE / "VERSION",
+        write_errors_to = sys.stderr
+) -> str:
+    """Parse a Python-friendly version from a ``bump-version``-compatible file.
 
+    On failure, it will:
+
+    #. Print an error to stderr
+    #. Return "0.0.0"
+
+    Args:
+        version_path:
+            The VERSION file's path, defaulting to the same directory as
+            this file.
+        write_errors_to:
+            Makes CI simpler by allowing a stream mock to be passed easily.
+    Returns:
+        Either a converted version or "0.0.0" on failure.
+    """
+    data = "0.0.0"
     try:
-        text_file = open(my_path, "r")
-        data = text_file.read().strip()
-        text_file.close()
-        data = _rreplace(data, ".", "", 1)
-        data = _rreplace(data, "-", ".", 1)
-    except Exception:
-        print(f"ERROR: Unable to load version number via '{my_path}'.")
-        data = "0.0.0"
+        raw = Path(version_path).resolve().read_text().strip()
+        data = _parse_python_friendly_version(raw)
+    except Exception as _:
+        print(f"ERROR: Unable to load version number via '{str(version_path)}'.", file=write_errors_to)
 
     return data
 
 
-VERSION = _get_version()
+VERSION = _parse_py_version_from_github_ci_file()

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -58,6 +58,8 @@ _HERE = Path(__file__).parent
 
 # Grab version numbers + optional dev point preview
 # Assumes $MAJOR.$MINOR.$POINT format with optional -dev$DEV_PREVIEW
+# Q: Why did you use regex?!
+# A: If the dev_preview field is invalid, the whole match fails instantly
 _VERSION_REGEX = re.compile(
     r"""
     (?P<major>[0-9]+)
@@ -65,7 +67,7 @@ _VERSION_REGEX = re.compile(
     \.(?P<point>[0-9]+)
     (?:
         -dev              # Dev prefix read as a literal
-        \.(?P<dev>[0-9]+) # Dev preview point number
+        \.(?P<dev_preview>[0-9]+) # Dev preview point number
     )?
     """, re.X)
 

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -84,15 +84,19 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
     # Quick preflight check: we don't support tuple format here!
     if not isinstance(version_for_github_actions, str):
         raise TypeError(
-            f"Expected a string of the format MAJOR.MINOR.POINT or MAJOR.MINOR.POINT-dev.DEV_PREVIEW,"
+            f"Expected a string of the format MAJOR.MINOR.POINT"
+            f"or MAJOR.MINOR.POINT-dev.DEV_PREVIEW,"
             f"not {version_for_github_actions!r}")
 
     # Attemppt to extract our raw data
     match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
     if match is None:
-        raise ValueError(f"String does not appear to be a version number: {version_for_github_actions!r}")
+        raise ValueError(
+            f"String does not appear to be a version number: "
+            f"{version_for_github_actions!r}")
 
     # Build final output, optionally adding a dev version
+    group_dict = match.groupdict()
     major, minor, point, dev_preview = group_dict.values()
     parts = [major, minor, point]
     if dev_preview is not None:

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -68,7 +68,7 @@ _HERE = Path(__file__).parent
 # A: If the dev_preview field is invalid, the whole match fails instantly
 _VERSION_REGEX = re.compile(
     r"""
-    # First three version numbers
+    # First three version number fields
       (?P<major>[0-9]+)
     \.(?P<minor>[0-9]+)
     \.(?P<point>[0-9]+)

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -68,12 +68,15 @@ _HERE = Path(__file__).parent
 # A: If the dev_preview field is invalid, the whole match fails instantly
 _VERSION_REGEX = re.compile(
     r"""
-    (?P<major>[0-9]+)
+    # First three version numbers
+      (?P<major>[0-9]+)
     \.(?P<minor>[0-9]+)
     \.(?P<point>[0-9]+)
+    # Optional dev preview suffix
     (?:
-        -dev              # Dev prefix read as a literal
-        \.(?P<dev_preview>[0-9]+) # Dev preview point number
+        -dev                    # Dev prefix as a literal
+        \.                      # Point
+        (?P<dev_preview>[0-9]+) # Dev preview number
     )?
     """,
     re.X,

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -1,39 +1,45 @@
 """
-Loads the Arcade version into a Python-readable VERSION string.
+Loads the Arcade version into a Python-readable ``VERSION`` string.
 
-For everyday use in your projects, you may want to use the ``VERSION``
-string from the :py:mod:`arcade` module's top level instead:
+Everyday Arcade users may prefer accessing the ``VERSION`` string
+from Arcade's top-level alias:
 
 .. code-block:: python
 
+   import sys
    import arcade
 
    if arcade.version < "3.0.0":
-       print("This game requires Arcade 3.0.0+ to run1")
+       # Using file=sys.stderr prints to the error stream (usually prints red)
+       print("This game requires Arcade 3.0.0+ to run!", file=sys.stderr)
 
-This loads and converts the ``VERSION`` file's contents before storing
-them in the ``VERSION`` attribute. We have convert it because we use a
-GitHub Action to auto-bump our version after making a release.
 
-When a release build succeeds, our GitHub CI then does the following:
+Arcade contributors will benefit from understanding how and why
+this file loads and converts the contents of the ``VERSION`` file.
 
-#. Pushes the package files to PyPI
-#. Calls the ``remorses/bump-version@js`` action to bump Arcade's version
-   on the development branch
+After a release build succeeds, GitHub's CI is configured to do
+the following:
+
+#. Push the package files to PyPI
+#. Call the ``remorses/bump-version@js`` action to auto-increment
+   Arcade's version on the development branch
+
+This is where an edge case arises:
+
+#. Our CI expects ``3.1.0-dev.1`` for dev preview builds
+#. Python expects ``3.1.0.dev1`` for dev preview builds
+
+The ``VERSION`` file in this file's directory stores the version
+in the form the GH Action prefers. This allows it to auto-increment
+the version number on the ``development`` branch after we make an
+Arcade release to PyPI.
 
 The auto-bump action is configured by the following file:
 https://github.com/pythonarcade/arcade/blob/development/.github/workflows/bump_version.yml
 
-Python expects a different format than the GH action does for dev previews.
-
-Python expects the following format:
-
-.. code-block::
-
-   3.1.0.dev6
-
-However, the GH action bumps the following preview format after a
-release succeeds:
+As an example, the GH action would auto-increment a dev preview's
+version after releasing the 5th dev preview of ``3.1.0`` by updating
+the ``VERSION`` file from this:
 
 .. code-block::
 
@@ -45,8 +51,6 @@ release succeeds:
 
    3.1.0-dev.6
 
-The functions in this file convert and load the data to ``VERSION`` so
-we can import it in the top-level ``__init__.py`` file.
 """
 
 from __future__ import annotations
@@ -54,6 +58,7 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
+from typing import Final
 
 _HERE = Path(__file__).parent
 
@@ -78,6 +83,8 @@ _VERSION_REGEX = re.compile(
 def _parse_python_friendly_version(version_for_github_actions: str) -> str:
     """Convert a GitHub CI version string to a Python-friendly one.
 
+    For example, ``3.1.0-dev.1`` would become ``3.1.0.dev1``.
+
     Args:
         version_for_github_actions:
             A raw GitHub CI version string, as read from a file.
@@ -92,14 +99,14 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
             f"not {version_for_github_actions!r}"
         )
 
-    # Attemppt to extract our raw data
+    # Attempt to extract our raw data
     match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
     if match is None:
         raise ValueError(
-            f"String does not appear to be a version number: " f"{version_for_github_actions!r}"
+            f"String does not appear to be a version number: {version_for_github_actions!r}"
         )
 
-    # Build final output, optionally adding a dev version
+    # Build final output, including a dev preview version if present
     group_dict = match.groupdict()
     major, minor, point, dev_preview = group_dict.values()
     parts = [major, minor, point]
@@ -135,11 +142,16 @@ def _parse_py_version_from_github_ci_file(
         data = _parse_python_friendly_version(raw)
     except Exception as e:
         print(
-            f"ERROR: Unable to load version number via '{str(version_path)}': " f"{e}",
+            f"ERROR: Unable to load version number via '{str(version_path)}': {e}",
             file=write_errors_to,
         )
 
     return data
 
 
-VERSION = _parse_py_version_from_github_ci_file()
+VERSION: Final[str] = _parse_py_version_from_github_ci_file()
+"""A Python-friendly version string.
+
+This value is converted from the GitHub-style ``VERSION`` file at the
+top-level of the arcade module.
+"""

--- a/arcade/version.py
+++ b/arcade/version.py
@@ -48,6 +48,7 @@ release succeeds:
 The functions in this file convert and load the data to ``VERSION`` so
 we can import it in the top-level ``__init__.py`` file.
 """
+
 from __future__ import annotations
 
 import re
@@ -69,7 +70,9 @@ _VERSION_REGEX = re.compile(
         -dev              # Dev prefix read as a literal
         \.(?P<dev_preview>[0-9]+) # Dev preview point number
     )?
-    """, re.X)
+    """,
+    re.X,
+)
 
 
 def _parse_python_friendly_version(version_for_github_actions: str) -> str:
@@ -86,14 +89,15 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
         raise TypeError(
             f"Expected a string of the format MAJOR.MINOR.POINT"
             f"or MAJOR.MINOR.POINT-dev.DEV_PREVIEW,"
-            f"not {version_for_github_actions!r}")
+            f"not {version_for_github_actions!r}"
+        )
 
     # Attemppt to extract our raw data
     match = _VERSION_REGEX.fullmatch(version_for_github_actions.strip())
     if match is None:
         raise ValueError(
-            f"String does not appear to be a version number: "
-            f"{version_for_github_actions!r}")
+            f"String does not appear to be a version number: " f"{version_for_github_actions!r}"
+        )
 
     # Build final output, optionally adding a dev version
     group_dict = match.groupdict()
@@ -107,8 +111,7 @@ def _parse_python_friendly_version(version_for_github_actions: str) -> str:
 
 
 def _parse_py_version_from_github_ci_file(
-        version_path: str | Path = _HERE / "VERSION",
-        write_errors_to = sys.stderr
+    version_path: str | Path = _HERE / "VERSION", write_errors_to=sys.stderr
 ) -> str:
     """Parse a Python-friendly version from a ``bump-version``-compatible file.
 
@@ -131,8 +134,10 @@ def _parse_py_version_from_github_ci_file(
         raw = Path(version_path).resolve().read_text().strip()
         data = _parse_python_friendly_version(raw)
     except Exception as e:
-        print(f"ERROR: Unable to load version number via '{str(version_path)}': "
-              f"{e}", file=write_errors_to)
+        print(
+            f"ERROR: Unable to load version number via '{str(version_path)}': " f"{e}",
+            file=write_errors_to,
+        )
 
     return data
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,7 +88,23 @@ def nice_version(version_string: str) -> str:
     return '.'.join(out)
 
 
-NICE_VERSION = nice_version(VERSION)
+# pending: 3.0.1 or 3.1 release?
+# Maintain title bar continuity for live doc showing 3.0 as the version
+VERSION_SPECIAL_CASES = {'3.0.0': '3.0'}
+
+
+def _specialcase_version(nice: str) -> str:
+    if nice in VERSION_SPECIAL_CASES:
+       new = VERSION_SPECIAL_CASES[nice]
+       log.info(f" Special-casing version {nice!r} to {new!r}")
+    else:
+       new = nice
+    return new
+
+
+NICE_VERSION = _specialcase_version(nice_version(VERSION))
+# pending: end
+
 log.info(f" Got nice version {NICE_VERSION=!r}")
 
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -35,10 +35,39 @@ class TestParsingWellFormedData:
             ) == expected
 
 
+@pytest.mark.parametrize(
+    "bad_value", (
+        '',
+        "This string is not a version number at all!"
+        # Malformed version numbers
+        "3",
+        "3.",
+        "3.1",
+        "3.1.",
+        "3.1.2.",
+        "3.1.0.dev",
+        "3.1.0-dev."
+    )
+)
+def test_parse_python_friendly_version_raises_value_errors(bad_value):
+    with pytest.raises(ValueError):
+        _parse_python_friendly_version(bad_value)
+
+
+@pytest.mark.parametrize('bad_type', (
+    None,
+    0xBAD,
+    0.1234,
+    (3, 1, 0),
+    ('3', '1' '0')
+))
+def test_parse_python_friendly_version_raises_typeerror_on_bad_values(bad_type):
+    with pytest.raises(TypeError):
+        _parse_python_friendly_version(bad_type)  # type: ignore  # Type mistmatch is the point
+
+
 def test_parse_py_version_from_github_ci_file_returns_zeroes_on_errors():
     fake_stderr = mock.MagicMock(sys.stderr)
     assert _parse_py_version_from_github_ci_file(
         "FILEDOESNOTEXIST", write_errors_to=fake_stderr
     ) == "0.0.0"
-
-

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -47,6 +47,12 @@ class TestParsingWellFormedData:
         "3.1.2.",
         "3.1.0.dev",
         "3.1.0-dev."
+        # Hex is not valid in version numbers
+        "A",
+        "3.A.",
+        "3.1.A",
+        "3.1.0.A",
+        "3.1.0-dev.A"
     )
 )
 def test_parse_python_friendly_version_raises_value_errors(bad_value):

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,44 @@
+import sys
+import tempfile
+from unittest import mock
+
+import pytest
+from arcade.version import (
+    _parse_python_friendly_version,
+    _parse_py_version_from_github_ci_file
+)
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("3.0.0-dev.1", "3.0.0.dev1"),
+    ("3.0.0", "3.0.0"),
+    # Edge cases
+    ("11.22.333-dev.4444", "11.22.333.dev4444"),
+    ("11.22.333", "11.22.333"),
+])
+class TestParsingWellFormedData:
+    def test_parse_python_friendly_version(
+            self, value, expected
+    ):
+        assert _parse_python_friendly_version(value) == expected
+
+    def test_parse_py_version_from_github_ci_file(
+            self, value, expected
+    ):
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write(value)
+            f.close()
+
+            assert _parse_py_version_from_github_ci_file(
+                f.name
+            ) == expected
+
+
+def test_parse_py_version_from_github_ci_file_returns_zeroes_on_errors():
+    fake_stderr = mock.MagicMock(sys.stderr)
+    assert _parse_py_version_from_github_ci_file(
+        "FILEDOESNOTEXIST", write_errors_to=fake_stderr
+    ) == "0.0.0"
+
+


### PR DESCRIPTION
**TL;DR:** Stop swallowing last `.` + add extensive tests, error reporting, and doc

### Why?

Release time is not a fun time to be debugging weird issues:

1. cspotcode is right, the current code is broken:
    > [The version numbering bug will publish it as a minor bump instead of a patch bump](https://discord.com/channels/458662222697070613/458662458198982676/1340844291706196040)
2. We should verify that our release-critical code does what it says
3. The code should tell us what went wrong during build, not `ERROR: Unable to load version number via './VERSION'`

### What?

1. Explain what's in the can and why
    * Our release process
    * A ctrl-clickable link to the version bump GH action's config YAML
2. Aggressive tests covering various possible typos or misconfigurations
3. Explain what went wrong in more detail if/when it does

Bonus: special-case `"3.0.0"` to `"3.0"` to avoid churn in bookmarks / etc change detection due to the title changing.