### PR TITLE
Fix GUI cam on_resize examples

### DIFF
--- a/arcade/examples/sprite_move_scrolling.py
+++ b/arcade/examples/sprite_move_scrolling.py
@@ -182,13 +182,12 @@ class GameView(arcade.View):
         """
         super().on_resize(width, height)
         self.camera_sprites.match_window()
-        self.camera_gui.match_window()
 
 
 def main():
     """ Main function """
     # Create a window class. This is what actually shows up on screen
-    window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
+    window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE, resizable=True)
 
     # Create and setup the GameView
     game = GameView()

--- a/arcade/examples/sprite_move_scrolling_shake.py
+++ b/arcade/examples/sprite_move_scrolling_shake.py
@@ -52,10 +52,8 @@ class GameView(arcade.View):
         # Physics engine so we don't run into walls.
         self.physics_engine = None
 
-        # Create the cameras. One for the GUI, one for the sprites.
-        # We scroll the 'sprite world' but not the GUI.
+        # Create camera that will follow the player sprite.
         self.camera_sprites = arcade.camera.Camera2D()
-        self.camera_gui = arcade.camera.Camera2D()
 
         self.camera_shake = arcade.camera.grips.ScreenShake2D(
             self.camera_sprites.view_data,
@@ -197,13 +195,12 @@ class GameView(arcade.View):
         """
         super().on_resize(width, height)
         self.camera_sprites.match_window()
-        self.camera_gui.match_window(position=True)
 
 
 def main():
     """ Main function """
     # Create a window class. This is what actually shows up on screen
-    window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
+    window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE, resizable=True)
 
     # Create and setup the GameView
     game = GameView()


### PR DESCRIPTION
In `arcade/examples/sprite_move_scrolling.py` the call to `self.camera_gui.match_window()` doesn't work, after resize it's misplaced (see screenshot). Another case of #2540 .

Calling `self.camera_gui.match_window(position=True)` does fix the issue, but also simply removing the call completely fixes the issue, so that's what I did here.

In `arcade/examples/sprite_move_scrolling_shake.py` there was a similar case, but there the `camera_gui` was completely unused, so I removed it.


<img width="1044" alt="Screenshot 2025-02-17 at 12 56 55" src="https://github.com/user-attachments/assets/d957f2b6-35f0-450d-8bf5-b743bba41cca" />
