### PR TITLE
Fix the type signature of collision check methods.

### DIFF
--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -801,7 +801,7 @@ class BasicSprite:
         x, y = point
         return is_point_in_polygon(x, y, self.hit_box.get_adjusted_points())
 
-    def collides_with_sprite(self: SpriteType, other: SpriteType) -> bool:
+    def collides_with_sprite(self, other: BasicSprite) -> bool:
         """Will check if a sprite is overlapping (colliding) another Sprite.
 
         Args:
@@ -813,7 +813,7 @@ class BasicSprite:
 
         return check_for_collision(self, other)
 
-    def collides_with_list(self: SpriteType, sprite_list: "SpriteList") -> list[SpriteType]:
+    def collides_with_list(self, sprite_list: SpriteList[SpriteType]) -> list[SpriteType]:
         """Check if current sprite is overlapping with any other sprite in a list
 
         Args:

--- a/arcade/sprite_list/collision.py
+++ b/arcade/sprite_list/collision.py
@@ -187,8 +187,8 @@ def _get_nearby_sprites(
 
 
 def check_for_collision_with_list(
-    sprite: SpriteType,
-    sprite_list: SpriteList,
+    sprite: BasicSprite,
+    sprite_list: SpriteList[SpriteType],
     method: int = 0,
 ) -> List[SpriteType]:
     """


### PR DESCRIPTION
The type of the sprites in the result never depend on the first argument single sprite. Instead, it depends on the type of sprites in the given `sprite_list`.

Previously, some signatures did not accurately reflect those properties. This commit fixes them.

Fixes #2576.

---

I don't think this can be *tested* per se? The tests don't seem to be checked by mypy, are they?

FWIW, changing `sprite_list: SpriteList` to `SpriteList[BasicSprite]` (only) *did* report type errors inside `check_collision_with_sprite_list`. It previously passed the type checker only because it was inferred as `SpriteList[Unknown]`, which it was happy to assign to `Iterable[SpriteType]`.