### PR TITLE
Fix UIMessageBox title

### DIFF
--- a/arcade/gui/constructs.py
+++ b/arcade/gui/constructs.py
@@ -29,6 +29,7 @@ class UIMessageBox(UIMouseFilterMixin, UIAnchorLayout):
       width: Width of the message box
       height: Height of the message box
       message_text: Text to show as message to the user
+      title: Title of the message box, displayed on the top
       buttons: List of strings, which are shown as buttons
 
     """
@@ -68,7 +69,7 @@ class UIMessageBox(UIMouseFilterMixin, UIAnchorLayout):
         if title:
             title_label = frame.add(
                 child=UILabel(
-                    text="Message",
+                    text=title,
                     font_size=16,
                     size_hint=(1, 0),
                     align="center",


### PR DESCRIPTION
- Add title as argument in docstring
- Use the title argument as the title UILabel's text instead of always setting it to "Message"