### PR TITLE
Fix typo in Install section of docs

### DIFF
--- a/doc/get_started/install.rst
+++ b/doc/get_started/install.rst
@@ -29,7 +29,7 @@ In general, even older convertible Windows tablets will work as long as they:
 
 .. note:: ARM-based Windows or Linux tablets may have issues.
 
-          These devices may or may not work.  the :ref:`requirements_raspi`
+          See the section on the :ref:`requirements_raspi` below.
 
 Windows
 """""""


### PR DESCRIPTION
Closes #2584

The line in the green note

```
These devices may or may not work. the Raspberry Pi and Other ARM SBCs
```

has been changed to 

```
See the section on the Raspberry Pi and Other ARM SBCs below.
```

Output screenshot:
![image](https://github.com/user-attachments/assets/a5894dd1-ee6b-4f9b-ad28-fe598cce2e44)
