### PR TITLE
Restored alt text + links for shields in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # Welcome to The Arcade Library!
 
 <p align="center">
-    <img src="https://img.shields.io/pypi/l/arcade">
-    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="http://makeapullrequest.com">
-    <img src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" alt=http://www.firsttimersonly.com/">
+    <a href="https://img.shields.io/pypi/l/arcade">
+        <img alt="MIT License" title="MIT License" src="https://img.shields.io/pypi/l/arcade">
+    </a>
+    <a href="http://makeapullrequest.com">
+        <img alt="Pull Requests Welcome" title="Pull Requests Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" />
+    </a>
+    <a href="http://www.firsttimersonly.com/">
+        <img alt="First Timers Friendly" title="First Timers Friendly" src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg" />
+    </a>
 </p>
 
 Arcade is an easy-to-learn Python library for creating 2D video games.
@@ -18,10 +24,18 @@ for example game jam entries and more.
 [Arcade Discord Server]: https://discord.gg/ZjGDqMp
 
 <p align="center">
-    <img src="https://img.shields.io/pypi/dm/arcade">
-    <img src="https://img.shields.io/github/commit-activity/m/pythonarcade/arcade">
-    <img src="https://img.shields.io/github/contributors/pythonarcade/arcade">
-    <img src="https://img.shields.io/github/stars/pythonarcade/arcade">
+    <a href="https://img.shields.io/pypi/dm/arcade">
+        <img alt="PyPI - Downloads" title="PyPI - Downloads" src="https://img.shields.io/pypi/dm/arcade">
+    </a>
+    <a href="https://img.shields.io/github/commit-activity/m/pythonarcade/arcade">
+        <img alt="GitHub Commit Activity" title="GitHub Commit Activity" src="https://img.shields.io/github/commit-activity/m/pythonarcade/arcade">
+    </a>
+    <a href="https://img.shields.io/github/contributors/pythonarcade/arcade">
+        <img alt="GitHub Contributors" title="GitHub Contributors" src="https://img.shields.io/github/contributors/pythonarcade/arcade">
+    </a>
+    <a href="https://img.shields.io/github/stars/pythonarcade/arcade">
+        <img alt="GitHub Stars" title="GitHub Stars" src="https://img.shields.io/github/stars/pythonarcade/arcade">
+    </a>
 </p>
 
 ## Stable Documentation


### PR DESCRIPTION
Fix issue #2588 

- added explicit `<a href>` tag around shield images.
- added alt and title to enable text hover.
- added back missing hover text.
- added hover text for "GitHub Contributors" and "GitHub Stars".

Note that I've added both alt and text. Under Firefox, alt is not enough to cause text to hover (https://support.mozilla.org/en-US/questions/838888).