### PR TITLE
Bandaid fix for link to pyglet module not working

### DIFF
--- a/doc/get_started/install.rst
+++ b/doc/get_started/install.rst
@@ -10,9 +10,12 @@ Install
 
 Requirements
 ------------
-:mod:`pyglet`
+Arcade requires a desktop, laptop, or compatible Single-Board Computer (SBC) with:
 
-All systems require Python 3.9 or higher on a desktop or laptop device.
+#. Python 3.9 or higher
+#. Graphics drivers with support for either:
+    * OpenGL 3.3+
+    * GLES 3.1+ with extensions on SBCs
 
 :ref:`Web <faq_web>` and :ref:`mobile <faq_mobile>` are currently
 unsupported.


### PR DESCRIPTION
A temporary solution is implemented here to just remove the link to `pyglet` for now and instead say that you need to have graphics drivers with support for OpenGL or GLES.

Closes #2585

![image](https://github.com/user-attachments/assets/ed753124-d580-4a97-90ed-e9a6bb7da0e1)
