### PR TITLE
Fix  pushing keyboard and mouse to the same stack level

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -314,7 +314,8 @@ class Window(pyglet.window.Window):
 
             else:
                 self.mouse = pyglet.window.mouse.MouseStateHandler()
-                self.push_handlers(self.keyboard, self.mouse)
+                self.push_handlers(self.keyboard)
+                self.push_handlers(self.mouse)
         else:
             self.keyboard = None
             self.mouse = None


### PR DESCRIPTION
The push_handlers function is used incorrectly. It only pushes a single stack level, meaning mouse and keyboard override each other. This means, their shared events, such as on_deactivate, will only be triggered by the last option, which is mouse here. This causes the keyboard to ignore the on_deactivate event. This fixes that issue by pushing 2 times to different levels.