### PR TITLE
Remove unnecessary debug print from NinePatch

### DIFF
--- a/arcade/gui/nine_patch.py
+++ b/arcade/gui/nine_patch.py
@@ -113,7 +113,6 @@ class NinePatchTexture:
         self._atlas = self._custom_atlas or self._ctx.default_atlas
         self._add_to_atlas(self.texture)
 
-        print("NinePatchTexture initialized")
         self._initialized = True
 
     def initialize(self) -> None:


### PR DESCRIPTION
Removes the unnecessary `NinePatchTexture initialized` print from NinePatchTexture. This was accidentally kept in the code.