### PR TITLE
Fix #2658: Use `is not None` for `boundary_left` and `boundary_right`.

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -792,12 +792,18 @@ class PhysicsEnginePlatformer:
             for platform in platform_list:
                 if platform.change_x != 0 or platform.change_y != 0:
                     # Check x boundaries and move the platform in x direction
-                    if platform.boundary_left and platform.left <= platform.boundary_left:
+                    if (
+                        platform.boundary_left is not None
+                        and platform.left <= platform.boundary_left
+                    ):
                         platform.left = platform.boundary_left
                         if platform.change_x < 0:
                             platform.change_x *= -1
 
-                    if platform.boundary_right and platform.right >= platform.boundary_right:
+                    if (
+                        platform.boundary_right is not None
+                        and platform.right >= platform.boundary_right
+                    ):
                         platform.right = platform.boundary_right
                         if platform.change_x > 0:
                             platform.change_x *= -1

--- a/tests/unit/physics_engine/test_physics_engine_platformer.py
+++ b/tests/unit/physics_engine/test_physics_engine_platformer.py
@@ -26,9 +26,22 @@ def test_physics_engine(window):
         sprite.center_y = 32
         wall_list.append(sprite)
 
+    platform_list = arcade.SpriteList[arcade.Sprite]()
+    platform = arcade.Sprite(
+        ":resources:images/tiles/boxCrate_double.png",
+        scale=CHARACTER_SCALING,
+        center_x=64,
+        center_y=256,
+    )
+    platform.boundary_left = 0 # 0 in particular was problematic, see #2658
+    platform.boundary_right = 128
+    platform.change_x = 8
+    platform_list.append(platform)
+
     physics_engine = arcade.PhysicsEnginePlatformer(
         character_sprite,
-        wall_list,
+        walls=wall_list,
+        platforms=platform_list,
         gravity_constant=GRAVITY,
     )
 
@@ -48,10 +61,23 @@ def test_physics_engine(window):
     assert physics_engine.can_jump() is True
     character_sprite.change_y = 15
     physics_engine.increment_jump_counter()
-    window.test()
+
+    window.test(frames=7)
+
     assert physics_engine.can_jump() is True
+    assert platform.center_x == 80 # it bounced against the boundary_right
+    assert platform.change_x == -8
     character_sprite.change_y = 15
     physics_engine.increment_jump_counter()
-    window.test()
+
+    window.test(frames=6)
+
     assert physics_engine.can_jump() is False
+    assert platform.center_x == 32 # right at the boundary
+    assert platform.change_x == -8 # still going left
     physics_engine.disable_multi_jump()
+
+    window.test(frames=3)
+
+    assert platform.center_x == 32 + 24 # it bounced against the boundary_left
+    assert platform.change_x == +8


### PR DESCRIPTION
Like was already done for `boundary_top` and `boundary_bottom`.