### PR TITLE
Fix ScrollArea redrawing every frame

### DIFF
--- a/arcade/gui/experimental/scroll_area.py
+++ b/arcade/gui/experimental/scroll_area.py
@@ -326,6 +326,7 @@ class UIScrollArea(UILayout):
             self.do_render_base(surface)
             self.do_render(surface)
             self._rendered = True
+            self._requires_render = False
 
         return rendered
 


### PR DESCRIPTION
The _requires_render property was not reset to False after rendering. This caused the UIScrollArea to re-render every frame.