### PR TITLE
Add method for syncing a Sprite's hitbox to it's pymunk Shape

### DIFF
--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -600,6 +600,31 @@ class PymunkPhysicsEngine:
         if separate_handler:
             h.separate = _f4
 
+    def update_sprite(self, sprite: Sprite) -> None:
+        """
+        Updates a Sprite's Shape to match it's current hitbox
+
+        Args:
+            sprite: The Sprite to update
+        """
+        physics_object = self.sprites[sprite]
+        old_shape = physics_object.shape
+        assert old_shape is not None, "Tried to update the shape for a Sprite which does not currently have a shape"
+
+        # Set the physics shape to the sprite's hitbox
+        poly = sprite.hit_box.points
+        scaled_poly = [[x * sprite.scale_x for x in z] for z in poly]
+        shape = pymunk.Poly(physics_object.body, scaled_poly, radius=old_shape.radius)  # type: ignore
+
+        shape.collision_type = old_shape.collision_type
+        shape.elasticity = old_shape.elasticity
+        shape.friction = old_shape.friction
+
+        self.space.remove(old_shape)
+        self.space.add(shape)
+        physics_object.shape = shape
+
+
     def resync_sprites(self) -> None:
         """
         Set visual sprites to be the same location as physics engine sprites.

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -609,7 +609,9 @@ class PymunkPhysicsEngine:
         """
         physics_object = self.sprites[sprite]
         old_shape = physics_object.shape
-        assert old_shape is not None, "Tried to update the shape for a Sprite which does not currently have a shape"
+        assert old_shape is not None, """
+        Tried to update the shape for a Sprite which does not currently have a shape
+        """
 
         # Set the physics shape to the sprite's hitbox
         poly = sprite.hit_box.points

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -626,7 +626,6 @@ class PymunkPhysicsEngine:
         self.space.add(shape)
         physics_object.shape = shape
 
-
     def resync_sprites(self) -> None:
         """
         Set visual sprites to be the same location as physics engine sprites.


### PR DESCRIPTION
Previously if you updated the texture of a Sprite(and in turn, it's hitbox) or just updated the hitbox of the sprite through any means. This change does not propagate to Pymunk when using the builtin pymunk physics engine. In order to make this happen currently you need to remove and re-add the sprite to the engine, which is a costly operation.

This adds a new method to the physics engine for triggering an update of a sprite. Which generates a new Pymunk shape based on the current hitbox of the sprite, and replaces the existing shape with it. This should be much less costly then fully removing/re-adding the Sprite.

Currently this is not automatically triggered so it's still up to the user on calling this function to update the sprite, open to ideas on how this can be triggered automatically when the Sprite's hitbox is synced to the texture for example.