### PR TITLE
Fix: Remove unnecessary vertical scrollbar (Resolves #2686)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,10 +254,10 @@ language.
 On Linux distros based on Debian and Ubuntu, you may need to install
 the following packages to build PDFs:
 
-``console
+```console
 sudo apt install latexmk
 sudo apt install texlive-latex-extra
-``
+```
 To reduce the large (300 MB+) install size of the second package, you
 may be able to use the `--no-install-recommends` flag.
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -293,6 +293,10 @@ table.resource-table td > .resource-thumb.file-icon {
     /* Not clear why this doesn't work for the .caption-text */
     font-size: 1em !important;
 }
+.resource-handle > .literal {
+    /* Removes the verticle scroll when you zoom out more than 100% */
+    overflow-y: hidden;
+}
 
 
 /* Imitate sphinx-copybutton style */


### PR DESCRIPTION
Remove the vertical scrollbar that appears when you zoom out beyond 100%