### PR TITLE
Fix #2727: Only handle space key events when there is a focused widget

### DIFF
--- a/arcade/gui/experimental/focus.py
+++ b/arcade/gui/experimental/focus.py
@@ -100,12 +100,12 @@ class UIFocusMixin(UIWidget):
 
                 return EVENT_HANDLED
 
-            elif event.symbol == arcade.key.SPACE:
+            elif event.symbol == arcade.key.SPACE and self.focused_widget is not None:
                 self._start_interaction()
                 return EVENT_HANDLED
 
         elif isinstance(event, UIKeyReleaseEvent):
-            if event.symbol == arcade.key.SPACE:
+            if event.symbol == arcade.key.SPACE and self.focused_widget is not None:
                 self._end_interaction()
                 return EVENT_HANDLED
 


### PR DESCRIPTION
Fixes #2727

## Changes
- Modified `UIFocusMixin` to only handle space key events when there is a focused widget
- Added checks for `self.focused_widget is not None` to both key press and key release handlers
- This ensures space key events are only captured when appropriate and passed through otherwise

## Testing
- Verified that space key events are only handled when there is a focused widget
- Confirmed that space key events are passed through when no widget is focused
- Tested both key press and key release events