### PR TITLE
Fix line highlights in sprite_move_animation.rst

### DIFF
--- a/doc/example_code/sprite_move_animation.rst
+++ b/doc/example_code/sprite_move_animation.rst
@@ -13,4 +13,4 @@ Move with a Sprite Animation
 .. literalinclude:: ../../arcade/examples/sprite_move_animation.py
     :caption: sprite_move_animation.py
     :linenos:
-    :emphasize-lines: 22-28, 31-38, 47-76, 78-97, 184-185
+    :emphasize-lines: 22-28, 31-39, 48-67, 77-106


### PR DESCRIPTION
**TL;DR:** Fixed highlights that hadn't been updated

### What's Broken?

Before:

| Before |  After |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/9fa1cd96-c501-46ca-bcc0-bf569b60737a) | ![image](https://github.com/user-attachments/assets/d25a6db4-b9f0-4e4b-a313-e877a12ce3fa) |
| ![image](https://github.com/user-attachments/assets/0bd8db41-f1aa-4c26-a5fb-ba5d7bb750a4) | ![image](https://github.com/user-attachments/assets/c5f1d39e-9019-4723-a53b-3229f3bf58d1) |
| ![image](https://github.com/user-attachments/assets/91d831d7-4e72-41f1-9f76-bf78002827f0) | ![image](https://github.com/user-attachments/assets/6dec9946-4db6-40ef-af04-3ccb9e3fb196) |
| ![image](https://github.com/user-attachments/assets/96fec67b-d418-4236-8965-f4bd7c744bc4) | ![image](https://github.com/user-attachments/assets/34e06b61-af94-4fff-90b9-7e7129c45759) |
