### PR TITLE
Update the arcade window so it resets gl context properly everyframe.

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -553,6 +553,8 @@ class Window(pyglet.window.Window):
 
             # In case the window close in on_update, on_fixed_update or input callbacks
             if not self.closed:
+                # Reset the context, camera, and active framebuffer.
+                self._ctx.reset()
                 self.draw(self._accumulated_draw_time)
             self._accumulated_draw_time %= self._draw_rate
 

--- a/arcade/camera/__init__.py
+++ b/arcade/camera/__init__.py
@@ -3,7 +3,7 @@ The Camera Types, Classes, and Methods of Arcade.
 Providing a multitude of camera's for any need.
 """
 
-from arcade.camera.data_types import (
+from .data_types import (
     Projection,
     Projector,
     CameraData,
@@ -11,7 +11,7 @@ from arcade.camera.data_types import (
     PerspectiveProjectionData,
 )
 
-from arcade.camera.projection_functions import (
+from .projection_functions import (
     generate_view_matrix,
     generate_orthographic_matrix,
     generate_perspective_matrix,
@@ -21,10 +21,10 @@ from arcade.camera.projection_functions import (
     unproject_perspective,
 )
 
-from arcade.camera.orthographic import OrthographicProjector
-from arcade.camera.perspective import PerspectiveProjector
-
-from arcade.camera.camera_2d import Camera2D
+from .viewport import ViewportProjector
+from .orthographic import OrthographicProjector
+from .perspective import PerspectiveProjector
+from .camera_2d import Camera2D
 
 import arcade.camera.grips as grips
 
@@ -32,6 +32,7 @@ import arcade.camera.grips as grips
 __all__ = [
     "Projection",
     "Projector",
+    "ViewportProjector",
     "CameraData",
     "generate_view_matrix",
     "OrthographicProjectionData",

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pyglet.math import Mat4
+
 from arcade.types import LBWH
 
 from .viewport import ViewportProjector

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -1,107 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from pyglet.math import Mat4, Vec2, Vec3
-from typing_extensions import Self
+from pyglet.math import Mat4
+from arcade.types import LBWH
 
-from arcade.types import LBWH, Point, Rect
-from arcade.window_commands import get_window
+from .viewport import ViewportProjector
 
 if TYPE_CHECKING:
     from arcade.context import ArcadeContext
 
-__all__ = ["ViewportProjector", "DefaultProjector"]
+__all__ = ("DefaultProjector",)
 
 
-class ViewportProjector:
-    """
-    A simple Projector which does not rely on any camera PoDs.
-
-    Does not have a way of moving, rotating, or zooming the camera.
-    perfect for something like UI or for mapping to an offscreen framebuffer.
-
-    Args:
-        viewport: The viewport to project to.
-        context: The window context to bind the camera to. Defaults to the currently active window.
-    """
-
-    def __init__(
-        self,
-        viewport: Rect | None = None,
-        *,
-        context: ArcadeContext | None = None,
-    ):
-        self._ctx: ArcadeContext = context or get_window().ctx
-        self._viewport: Rect = viewport or LBWH(*self._ctx.viewport)
-        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
-            0.0, self._viewport.width, 0.0, self._viewport.height, -100, 100
-        )
-
-    @property
-    def viewport(self) -> Rect:
-        """
-        The viewport use to derive projection and view matrix.
-        """
-        return self._viewport
-
-    @viewport.setter
-    def viewport(self, viewport: Rect) -> None:
-        self._viewport = viewport
-        self._projection_matrix = Mat4.orthogonal_projection(
-            0, viewport.width, 0, viewport.height, -100, 100
-        )
-
-    def use(self) -> None:
-        """
-        Set the window's projection and view matrix.
-        Also sets the projector as the windows current camera.
-        """
-        self._ctx.current_camera = self
-
-        self._ctx.viewport = self.viewport.lbwh_int  # get the integer 4-tuple LBWH
-
-        self._ctx.view_matrix = Mat4()
-        self._ctx.projection_matrix = self._projection_matrix
-
-    @contextmanager
-    def activate(self) -> Generator[Self, None, None]:
-        """
-        The context manager version of the use method.
-
-        usable with the 'with' block. e.g. 'with ViewportProjector.activate() as cam: ...'
-        """
-        previous = self._ctx.current_camera
-        try:
-            self.use()
-            yield self
-        finally:
-            previous.use()
-
-    def project(self, world_coordinate: Point) -> Vec2:
-        """
-        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
-        """
-        x, y, *z = world_coordinate
-        return Vec2(x, y)
-
-    def unproject(self, screen_coordinate: Point) -> Vec3:
-        """
-        Map the screen pos to screen_coordinates.
-
-        Due to the nature of viewport projector this does not do anything.
-        """
-        x, y, *_z = screen_coordinate
-        z = 0.0 if not _z else _z[0]
-
-        return Vec3(x, y, z)
-
-
-# As this class is only supposed to be used internally
-# I wanted to place an _ in front, but the linting complains
-# about it being a protected class.
 class DefaultProjector(ViewportProjector):
     """
     An extremely limited projector which lacks any kind of control. This is only

--- a/arcade/camera/viewport.py
+++ b/arcade/camera/viewport.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from pyglet.math import Mat4, Vec2, Vec3
+from typing_extensions import Self
+
+from arcade.types import LBWH, Point, Rect
+from arcade.window_commands import get_window
+
+if TYPE_CHECKING:
+    from arcade.context import ArcadeContext
+
+__all__ = ("ViewportProjector",)
+
+class ViewportProjector:
+    """
+    A simple Projector which does not rely on any camera PoDs.
+
+    Does not have a way of moving, rotating, or zooming the camera.
+    perfect for something like UI or for mapping to an offscreen framebuffer.
+
+    Args:
+        viewport: The viewport to project to.
+        context: The window context to bind the camera to. Defaults to the currently active window.
+    """
+
+    def __init__(
+        self,
+        viewport: Rect | None = None,
+        *,
+        context: ArcadeContext | None = None,
+    ):
+        self._ctx: ArcadeContext = context or get_window().ctx
+        self._viewport: Rect = viewport or LBWH(*self._ctx.viewport)
+        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
+            0.0, self._viewport.width, 0.0, self._viewport.height, -100, 100
+        )
+
+    @property
+    def viewport(self) -> Rect:
+        """
+        The viewport use to derive projection and view matrix.
+        """
+        return self._viewport
+
+    @viewport.setter
+    def viewport(self, viewport: Rect) -> None:
+        self._viewport = viewport
+        self._projection_matrix = Mat4.orthogonal_projection(
+            0, viewport.width, 0, viewport.height, -100, 100
+        )
+
+    def use(self) -> None:
+        """
+        Set the window's projection and view matrix.
+        Also sets the projector as the windows current camera.
+        """
+        self._ctx.current_camera = self
+
+        self._ctx.viewport = self.viewport.lbwh_int  # get the integer 4-tuple LBWH
+
+        self._ctx.view_matrix = Mat4()
+        self._ctx.projection_matrix = self._projection_matrix
+
+    @contextmanager
+    def activate(self) -> Generator[Self, None, None]:
+        """
+        The context manager version of the use method.
+
+        usable with the 'with' block. e.g. 'with ViewportProjector.activate() as cam: ...'
+        """
+        previous = self._ctx.current_camera
+        try:
+            self.use()
+            yield self
+        finally:
+            previous.use()
+
+    def project(self, world_coordinate: Point) -> Vec2:
+        """
+        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
+        """
+        x, y, *z = world_coordinate
+        return Vec2(x, y)
+
+    def unproject(self, screen_coordinate: Point) -> Vec3:
+        """
+        Map the screen pos to screen_coordinates.
+
+        Due to the nature of viewport projector this does not do anything.
+        """
+        x, y, *_z = screen_coordinate
+        z = 0.0 if not _z else _z[0]
+
+        return Vec3(x, y, z)

--- a/arcade/camera/viewport.py
+++ b/arcade/camera/viewport.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 __all__ = ("ViewportProjector",)
 
+
 class ViewportProjector:
     """
     A simple Projector which does not rely on any camera PoDs.

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -56,6 +56,7 @@ class ArcadeContext(Context):
         gc_mode: str = "context_gc",
         gl_api: str = "gl",
     ) -> None:
+        
         super().__init__(window, gc_mode=gc_mode, gl_api=gl_api)
 
         # Set up a default orthogonal projection for sprites and shapes
@@ -68,6 +69,7 @@ class ArcadeContext(Context):
         self.current_camera: Projector = self._default_camera
 
         self.viewport = (0, 0, window.width, window.height)
+        
 
         # --- Pre-load system shaders here ---
         # FIXME: These pre-created resources needs to be packaged nicely
@@ -311,10 +313,7 @@ class ArcadeContext(Context):
         self.bind_window_block()
         # self.active_program = None
         self.viewport = 0, 0, self.window.width, self.window.height
-        self.view_matrix = Mat4()
-        self.projection_matrix = Mat4.orthogonal_projection(
-            0, self.window.width, 0, self.window.height, -100, 100
-        )
+        self._default_camera.use()
         self.enable_only(self.BLEND)
         self.blend_func = self.BLEND_DEFAULT
         self.point_size = 1.0
@@ -356,7 +355,7 @@ class ArcadeContext(Context):
             )
 
         return self._atlas
-
+ 
     @property
     def viewport(self) -> tuple[int, int, int, int]:
         """
@@ -378,7 +377,7 @@ class ArcadeContext(Context):
     @viewport.setter
     def viewport(self, value: tuple[int, int, int, int]):
         self.active_framebuffer.viewport = value
-        if self._default_camera == self.current_camera:
+        if self._default_camera is self.current_camera:
             self._default_camera.use()
 
     @property

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -56,7 +56,6 @@ class ArcadeContext(Context):
         gc_mode: str = "context_gc",
         gl_api: str = "gl",
     ) -> None:
-        
         super().__init__(window, gc_mode=gc_mode, gl_api=gl_api)
 
         # Set up a default orthogonal projection for sprites and shapes
@@ -69,7 +68,6 @@ class ArcadeContext(Context):
         self.current_camera: Projector = self._default_camera
 
         self.viewport = (0, 0, window.width, window.height)
-        
 
         # --- Pre-load system shaders here ---
         # FIXME: These pre-created resources needs to be packaged nicely
@@ -355,7 +353,7 @@ class ArcadeContext(Context):
             )
 
         return self._atlas
- 
+
     @property
     def viewport(self) -> tuple[int, int, int, int]:
         """

--- a/arcade/gl/framebuffer.py
+++ b/arcade/gl/framebuffer.py
@@ -225,6 +225,9 @@ class Framebuffer(ABC):
         self._use(force=force)
         self._ctx.active_framebuffer = self
 
+        # This is a hack to ensure the default camera has the correct viewport.
+        self._ctx.viewport = self.viewport
+
     @abstractmethod
     def _use(self, *, force: bool = False):
         """Internal use that do not change the global active framebuffer"""


### PR DESCRIPTION
This was discussed a while ago as part of the 3.0 changes. I put it off so that 3.0 could be released, and because there were larger issues with it to be solved. _That work still needs doing_. 

The `ArcadeContext` reset method used by unit tests did not work well. It has now been updated to use the default camera rather than setting the `Projection` and `View` matrices manually.

The GL state was not being reset before every `on_draw` dispatch. This PR makes it so the gl state is reset, the screen's framebuffer is active, and the default camera is the active before every `on_draw`. The consequences of this change on examples and unit tests should be checked before the PR is merged.