### PR TITLE
Add method 0 for auto-select to check_for_collision_with_lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Arcade [PyPi Release History](https://pypi.org/project/arcade/#history) page.
 
 ## Unreleased
 
+- Fixes a bug with the `check_for_collision_with_lists` function. This function is intended to mimic the functionality of
+  `check_for_collision_with_list` but allow passing multiple lists and looping the same behavior. The `lists` function however
+  handled the collision method differently. Which resulted in only spatial hash being used if it was available, or GPU collision.
+  It would never fallback to the pure CPU brute force approach, which is the best option for spritelists which don't have spatial hash
+  and less than 1,500 sprites. Certain games may see a substantial performance improvement from this change.
+
 - PyInstaller
   - Fixed an issue where imports for backends for the `arcade.gl` package could not be discovered by PyInstaller.
     Since 3.3.0 users have needed to add these hidden imports via the pyinstaller CLI in order for Arcade to work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Arcade [PyPi Release History](https://pypi.org/project/arcade/#history) page.
   `check_for_collision_with_list` but allow passing multiple lists and looping the same behavior. The `lists` function however
   handled the collision method differently. Which resulted in only spatial hash being used if it was available, or GPU collision.
   It would never fallback to the pure CPU brute force approach, which is the best option for spritelists which don't have spatial hash
-  and less than 1,500 sprites. Certain games may see a substantial performance improvement from this change.
+  and less than 1,500 sprites. Certain games may see a substantial performance improvement from this change. See [2762](https://github.com/pythonarcade/arcade/pull/2762)
 
 - PyInstaller
   - Fixed an issue where imports for backends for the `arcade.gl` package could not be discovered by PyInstaller.

--- a/arcade/sprite_list/collision.py
+++ b/arcade/sprite_list/collision.py
@@ -196,7 +196,7 @@ def check_for_collision_with_list(
 def check_for_collision_with_lists(
     sprite: BasicSprite,
     sprite_lists: Iterable[SpriteSequence[SpriteType]],
-    method=1,
+    method=0,
 ) -> list[SpriteType]:
     """
     Check for a collision between a Sprite, and a list of SpriteLists.
@@ -207,8 +207,16 @@ def check_for_collision_with_lists(
         sprite_lists:
             SpriteLists to check against
         method:
-            Collision check method. 1 is Spatial Hashing if available,
-            2 is GPU based, 3 is slow CPU-bound check-everything. Defaults to 1.
+            Collision check method. Defaults to 0.
+
+            - 0: auto-select. (spatial if available, GPU if 1500+ sprites, else simple)
+            - 1: Spatial Hashing if available,
+            - 2: GPU based
+            - 3: Simple check-everything.
+
+            Note that while the GPU method is very fast when you cannot use spatial hashing,
+            it's also very slow if you are calling this function many times per frame.
+            What method is the most appropriate depends entirely on your use case.
 
     Returns:
         List of sprites colliding, or an empty list.
@@ -224,9 +232,10 @@ def check_for_collision_with_lists(
     sprites_to_check: Iterable[SpriteType]
 
     for sprite_list in sprite_lists:
-        if sprite_list.spatial_hash is not None and method == 1:
+        # Spatial
+        if sprite_list.spatial_hash is not None and (method == 1 or method == 0):
             sprites_to_check = sprite_list.spatial_hash.get_sprites_near_sprite(sprite)
-        elif method == 3:
+        elif method == 3 or (method == 0 and len(sprite_list) <= 1500):
             sprites_to_check = sprite_list
         else:
             # GPU transform


### PR DESCRIPTION
The `check_for_collision_with_lists` function had different behavior than `check_for_collision_with_list`.

By default in the non nested version of the function we use `method=0` which performs an auto-select that say:

1. If spatial hashing is available, use it
2. If no spatial hashing, and the spritelist size is <1500 then use full CPU check for every sprite
3. If no spatial hashing, and the spritelist size is >1500 then use GPU collision

This auto-selection didn't exist in `check_for_collision_with_lists` and so would only ever use the selected mode, which by default was spatial hashing. However if the spatial hash wasn't available it would fallback to GPU collision, and only ever use the full CPU check if it was explicitly requested with `method=3`. GPU collision is very costly for small spritelists and only makes sense with large spritelists.

This adds the same auto-selection to each function.