### PR TITLE
Add GL backends to pyinstaller hidden imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Arcade [PyPi Release History](https://pypi.org/project/arcade/#history) page.
 
 ## Unreleased
 
+- PyInstaller
+  - Fixed an issue where imports for backends for the `arcade.gl` package could not be discovered by PyInstaller.
+    Since 3.3.0 users have needed to add these hidden imports via the pyinstaller CLI in order for Arcade to work.
+
 - GUI
   - Fix a bug, where the caret of UIInputText was misplaced after resizing the widget
   - Use incremental layout for UIScrollArea to improve performance of changing text

--- a/arcade/__pyinstaller/hook-arcade.py
+++ b/arcade/__pyinstaller/hook-arcade.py
@@ -22,6 +22,8 @@ if not is_win and not is_darwin and not is_unix:
         "Only Linux, Mac, and Windows are supported."
     )
 
+hiddenimports = ["arcade.gl.backends.opengl.provider", "arcade.gl.backends.opengl"]
+
 datas = []
 binaries = []
 


### PR DESCRIPTION
As part of doing the abstraction for the `arcade.gl` package, the backends were imported in a way that pyinstaller can't see the imports(dynamically importing backends through importlib). This means we need to inform pyinstaller of the hidden import in our hook.