### PR TITLE
Added center_x and center_y to SpriteCircle's constructor

### DIFF
--- a/arcade/sprite/colored.py
+++ b/arcade/sprite/colored.py
@@ -139,12 +139,24 @@ class SpriteCircle(Sprite):
         soft:
             If ``True``, the circle will fade from an opaque
             center to transparent edges.
+        center_x:
+            Initial x position of the sprite
+        center_y:
+            Initial y position of the sprite
     """
 
     # Local weak cache for textures to avoid creating multiple instances with the same configuration
     _texture_cache: WeakValueDictionary[tuple[int, RGBA255, bool], Texture] = WeakValueDictionary()
 
-    def __init__(self, radius: int, color: RGBA255, soft: bool = False, **kwargs):
+    def __init__(
+        self,
+        radius: int,
+        color: RGBA255,
+        soft: bool = False,
+        center_x: float = 0,
+        center_y: float = 0,
+        **kwargs,
+    ):
         radius = int(radius)
         diameter = radius * 2
 
@@ -168,5 +180,5 @@ class SpriteCircle(Sprite):
             self.__class__._texture_cache[cache_key] = texture
 
         # apply results to the new sprite
-        super().__init__(texture)
+        super().__init__(texture, center_x=center_x, center_y=center_y)
         self.color = Color.from_iterable(color)

--- a/tests/unit/sprite/test_sprite_colored.py
+++ b/tests/unit/sprite/test_sprite_colored.py
@@ -7,9 +7,11 @@ import arcade
 
 def test_sprite_circle_props():
     """Test basic properties of SpriteCircle"""
-    sprite = arcade.SpriteCircle(50, arcade.color.RED)
+    sprite = arcade.SpriteCircle(50, arcade.color.RED, center_x=5, center_y=7)
     assert sprite.color == arcade.color.RED
     assert sprite.size == (100, 100)
+    assert sprite.center_x == 5
+    assert sprite.center_y == 7
 
 
 def test_sprite_circle_texture_cache():


### PR DESCRIPTION
As requested in #2765, I added center_x and center_y to SpriteCircle's constructor.

Thanks @pushfoo for the clear instructions. 