### PR TITLE
Update examples to use SpriteCircle's new center_* keyword arguments

### DIFF
--- a/arcade/examples/conway_alpha.py
+++ b/arcade/examples/conway_alpha.py
@@ -10,6 +10,7 @@ python -m arcade.examples.conway_alpha
 """
 
 import arcade
+from arcade import SpriteCircle, SpriteList
 import random
 
 # Set how many rows and columns we will have
@@ -45,12 +46,12 @@ def create_grids(
     sprites.
     """
     # One dimensional list of all sprites in the two-dimensional sprite list
-    grid_sprites_one_dim = arcade.SpriteList()
+    grid_sprites_one_dim: SpriteList[SpriteCircle] = SpriteList()
 
     # This will be a two-dimensional grid of sprites to mirror the two
     # dimensional grid of numbers. This points to the SAME sprites that are
     # in grid_sprite_list, just in a 2d manner.
-    grid_sprites_two_dim = []
+    grid_sprites_two_dim: list[list[SpriteCircle]] = []
 
     # Calculate values we'll re-use below
     cell_width, cell_height = cell_size
@@ -63,12 +64,8 @@ def create_grids(
     center_offset_x = half_width + cell_margin
     center_offset_y = half_height + cell_margin
 
-    shared_kwargs = dict(
-        # Fit the cell into the box
-        radius=min(half_width, half_height),
-        color=ALIVE_COLOR,
-        soft=True,
-    )
+    # Fit sprites into the cell size
+    radius = min(half_width, half_height)
 
     # Create a list of sprites to represent each grid location
     for row in range(ROW_COUNT):
@@ -80,7 +77,7 @@ def create_grids(
             y = row * y_step + center_offset_y
 
             # Make the sprite as a soft circle
-            sprite = arcade.SpriteCircle(center_x=x, center_y=y, **shared_kwargs)
+            sprite = SpriteCircle(radius, ALIVE_COLOR, True, center_x=x, center_y=y)
 
             # Add the sprite to both lists
             grid_sprites_one_dim.append(sprite)

--- a/arcade/examples/conway_alpha.py
+++ b/arcade/examples/conway_alpha.py
@@ -8,6 +8,7 @@ After installing the `arcade` package version 2.4.4+, this program can be run by
 typing:
 python -m arcade.examples.conway_alpha
 """
+
 import arcade
 import random
 
@@ -35,7 +36,9 @@ ALPHA_ON = 255
 ALPHA_OFF = 0
 
 
-def create_grids():
+def create_grids(
+    cell_size: tuple[int, int] = (CELL_WIDTH, CELL_HEIGHT), cell_margin: int = CELL_MARGIN
+):
     """
     Create a 2D and 1D grid of sprites. We use the 1D SpriteList for drawing,
     and the 2D list for accessing via grid. Both lists point to the same set of
@@ -49,20 +52,35 @@ def create_grids():
     # in grid_sprite_list, just in a 2d manner.
     grid_sprites_two_dim = []
 
+    # Calculate values we'll re-use below
+    cell_width, cell_height = cell_size
+    half_width = cell_width // 2
+    half_height = cell_height // 2
+
+    x_step = cell_width + cell_margin
+    y_step = cell_height + cell_margin
+
+    center_offset_x = half_width + cell_margin
+    center_offset_y = half_height + cell_margin
+
+    shared_kwargs = dict(
+        # Fit the cell into the box
+        radius=min(half_width, half_height),
+        color=ALIVE_COLOR,
+        soft=True,
+    )
+
     # Create a list of sprites to represent each grid location
     for row in range(ROW_COUNT):
         grid_sprites_two_dim.append([])
 
         for column in range(COLUMN_COUNT):
+            # Position the sprite
+            x = column * x_step + center_offset_x
+            y = row * y_step + center_offset_y
 
             # Make the sprite as a soft circle
-            sprite = arcade.SpriteCircle(CELL_WIDTH // 2, ALIVE_COLOR, soft=True)
-
-            # Position the sprite
-            x = column * (CELL_WIDTH + CELL_MARGIN) + (CELL_WIDTH / 2 + CELL_MARGIN)
-            y = row * (CELL_HEIGHT + CELL_MARGIN) + (CELL_HEIGHT / 2 + CELL_MARGIN)
-            sprite.center_x = x
-            sprite.center_y = y
+            sprite = arcade.SpriteCircle(center_x=x, center_y=y, **shared_kwargs)
 
             # Add the sprite to both lists
             grid_sprites_one_dim.append(sprite)
@@ -72,7 +90,7 @@ def create_grids():
 
 
 def randomize_grid(grid: arcade.SpriteList):
-    """ Randomize the grid to alive/dead """
+    """Randomize the grid to alive/dead"""
     for cell in grid:
         pick = random.randrange(2)
         if pick:
@@ -106,24 +124,24 @@ class GameView(arcade.View):
         randomize_grid(self.layers_grid_sprites_one_dim[0])
 
     def reset(self):
-        """ Reset the grid """
+        """Reset the grid"""
         randomize_grid(self.layers_grid_sprites_one_dim[0])
 
     def on_draw(self):
-        """ Render the screen. """
+        """Render the screen."""
         # Clear all pixels in the window
         self.clear()
         self.layers_grid_sprites_one_dim[0].draw()
 
     def on_key_press(self, symbol: int, modifiers: int):
-        """ Handle key press events """
+        """Handle key press events"""
         if symbol == arcade.key.SPACE:
             self.reset()
         elif symbol == arcade.key.ESCAPE:
             self.window.close()
 
     def on_update(self, delta_time: float):
-        """ Update the grid """
+        """Update the grid"""
 
         # Flip layers
         if self.cur_layer == 0:
@@ -140,31 +158,37 @@ class GameView(arcade.View):
             for column in range(COLUMN_COUNT):
                 live_neighbors = 0
                 # -1 -1
-                if row > 0 and column > 0 \
-                        and layer1[row - 1][column - 1].alpha == ALPHA_ON:
+                if row > 0 and column > 0 and layer1[row - 1][column - 1].alpha == ALPHA_ON:
                     live_neighbors += 1
                 # -1  0
                 if row > 0 and layer1[row - 1][column].alpha == ALPHA_ON:
                     live_neighbors += 1
                 # -1 +1
-                if row > 0 and column < COLUMN_COUNT - 1\
-                        and layer1[row - 1][column + 1].alpha == ALPHA_ON:
+                if (
+                    row > 0
+                    and column < COLUMN_COUNT - 1
+                    and layer1[row - 1][column + 1].alpha == ALPHA_ON
+                ):
                     live_neighbors += 1
                 #  0 +1
-                if column < COLUMN_COUNT - 1 \
-                        and layer1[row][column + 1].alpha == ALPHA_ON:
+                if column < COLUMN_COUNT - 1 and layer1[row][column + 1].alpha == ALPHA_ON:
                     live_neighbors += 1
                 # +1 +1
-                if row < ROW_COUNT - 1 \
-                        and column < COLUMN_COUNT - 1 \
-                        and layer1[row + 1][column + 1].alpha == ALPHA_ON:
+                if (
+                    row < ROW_COUNT - 1
+                    and column < COLUMN_COUNT - 1
+                    and layer1[row + 1][column + 1].alpha == ALPHA_ON
+                ):
                     live_neighbors += 1
                 # +1  0
                 if row < ROW_COUNT - 1 and layer1[row + 1][column].alpha == ALPHA_ON:
                     live_neighbors += 1
                 # +1 -1
-                if row < ROW_COUNT - 1 and column > 0 \
-                        and layer1[row + 1][column - 1].alpha == ALPHA_ON:
+                if (
+                    row < ROW_COUNT - 1
+                    and column > 0
+                    and layer1[row + 1][column - 1].alpha == ALPHA_ON
+                ):
                     live_neighbors += 1
                 #  0 -1
                 if column > 0 and layer1[row][column - 1].alpha == ALPHA_ON:
@@ -194,7 +218,7 @@ class GameView(arcade.View):
 
 
 def main():
-    """ Main function """
+    """Main function"""
     # Create a window class. This is what actually shows up on screen
     window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
     window.center_window()

--- a/arcade/examples/easing_example_1.py
+++ b/arcade/examples/easing_example_1.py
@@ -10,6 +10,7 @@ See example 2 for how to use easings for angles.
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.examples.easing_example_1
 """
+
 import arcade
 from arcade import easing
 from arcade.types import Color
@@ -34,13 +35,13 @@ TIME = 3.0
 
 
 class EasingCircle(arcade.SpriteCircle):
-    """ Player class """
+    """Player class"""
 
-    def __init__(self, radius, color):
-        """ Set up the player """
+    def __init__(self, radius, color, center_x: float = 0, center_y: float = 0):
+        """Set up the player"""
 
         # Call the parent init
-        super().__init__(radius, color)
+        super().__init__(radius, color, center_x=center_x, center_y=center_y)
 
         self.easing_x_data = None
         self.easing_y_data = None
@@ -52,10 +53,12 @@ class EasingCircle(arcade.SpriteCircle):
                 x = X_START
                 if self.center_x < WINDOW_WIDTH / 2:
                     x = X_END
-                ex, ey = easing.ease_position(self.position,
-                                              (x, self.center_y),
-                                              rate=180,
-                                              ease_function=self.easing_x_data.ease_function)
+                ex, ey = easing.ease_position(
+                    self.position,
+                    (x, self.center_y),
+                    rate=180,
+                    ease_function=self.easing_x_data.ease_function,
+                )
                 self.easing_x_data = ex
 
         if self.easing_y_data is not None:
@@ -65,10 +68,10 @@ class EasingCircle(arcade.SpriteCircle):
 
 
 class GameView(arcade.View):
-    """ Main application class. """
+    """Main application class."""
 
     def __init__(self):
-        """ Initializer """
+        """Initializer"""
 
         # Call the parent class initializer
         super().__init__()
@@ -81,15 +84,16 @@ class GameView(arcade.View):
         self.lines = None
 
     def setup(self):
-        """ Set up the game and initialize the variables. """
+        """Set up the game and initialize the variables."""
 
         # Sprite lists
         self.ball_list = arcade.SpriteList()
         self.lines = arcade.shape_list.ShapeElementList()
+        color = Color.from_hex_string(BALL_COLOR)
+        shared_ball_kwargs = dict(radius=BALL_RADIUS, color=color)
 
         def create_ball(ball_y, ease_function):
-            ball = EasingCircle(BALL_RADIUS, Color.from_hex_string(BALL_COLOR))
-            ball.position = X_START, ball_y
+            ball = EasingCircle(**shared_ball_kwargs, center_x=X_START, center_y=ball_y)
             p1 = ball.position
             p2 = (X_END, ball_y)
             ex, ey = easing.ease_position(p1, p2, time=TIME, ease_function=ease_function)
@@ -100,9 +104,12 @@ class GameView(arcade.View):
 
         def create_line(line_y):
             line = arcade.shape_list.create_line(
-                X_START, line_y - BALL_RADIUS - LINE_WIDTH,
-                X_END, line_y - BALL_RADIUS,
-                line_color, line_width=LINE_WIDTH,
+                X_START,
+                line_y - BALL_RADIUS - LINE_WIDTH,
+                X_END,
+                line_y - BALL_RADIUS,
+                line_color,
+                line_width=LINE_WIDTH,
             )
             return line
 
@@ -161,7 +168,7 @@ class GameView(arcade.View):
         add_item(y, easing.ease_in_out_sin, "Ease in out sin")
 
     def on_draw(self):
-        """ Render the screen. """
+        """Render the screen."""
 
         # This command has to happen before we start drawing
         self.clear()
@@ -175,7 +182,7 @@ class GameView(arcade.View):
             text.draw()
 
     def on_update(self, delta_time):
-        """ Movement and game logic """
+        """Movement and game logic"""
 
         # Call update on all sprites (The sprites don't do much in this
         # example though.)
@@ -183,7 +190,7 @@ class GameView(arcade.View):
 
 
 def main():
-    """ Main function """
+    """Main function"""
     # Create a window class. This is what actually shows up on screen
     window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
 

--- a/arcade/examples/snow.py
+++ b/arcade/examples/snow.py
@@ -25,8 +25,8 @@ class Snowflake(arcade.SpriteCircle):
     Based on drawing filled-circles.
     """
 
-    def __init__(self, size, speed, drift):
-        super().__init__(size, arcade.color.WHITE)
+    def __init__(self, size, speed, drift, center_x: float = 0, center_y: float = 0):
+        super().__init__(size, arcade.color.WHITE, center_x=center_x, center_y=center_y)
         self.speed = speed
         self.drift = drift
 
@@ -37,7 +37,7 @@ class Snowflake(arcade.SpriteCircle):
             random.randrange(WINDOW_HEIGHT, WINDOW_HEIGHT + 100),
         )
 
-    def update(self, delta_time: float = 1/60) -> None:
+    def update(self, delta_time: float = 1 / 60) -> None:
         self.center_y -= self.speed * delta_time
 
         # Check if snowflake has fallen below screen
@@ -50,10 +50,10 @@ class Snowflake(arcade.SpriteCircle):
 
 
 class GameView(arcade.View):
-    """ Main application class. """
+    """Main application class."""
 
     def __init__(self):
-        """ Initializer """
+        """Initializer"""
         # Calls "__init__" of parent class (arcade.Window) to setup screen
         super().__init__()
 
@@ -66,24 +66,22 @@ class GameView(arcade.View):
         self.background_color = arcade.color.BLACK
 
     def start_snowfall(self):
-        """ Set up snowfall and initialize variables. """
+        """Set up snowfall and initialize variables."""
         for i in range(SNOWFLAKE_COUNT):
             # Create snowflake instance
             snowflake = Snowflake(
                 size=random.randrange(1, 4),
                 speed=random.randrange(20, 40),
                 drift=random.uniform(math.pi, math.pi * 2),
-            )
-            # Randomly position snowflake
-            snowflake.position = (
-                random.randrange(WINDOW_WIDTH),
-                random.randrange(WINDOW_HEIGHT + 200),
+                # Randomly position snowflake
+                center_x=random.randrange(WINDOW_WIDTH),
+                center_y=random.randrange(WINDOW_HEIGHT + 200),
             )
             # Add snowflake to snowflake list
             self.snowflake_list.append(snowflake)
 
     def on_draw(self):
-        """ Render the screen. """
+        """Render the screen."""
         # Clear the screen to the background color
         self.clear()
 
@@ -91,13 +89,13 @@ class GameView(arcade.View):
         self.snowflake_list.draw()
 
     def on_update(self, delta_time):
-        """ All the logic to move, and the game logic goes here. """
+        """All the logic to move, and the game logic goes here."""
         # Call update on all the snowflakes
         self.snowflake_list.update(delta_time)
 
 
 def main():
-    """ Main function """
+    """Main function"""
     # Create a window class. This is what actually shows up on screen
     window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
 


### PR DESCRIPTION
Follow-up to #2766:
- Use new `SpriteCircle` keyword arguments in examples (`center_x`, `center_y`)
- Use shared kwarg dictionaries to reduce verbosity
- Run `ruff format` on altered files
