### PR TITLE
Temp fix texture atlas issues from mypy 1.18.1

### DIFF
--- a/arcade/texture_atlas/atlas_default.py
+++ b/arcade/texture_atlas/atlas_default.py
@@ -375,7 +375,7 @@ class DefaultTextureAtlas(TextureAtlasBase):
                 texture.image_data.hash,
             )
             # Don't bother removing texture on program exit
-            finalizer_ref.atexit = False
+            finalizer_ref.atexit = False  # type: ignore
             self._finalizers_created += 1
 
         self._textures_added += 1


### PR DESCRIPTION
**TL;DR:** Temp fix default atlases for `mypy` 1.18.1+

If we don't do this, junior contributors will get confused when their PRs fail CI checks.

Per Discord:
> pushfoo: any risk in this?
> pushfoo: I don't see one but texture atlas is a little scary so I figured I should ask
> Clepto: Yeah probably fine
