### PR TITLE
Fixed math.py inconsistencies

### DIFF
--- a/arcade/draw/arc.py
+++ b/arcade/draw/arc.py
@@ -59,7 +59,7 @@ def draw_arc_filled(
         uncentered_point_list = unrotated_point_list
     else:
         uncentered_point_list = [
-            rotate_point(point[0], point[1], 0, 0, tilt_angle) for point in unrotated_point_list
+            rotate_point(point, (0, 0), tilt_angle) for point in unrotated_point_list
         ]
 
     point_list = [(point[0] + center_x, point[1] + center_y) for point in uncentered_point_list]
@@ -132,7 +132,7 @@ def draw_arc_outline(
         uncentered_point_list = unrotated_point_list
     else:
         uncentered_point_list = [
-            rotate_point(point[0], point[1], 0, 0, tilt_angle) for point in unrotated_point_list
+            rotate_point(point, (0, 0), tilt_angle) for point in unrotated_point_list
         ]
 
     point_list = [(point[0] + center_x, point[1] + center_y) for point in uncentered_point_list]

--- a/arcade/draw/rect.py
+++ b/arcade/draw/rect.py
@@ -349,16 +349,16 @@ def draw_rect_outline(
         )
     else:
         point_list = (
-            rotate_point(o_left   , o_top   , x, y, tilt_angle),
-            rotate_point(i_left   , i_top   , x, y, tilt_angle),
-            rotate_point(o_right  , o_top   , x, y, tilt_angle),
-            rotate_point(i_right  , i_top   , x, y, tilt_angle),
-            rotate_point(o_right  , o_bottom, x, y, tilt_angle),
-            rotate_point(i_right  , i_bottom, x, y, tilt_angle),
-            rotate_point(o_left   , o_bottom, x, y, tilt_angle),
-            rotate_point(i_left   , i_bottom, x, y, tilt_angle),
-            rotate_point(o_left   , o_top   , x, y, tilt_angle),
-            rotate_point(i_left   , i_top   , x, y, tilt_angle)
+            rotate_point((o_left   , o_top)   , (x, y), tilt_angle),
+            rotate_point((i_left   , i_top)   , (x, y), tilt_angle),
+            rotate_point((o_right  , o_top)   , (x, y), tilt_angle),
+            rotate_point((i_right  , i_top)   , (x, y), tilt_angle),
+            rotate_point((o_right  , o_bottom), (x, y), tilt_angle),
+            rotate_point((i_right  , i_bottom), (x, y), tilt_angle),
+            rotate_point((o_left   , o_bottom), (x, y), tilt_angle),
+            rotate_point((i_left   , i_bottom), (x, y), tilt_angle),
+            rotate_point((o_left   , o_top)   , (x, y), tilt_angle),
+            rotate_point((i_left   , i_top)   , (x, y), tilt_angle)
         )
     # fmt: on
     _generic_draw_line_strip(point_list, color, gl.TRIANGLE_STRIP)

--- a/arcade/easing.py
+++ b/arcade/easing.py
@@ -243,7 +243,7 @@ def ease_position(
     """
     Get an easing position
     """
-    distance = get_distance(start_position[0], start_position[1], end_position[0], end_position[1])
+    distance = get_distance(start_position, end_position)
 
     if rate is not None:
         time = distance / rate

--- a/arcade/examples/easing_example_2.py
+++ b/arcade/examples/easing_example_2.py
@@ -154,7 +154,7 @@ class GameView(arcade.View):
 
     def on_mouse_press(self, x: float, y: float, button: int, modifiers: int):
         angle = arcade.math.get_angle_degrees(
-            x1=self.player_sprite.position[0], y1=self.player_sprite.position[1], x2=x, y2=y
+            self.player_sprite.position, (x, y)
         )
         self.player_sprite.angle = angle
 

--- a/arcade/examples/sprite_rotate_around_tank.py
+++ b/arcade/examples/sprite_rotate_around_tank.py
@@ -71,11 +71,11 @@ class RotatingSprite(arcade.Sprite):
 
         # Move the sprite along a circle centered around the passed point
         self.position = rotate_point(
-            self.center_x, self.center_y,
-            point[0], point[1], degrees)
+            (self.center_x, self.center_y),
+            point, degrees) # type: ignore
 
     def face_point(self, point: Point):
-        self.angle = get_angle_degrees(*self.position, *point)
+        self.angle = get_angle_degrees(self.position, point) # type: ignore
 
 
 class GameView(arcade.View):
@@ -209,8 +209,8 @@ class GameView(arcade.View):
         self._correct = correct
         if correct:
             angle = get_angle_radians(
-                self.tank.center_y, self.tank.center_x,
-                self.mouse_pos[1], self.mouse_pos[0])
+                (self.tank.center_y, self.tank.center_x),
+                (self.mouse_pos[1], self.mouse_pos[0]))
 
             self.barrel.position = (
                 self.barrel.center_x + math.sin(angle) * TANK_BARREL_LENGTH_HALF,

--- a/arcade/examples/turn_and_move.py
+++ b/arcade/examples/turn_and_move.py
@@ -63,7 +63,7 @@ class Player(arcade.Sprite):
         # Do math to calculate how to get the sprite to the destination.
         # Calculation the angle in radians between the start points
         # and end points. This is the angle the player will travel.
-        target_angle = arcade.math.get_angle_degrees(start_x, start_y, dest_x, dest_y)
+        target_angle = arcade.math.get_angle_degrees((start_x, start_y), (dest_x, dest_y))
         current_angle = self.angle - IMAGE_ROTATION
 
         new_angle = arcade.math.lerp_angle(current_angle, target_angle, self.rot_speed)

--- a/arcade/math.py
+++ b/arcade/math.py
@@ -311,38 +311,32 @@ def rand_vec_magnitude(
     return vel.x, vel.y
 
 
-def get_distance(x1: float, y1: float, x2: float, y2: float) -> float:
+def get_distance(pos1: Point2, pos2: Point2) -> float:
     """
     Get the distance between two points.
 
     Args:
-        x1 (float): x coordinate of the first point
-        y1 (float): y coordinate of the first point
-        x2 (float): x coordinate of the second point
-        y2 (float): y coordinate of the second point
+        pos1 (Point2): the first point
+        pos2 (Point2): the second point
     """
-    return math.hypot(x1 - x2, y1 - y2)
+    return math.hypot(pos1[0] - pos2[0], pos1[1] - pos2[1])
 
 
 def rotate_point(
-    x: float,
-    y: float,
-    cx: float,
-    cy: float,
+    point: Point2,
+    center: Point2,
     angle_degrees: float,
 ) -> Point2:
     """
     Rotate a point around a center.
 
     Args:
-        x (float): x value of the point you want to rotate
-        y (float): y value of the point you want to rotate
-        cx (float): x value of the center point you want to rotate around
-        cy (float): y value of the center point you want to rotate around
+        point (Point2): the point you want to rotate
+        center (Point2): the center point you want to rotate around
         angle_degrees (float): Angle, in degrees, to rotate
     """
-    temp_x = x - cx
-    temp_y = y - cy
+    temp_x = point[0] - point[0]
+    temp_y = point[1] - center[1]
 
     # now apply rotation
     angle_radians = math.radians(angle_degrees)
@@ -352,8 +346,8 @@ def rotate_point(
     rotated_y = -temp_x * sin_angle + temp_y * cos_angle
 
     # translate back
-    x = round(rotated_x + cx, _PRECISION)
-    y = round(rotated_y + cy, _PRECISION)
+    x = round(rotated_x + center[0], _PRECISION)
+    y = round(rotated_y + center[1], _PRECISION)
 
     return x, y
 
@@ -424,34 +418,28 @@ def rotate_around_point(source: Point2, target: Point2, angle: float):
     return target[0] + dx, target[1] + dy
 
 
-def get_angle_degrees(x1: float, y1: float, x2: float, y2: float) -> float:
+def get_angle_degrees(pos1: Point2, pos2: Point2) -> float:
     """
     Get the angle in degrees between two points.
 
     Args:
-        x1 (float): x coordinate of the first point
-        y1 (float): y coordinate of the first point
-        x2 (float): x coordinate of the second point
-        y2 (float): y coordinate of the second point
+        pos1 (Point2): the first point
+        pos2 (Point2): the second point
     """
-    x_diff = x2 - x1
-    y_diff = y2 - y1
-    return -math.degrees(math.atan2(y_diff, x_diff))
+    return math.degrees(get_angle_radians(pos1, pos2))
 
 
-def get_angle_radians(x1: float, y1: float, x2: float, y2: float) -> float:
+def get_angle_radians(pos1: Point2, pos2: Point2) -> float:
     """
     Get the angle in radians between two points.
 
     Args:
-        x1 (float): x coordinate of the first point
-        y1 (float): y coordinate of the first point
-        x2 (float): x coordinate of the second point
-        y2 (float): y coordinate of the second point
+        pos1 (Point2): the first point
+        pos2 (Point2): the second point
     """
-    x_diff = x2 - x1
-    y_diff = y2 - y1
-    return math.atan2(x_diff, y_diff)
+    x_diff = pos2[0] - pos1[0]
+    y_diff = pos2[1] - pos1[1]
+    return math.atan2(y_diff, x_diff)
 
 
 def quaternion_rotation(axis: Point3, vector: Point3, angle: float) -> tuple[float, float, float]:

--- a/arcade/paths.py
+++ b/arcade/paths.py
@@ -413,7 +413,7 @@ def has_line_of_sight(
     if check_resolution <= 0:
         raise ValueError("check_resolution must be greater than zero")
 
-    distance = get_distance(observer[0], observer[1], target[0], target[1])
+    distance = get_distance(observer, target)
     if distance == 0:
         return True
 

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -125,7 +125,9 @@ def _move_sprite(
             # Resolve any collisions by this weird kludge
             _wiggle_until_free(moving_sprite, can_collide)
             if (
-                get_distance(original_x, original_y, moving_sprite.center_x, moving_sprite.center_y)
+                get_distance(
+                    (original_x, original_y), (moving_sprite.center_x, moving_sprite.center_y)
+                )
                 > max_distance
             ):
                 # Ok, glitched trying to rotate. Reset.

--- a/arcade/shape_list.py
+++ b/arcade/shape_list.py
@@ -420,10 +420,10 @@ def get_rectangle_points(
     y4 = -height / 2 + center_y
 
     if tilt_angle:
-        x1, y1 = rotate_point(x1, y1, center_x, center_y, tilt_angle)
-        x2, y2 = rotate_point(x2, y2, center_x, center_y, tilt_angle)
-        x3, y3 = rotate_point(x3, y3, center_x, center_y, tilt_angle)
-        x4, y4 = rotate_point(x4, y4, center_x, center_y, tilt_angle)
+        x1, y1 = rotate_point((x1, y1), (center_x, center_y), tilt_angle)
+        x2, y2 = rotate_point((x2, y2), (center_x, center_y), tilt_angle)
+        x3, y3 = rotate_point((x3, y3), (center_x, center_y), tilt_angle)
+        x4, y4 = rotate_point((x4, y4), (center_x, center_y), tilt_angle)
 
     return [(x1, y1), (x2, y2), (x3, y3), (x4, y4)]
 
@@ -505,7 +505,7 @@ def create_rectangle(
         if tilt_angle != 0:
             point_list_2: list[Point] = []
             for point in data:
-                new_point = rotate_point(point[0], point[1], center_x, center_y, tilt_angle)
+                new_point = rotate_point(point, (center_x, center_y), tilt_angle)  # type: ignore
                 point_list_2.append(new_point)
             data = point_list_2
 
@@ -752,7 +752,7 @@ def create_ellipse(
         y = height / 2 * math.sin(theta) + center_y
 
         if tilt_angle:
-            x, y = rotate_point(x, y, center_x, center_y, tilt_angle)
+            x, y = rotate_point((x, y), (center_x, center_y), tilt_angle)
 
         point_list.append((x, y))
 
@@ -812,7 +812,7 @@ def create_ellipse_filled_with_colors(
         y = height * math.sin(theta) + center_y
 
         if tilt_angle:
-            x, y = rotate_point(x, y, center_x, center_y, tilt_angle)
+            x, y = rotate_point((x, y), (center_x, center_y), tilt_angle)
 
         point_list.append((x, y))
     point_list.append(point_list[1])

--- a/arcade/sprite_list/collision.py
+++ b/arcade/sprite_list/collision.py
@@ -20,7 +20,7 @@ def get_distance_between_sprites(sprite1: SpriteType, sprite2: SpriteType) -> fl
         sprite1: Sprite one
         sprite2: Sprite two
     """
-    return get_distance(*sprite1._position, *sprite2._position)
+    return get_distance(sprite1._position, sprite2._position)
 
 
 def get_closest_sprite(

--- a/arcade/texture/transforms.py
+++ b/arcade/texture/transforms.py
@@ -113,7 +113,7 @@ class Rotate90Transform(Transform):
         """
         Transform hit box points by rotating them 90 degrees clockwise.
         """
-        return tuple(rotate_point(point[0], point[1], 0, 0, 90) for point in points)
+        return tuple(rotate_point(point, (0, 0), 90) for point in points)
 
 
 class Rotate180Transform(Transform):
@@ -135,7 +135,7 @@ class Rotate180Transform(Transform):
         """
         Transform hit box points by rotating them 180 degrees clockwise.
         """
-        return tuple(rotate_point(point[0], point[1], 0, 0, 180) for point in points)
+        return tuple(rotate_point(point, (0, 0), 180) for point in points)
 
 
 class Rotate270Transform(Transform):
@@ -157,7 +157,7 @@ class Rotate270Transform(Transform):
         """
         Transform hit box points by rotating them 270 degrees clockwise.
         """
-        return tuple(rotate_point(point[0], point[1], 0, 0, 270) for point in points)
+        return tuple(rotate_point(point, (0, 0), 270) for point in points)
 
 
 class FlipLeftRightTransform(Transform):

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -891,7 +891,7 @@ class TileMap:
 
                 angle_degrees = math.degrees(rotation)
                 rotated_center_x, rotated_center_y = rotate_point(
-                    width / 2, height / 2, 0, 0, angle_degrees
+                    (width / 2, height / 2), (0, 0), angle_degrees
                 )
 
                 my_sprite.position = (x + rotated_center_x, y + rotated_center_y)


### PR DESCRIPTION
This PR refactors math utilities and related code to use `Point2` tuples consistently instead of mixing `x, y` float parameters and `Point2`:

# Changes

- Updated core math functions:

     - `get_distance(x1, y1, x2, y2)` → `get_distance(pos1: Point2, pos2: Point2)`

     - `rotate_point(x, y, cx, cy, angle)` → `rotate_point(point: Point2, center: Point2, angle)`

    - `get_angle_degrees` and `get_angle_radians` now take Point2 pairs.

- Fixed `get_angle_radians`: previously used `math.atan2(x, y)`, now corrected to `math.atan2(y, x)`.

- Updated all call sites across the codebase (drawing functions, physics, easing, examples, etc.) to use the new signatures.

- Improved readability and reduced chance of mismatching parameters.
