### PR TITLE
Enable Python 3.14 by updating to pillow 11.3.X and adding 3.14 to CI

### DIFF
--- a/.github/workflows/selfhosted_runner.yml
+++ b/.github/workflows/selfhosted_runner.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         architecture: ['x64']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "pyglet~=2.1.5",
-    "pillow~=11.0.0",
+    "pillow~=11.3.0",
     "pymunk~=6.9.0",
     "pytiled-parser~=2.2.9",
 ]


### PR DESCRIPTION
Python 3.14 just released today. We already dropped 3.9 support a few months ago so this is all we should need to do.

EDIT: Pillow needed a bump to 11.3.0 [to enable beta 3.14 support](https://pillow.readthedocs.io/en/stable/releasenotes/11.3.0.html#python-3-14-beta).