### PR TITLE
InputManager - Check if Controller device is open before opening

### DIFF
--- a/arcade/future/input/manager.py
+++ b/arcade/future/input/manager.py
@@ -114,7 +114,9 @@ class InputManager:
         self.controller_deadzone = controller_deadzone
         if controller:
             self.controller = controller
-            self.controller.open()
+            if not self.controller.device.is_open:
+                self.controller.open()
+
             self.controller.push_handlers(
                 self.on_button_press,
                 self.on_button_release,


### PR DESCRIPTION
Before this merge, the `__init__` of the `InputManager` could fail if a controller had already been open. This could occur if an `InputManager` was instantiated twice, see #2778.

This commit closes issue #2778.