### PR TITLE
Add NoArcadeWindowError subclassing RuntimeError

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -90,6 +90,7 @@ from .window_commands import set_window
 from .window_commands import start_render
 from .window_commands import unschedule
 from .window_commands import schedule_once
+from .window_commands import window_exists
 
 from .sections import Section, SectionManager
 
@@ -359,6 +360,7 @@ __all__ = [
     "create_text_sprite",
     "clear_timings",
     "get_window",
+    "window_exists",
     "get_fps",
     "has_line_of_sight",
     "load_animated_gif",

--- a/arcade/exceptions.py
+++ b/arcade/exceptions.py
@@ -24,14 +24,14 @@ _TType = TypeVar("_TType", bound=type)
 _CT = TypeVar("_CT")  # Comparable type, ie supports the <= operator
 
 
-
 class NoArcadeWindowError(RuntimeError):
     """No valid Arcade window exists.
-    
+
     It may be handled as a :py:class:`RuntimeError`.
     """
+
     ...
- 
+
 
 class OutsideRangeError(ValueError):
     """

--- a/arcade/exceptions.py
+++ b/arcade/exceptions.py
@@ -7,6 +7,7 @@ import warnings
 from typing import TypeVar
 
 __all__ = [
+    "NoArcadeWindowError",
     "OutsideRangeError",
     "IntOutsideRangeError",
     "FloatOutsideRangeError",
@@ -22,6 +23,15 @@ __all__ = [
 _TType = TypeVar("_TType", bound=type)
 _CT = TypeVar("_CT")  # Comparable type, ie supports the <= operator
 
+
+
+class NoArcadeWindowError(RuntimeError):
+    """No valid Arcade window exists.
+    
+    It may be handled as a :py:class:`RuntimeError`.
+    """
+    ...
+ 
 
 class OutsideRangeError(ValueError):
     """

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING
 
 import pyglet
 
-from arcade.types import RGBA255, Color
 from arcade.exceptions import NoArcadeWindowError
+from arcade.types import RGBA255, Color
 
 if TYPE_CHECKING:
     from arcade import Window
@@ -58,9 +58,9 @@ def get_display_size(screen_id: int = 0) -> tuple[int, int]:
 
 def have_window() -> bool:
     """Returns ``True`` if an Arcade window exists.
-    
+
     .. tip:: Use this to avoid an :py:class:`~arcade.exceptions.NoArcadeWindowError`.
-    
+
 
     Returns:
         Whether a :py:class:`~arcade.Window` exists.
@@ -70,7 +70,7 @@ def have_window() -> bool:
 
 def get_window() -> Window:
     """Return a handle to the current window.
-    
+
     If no window exists, it will raise an exception you can
     handle as a :py:class:`RuntimeError`. Use :py:func:`have_window`
     to prevent raising an exception.
@@ -80,7 +80,9 @@ def get_window() -> Window:
     """
     # This avoids calling the function above because it may be a hot code path.
     if _window is None:
-        raise NoArcadeWindowError("No window is active. It has not been created yet, or it was closed.")
+        raise NoArcadeWindowError(
+            "No window is active. It has not been created yet, or it was closed."
+        )
 
     return _window
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -60,7 +60,7 @@ def get_window() -> Window:
     """Return a handle to the current window.
 
     If no window exists, it will raise an exception you can
-    handle as a :py:class:`RuntimeError`. Use :py:func:`have_window`
+    handle as a :py:class:`RuntimeError`. Use :py:func:`window_exists`
     to prevent raising an exception.
 
     Raises:

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -27,6 +27,7 @@ __all__ = [
     "get_display_size",
     "get_window",
     "set_window",
+    "window_exists",
     "close_window",
     "run",
     "exit",
@@ -82,6 +83,21 @@ def set_window(window: Window | None) -> None:
     """
     global _window
     _window = window
+
+
+def window_exists() -> bool:
+    """
+    Returns True or False based on wether there is currently a Window.
+
+    Returns:
+        Boolean for if a window exists.
+    """
+    try:
+        get_window()
+    except NoArcadeWindowError:
+        return False
+
+    return True
 
 
 def close_window() -> None:

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import pyglet
 
 from arcade.types import RGBA255, Color
+from arcade.exceptions import NoArcadeWindowError
 
 if TYPE_CHECKING:
     from arcade import Window
@@ -25,6 +26,7 @@ _window: Window | None = None
 __all__ = [
     "get_display_size",
     "get_window",
+    "have_window",
     "set_window",
     "close_window",
     "run",
@@ -54,14 +56,31 @@ def get_display_size(screen_id: int = 0) -> tuple[int, int]:
     return screen.width, screen.height
 
 
-def get_window() -> Window:
-    """
-    Return a handle to the current window.
+def have_window() -> bool:
+    """Returns ``True`` if an Arcade window exists.
+    
+    .. tip:: Use this to avoid an :py:class:`~arcade.exceptions.NoArcadeWindowError`.
+    
 
-    :return: Handle to the current window.
+    Returns:
+        Whether a :py:class:`~arcade.Window` exists.
     """
+    return _window is None
+
+
+def get_window() -> Window:
+    """Return a handle to the current window.
+    
+    If no window exists, it will raise an exception you can
+    handle as a :py:class:`RuntimeError`. Use :py:func:`have_window`
+    to prevent raising an exception.
+
+    Raises:
+        :py:class:`~arcade.exceptions.NoArcadeWindowError` when no window exists.
+    """
+    # This avoids calling the function above because it may be a hot code path.
     if _window is None:
-        raise RuntimeError("No window is active. It has not been created yet, or it was closed.")
+        raise NoArcadeWindowError("No window is active. It has not been created yet, or it was closed.")
 
     return _window
 

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -26,7 +26,6 @@ _window: Window | None = None
 __all__ = [
     "get_display_size",
     "get_window",
-    "have_window",
     "set_window",
     "close_window",
     "run",
@@ -56,18 +55,6 @@ def get_display_size(screen_id: int = 0) -> tuple[int, int]:
     return screen.width, screen.height
 
 
-def have_window() -> bool:
-    """Returns ``True`` if an Arcade window exists.
-
-    .. tip:: Use this to avoid an :py:class:`~arcade.exceptions.NoArcadeWindowError`.
-
-
-    Returns:
-        Whether a :py:class:`~arcade.Window` exists.
-    """
-    return _window is None
-
-
 def get_window() -> Window:
     """Return a handle to the current window.
 
@@ -78,7 +65,6 @@ def get_window() -> Window:
     Raises:
         :py:class:`~arcade.exceptions.NoArcadeWindowError` when no window exists.
     """
-    # This avoids calling the function above because it may be a hot code path.
     if _window is None:
         raise NoArcadeWindowError(
             "No window is active. It has not been created yet, or it was closed."


### PR DESCRIPTION
Per Discord discussion with @DragonMoffon:

> Please can we. its also super useful non daemon threads. If i have a worker thread open for file IO having it close if it catches a no window error would be great
> also a `does_window_exist` function would be nice

The function name is `have_window` in this PR but otherwise it's the same idea.

Changes: 
1. Add `arcade.exceptions.NoArcadeWindowError`
   - subclasses `RuntimeError`
   - no args, just a semantic wrapper
2. In `arcade.window_commands`:
   - Make `get_window()` raise `NoArcadeWindowError` when no window exists
   - Touch up old-style `:returns:` docstring for `get_window()`
   
Deferred until a later PR:
- Add `has_window()` somewhere
  - has/have bikeshedding
  - `window_commands` may be worth moving (especially if we add multi-window support?)