### PR TITLE
Bump to Pillow 12.0.0 for full Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "pyglet~=2.1.5",
-    "pillow~=11.3.0",
+    "pillow~=12.0.0",
     "pymunk~=6.9.0",
     "pytiled-parser~=2.2.9",
 ]


### PR DESCRIPTION
**TL;DR:** Bump to Pillow 12 as it's the official Python 3.14 support release

The prior Pillow bump to 11.3.0 (#2777) offered "beta" support for Python 3.14, not official support.