### PR TITLE
Update the `DefaultProjector` to behave better when changing framebuffers

### DIFF
--- a/arcade/camera/__init__.py
+++ b/arcade/camera/__init__.py
@@ -23,6 +23,7 @@ from arcade.camera.projection_functions import (
 
 from arcade.camera.orthographic import OrthographicProjector
 from arcade.camera.perspective import PerspectiveProjector
+from arcade.camera.viewport import ViewportProjector
 
 from arcade.camera.camera_2d import Camera2D
 
@@ -33,6 +34,7 @@ __all__ = [
     "Projection",
     "Projector",
     "CameraData",
+    "ViewportProjector",
     "generate_view_matrix",
     "OrthographicProjectionData",
     "generate_orthographic_matrix",

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -5,11 +5,10 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from pyglet.math import Mat4, Vec2, Vec3
-from pyglet.window.key import F
 from typing_extensions import Self
 
 from arcade.camera.data_types import DEFAULT_FAR, DEFAULT_NEAR_ORTHO
-from arcade.types import LBWH, Point, Rect
+from arcade.types import Point
 from arcade.window_commands import get_window
 
 if TYPE_CHECKING:
@@ -24,13 +23,10 @@ class DefaultProjector:
     here to act as the default camera used internally by Arcade. There should be
     no instance where a developer would want to use this class.
 
-    The default viewport tries it's best to allow
-    simple usecases with no need to use a camera.
-
-    It does this by defaulting to the size of the active
-    framebuffer. If the user sets the framebuffer's viewport
-    without a camera then the default camera will match it
-    until the framebuffer is changed again.
+    The job of the default projector is to ensure that when no other Projector
+    (Camera2D, OthrographicProjector, PerspectiveProjector, etc) is in use the
+    projection and view matrices are correct such at (0.0, 0.0) is in the bottom
+    left corner of the viewport and that one pixel equals one 'unit'.
 
     Args:
         context: The window context to bind the camera to. Defaults to the currently active context.
@@ -38,10 +34,9 @@ class DefaultProjector:
 
     def __init__(self, *, context: ArcadeContext | None = None):
         self._ctx: ArcadeContext = context or get_window().ctx
-        self._viewport: Rect | None = None
-        self._scissor: Rect | None = None
+        self._viewport: tuple[int, int, int, int] | None = None
+        self._scissor: tuple[int, int, int, int] | None = None
         self._matrix: Mat4 | None = None
-        self._updating: bool = False
 
     def update_viewport(self):
         """
@@ -54,27 +49,25 @@ class DefaultProjector:
 
         # If another camera is active then the viewport was probably set
         # by camera.use()
-        if self._ctx.current_camera != self or self._updating:
+        if self._ctx.current_camera != self:
             return
-        self._updating = True
 
         if (
             self._ctx.viewport[2] != self._ctx.fbo.width
             or self._ctx.viewport[3] != self._ctx.fbo.height
         ):
-            self.viewport = LBWH(*self._ctx.viewport)
+            self.viewport = self._ctx.viewport
         else:
             self.viewport = None
 
         self.use()
-        self._updating = False
 
     @property
-    def viewport(self) -> Rect | None:
+    def viewport(self) -> tuple[int, int, int, int] | None:
         return self._viewport
 
     @viewport.setter
-    def viewport(self, viewport: Rect | None) -> None:
+    def viewport(self, viewport: tuple[int, int, int, int] | None) -> None:
         if viewport == self._viewport:
             return
         self._viewport = viewport
@@ -87,11 +80,11 @@ class DefaultProjector:
         self.viewport = None
 
     @property
-    def scissor(self) -> Rect | None:
+    def scissor(self) -> tuple[int, int, int, int] | None:
         return self._scissor
 
     @scissor.setter
-    def scissor(self, scissor: Rect | None) -> None:
+    def scissor(self, scissor: tuple[int, int, int, int] | None) -> None:
         self._scissor = scissor
 
     @scissor.deleter
@@ -101,18 +94,18 @@ class DefaultProjector:
     @property
     def width(self) -> int:
         if self._viewport is not None:
-            return int(self._viewport.width)
+            return int(self._viewport[2])
         return self._ctx.fbo.width
 
     @property
     def height(self) -> int:
         if self._viewport is not None:
-            return int(self._viewport.height)
+            return int(self._viewport[3])
         return self._ctx.fbo.height
 
     def get_current_viewport(self) -> tuple[int, int, int, int]:
         if self._viewport is not None:
-            return self._viewport.lbwh_int
+            return self._viewport
         return (0, 0, self._ctx.fbo.width, self._ctx.fbo.height)
 
     def use(self) -> None:
@@ -124,8 +117,8 @@ class DefaultProjector:
 
         self._ctx.current_camera = self
         if self._ctx.viewport != viewport:
-            self._ctx.viewport = viewport
-        self._ctx.scissor = None if self._scissor is None else self._scissor.lbwh_int
+            self._ctx.active_framebuffer.viewport = viewport
+        self._ctx.scissor = None if self._scissor is None else self._scissor
 
         self._ctx.view_matrix = Mat4()
         if self._matrix is None:
@@ -141,14 +134,20 @@ class DefaultProjector:
 
         usable with the 'with' block. e.g. 'with ViewportProjector.activate() as cam: ...'
         """
-        previous = self._ctx.current_camera
+        previous_projector = self._ctx.current_camera
+        previous_view = self._ctx.view_matrix
+        previous_projection = self._ctx.projection_matrix
+        previous_scissor = self._ctx.scissor
         previous_viewport = self._ctx.viewport
         try:
             self.use()
             yield self
         finally:
             self._ctx.viewport = previous_viewport
-            previous.use()
+            self._ctx.scissor = previous_scissor
+            self._ctx.projection_matrix = previous_projection
+            self._ctx.view_matrix = previous_view
+            self._ctx.current_camera = previous_projector
 
     def project(self, world_coordinate: Point) -> Vec2:
         """

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from pyglet.math import Mat4, Vec2, Vec3
+from pyglet.window.key import F
 from typing_extensions import Self
 
 from arcade.types import LBWH, Point, Rect
@@ -40,6 +41,7 @@ class DefaultProjector:
         self._viewport: Rect | None = None
         self._scissor: Rect | None = None
         self._matrix: Mat4 | None = None
+        self._updating: bool = False
 
     def update_viewport(self):
         """
@@ -49,13 +51,17 @@ class DefaultProjector:
         setting the viewport to match the size of the active
         framebuffer sets the viewport to None.
         """
-        if self._ctx.current_camera != self:
+        if self._ctx.current_camera != self or self._updating:
             return
+        self._updating = True
+
         if self._ctx.viewport[2] != self.width or self._ctx.viewport[3] != self.height:
-            self._viewport = LBWH(*self._ctx.viewport)
-        self._viewport = None
+            self.viewport = LBWH(*self._ctx.viewport)
+        else:
+            self.viewport = None
 
         self.use()
+        self._updating = False
 
     @property
     def viewport(self) -> Rect | None:
@@ -98,24 +104,26 @@ class DefaultProjector:
             return int(self._viewport.height)
         return self._ctx.active_framebuffer.height
 
+    def get_current_viewport(self) -> tuple[int, int, int, int]:
+        if self._viewport is not None:
+            return self._viewport.lbwh_int
+        return (0, 0, self._ctx.active_framebuffer.width, self._ctx.active_framebuffer.width)
+
     def use(self) -> None:
         """
         Set the window's Projection and View matrices.
         """
 
-        viewport = (0, 0, self.width, self.height)
-        # If the viewport is correct and the default camera is in use,
-        # then don't waste time resetting the view and projection matrices
-        if self._ctx.viewport == viewport and self._ctx.current_camera == self:
-            return
+        viewport = self.get_current_viewport()
 
         self._ctx.current_camera = self
         self._ctx.viewport = viewport
+        self._ctx.scissor = None if self._scissor is None else self._scissor.lbwh_int
 
         self._ctx.view_matrix = Mat4()
         if self._matrix is None:
             self._matrix = Mat4.orthogonal_projection(
-                0, 0, viewport[2], viewport[3], DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+                0, viewport[2], 0, viewport[3], DEFAULT_NEAR_ORTHO, DEFAULT_FAR
             )
         self._ctx.projection_matrix = self._matrix
 

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -9,62 +9,115 @@ from typing_extensions import Self
 
 from arcade.types import LBWH, Point, Rect
 from arcade.window_commands import get_window
+from arcade.camera.data_types import DEFAULT_NEAR_ORTHO, DEFAULT_FAR
 
 if TYPE_CHECKING:
     from arcade.context import ArcadeContext
 
-__all__ = ["ViewportProjector", "DefaultProjector"]
+__all__ = ()
 
 
-class ViewportProjector:
+class DefaultProjector:
     """
-    A simple Projector which does not rely on any camera PoDs.
+    An extremely limited projector which lacks any kind of control. This is only
+    here to act as the default camera used internally by Arcade. There should be
+    no instance where a developer would want to use this class.
 
-    Does not have a way of moving, rotating, or zooming the camera.
-    perfect for something like UI or for mapping to an offscreen framebuffer.
+    The default viewport tries it's best to allow
+    simple usecases with no need to use a camera.
+
+    It does this by defaulting to the size of the active
+    framebuffer. If the user sets the framebuffer's viewport
+    without a camera then the default camera will match it
+    until the framebuffer is changed again.
 
     Args:
-        viewport: The viewport to project to.
-        context: The window context to bind the camera to. Defaults to the currently active window.
+        context: The window context to bind the camera to. Defaults to the currently active context.
     """
 
-    def __init__(
-        self,
-        viewport: Rect | None = None,
-        *,
-        context: ArcadeContext | None = None,
-    ):
+    def __init__(self, *, context: ArcadeContext | None = None):
         self._ctx: ArcadeContext = context or get_window().ctx
-        self._viewport: Rect = viewport or LBWH(*self._ctx.viewport)
-        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
-            0.0, self._viewport.width, 0.0, self._viewport.height, -100, 100
-        )
+        self._viewport: Rect | None = None
+        self._scissor: Rect | None = None
+        self._matrix: Mat4 | None = None
+
+    def update_viewport(self):
+        """
+        Called when the ArcadeContext's viewport or active
+        framebuffer has been set. It only actually updates
+        the viewport if no other camera is active. Also
+        setting the viewport to match the size of the active
+        framebuffer sets the viewport to None.
+        """
+        if self._ctx.current_camera != self:
+            return
+        if self._ctx.viewport[2] != self.width or self._ctx.viewport[3] != self.height:
+            self._viewport = LBWH(*self._ctx.viewport)
+        self._viewport = None
+
+        self.use()
 
     @property
-    def viewport(self) -> Rect:
-        """
-        The viewport use to derive projection and view matrix.
-        """
+    def viewport(self) -> Rect | None:
         return self._viewport
 
     @viewport.setter
-    def viewport(self, viewport: Rect) -> None:
+    def viewport(self, viewport: Rect | None) -> None:
+        if viewport == self._viewport:
+            return
         self._viewport = viewport
-        self._projection_matrix = Mat4.orthogonal_projection(
-            0, viewport.width, 0, viewport.height, -100, 100
+        self._matrix = Mat4.orthogonal_projection(
+            0, self.width, 0, self.height, DEFAULT_NEAR_ORTHO, DEFAULT_FAR
         )
+
+    @viewport.deleter
+    def viewport(self):
+        self.viewport = None
+
+    @property
+    def scissor(self) -> Rect | None:
+        return self._scissor
+
+    @scissor.setter
+    def scissor(self, scissor: Rect | None) -> None:
+        self._scissor = scissor
+
+    @scissor.deleter
+    def scissor(self) -> None:
+        self._scissor = None
+
+    @property
+    def width(self) -> int:
+        if self._viewport is not None:
+            return int(self._viewport.width)
+        return self._ctx.active_framebuffer.width
+
+    @property
+    def height(self) -> int:
+        if self._viewport is not None:
+            return int(self._viewport.height)
+        return self._ctx.active_framebuffer.height
 
     def use(self) -> None:
         """
-        Set the window's projection and view matrix.
-        Also sets the projector as the windows current camera.
+        Set the window's Projection and View matrices.
         """
-        self._ctx.current_camera = self
 
-        self._ctx.viewport = self.viewport.lbwh_int  # get the integer 4-tuple LBWH
+        viewport = (0, 0, self.width, self.height)
+        # If the viewport is correct and the default camera is in use,
+        # then don't waste time resetting the view and projection matrices
+        if self._ctx.viewport == viewport and self._ctx.current_camera == self:
+            return
+
+        self._ctx.current_camera = self
+        self._ctx.viewport = viewport
 
         self._ctx.view_matrix = Mat4()
-        self._ctx.projection_matrix = self._projection_matrix
+        if self._matrix is None:
+            self._matrix = Mat4.orthogonal_projection(
+                0, 0, viewport[2], viewport[3], DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+            )
+        self._ctx.projection_matrix = self._matrix
 
     @contextmanager
     def activate(self) -> Generator[Self, None, None]:
@@ -74,10 +127,12 @@ class ViewportProjector:
         usable with the 'with' block. e.g. 'with ViewportProjector.activate() as cam: ...'
         """
         previous = self._ctx.current_camera
+        previous_viewport = self._ctx.viewport
         try:
             self.use()
             yield self
         finally:
+            self._ctx.viewport = previous_viewport
             previous.use()
 
     def project(self, world_coordinate: Point) -> Vec2:
@@ -97,46 +152,3 @@ class ViewportProjector:
         z = 0.0 if not _z else _z[0]
 
         return Vec3(x, y, z)
-
-
-# As this class is only supposed to be used internally
-# I wanted to place an _ in front, but the linting complains
-# about it being a protected class.
-class DefaultProjector(ViewportProjector):
-    """
-    An extremely limited projector which lacks any kind of control. This is only
-    here to act as the default camera used internally by Arcade. There should be
-    no instance where a developer would want to use this class.
-
-    Args:
-        context: The window context to bind the camera to. Defaults to the currently active window.
-    """
-
-    def __init__(self, *, context: ArcadeContext | None = None):
-        super().__init__(context=context)
-
-    def use(self) -> None:
-        """
-        Set the window's Projection and View matrices.
-
-        cache's the window viewport to determine the projection matrix.
-        """
-
-        viewport = self.viewport.lbwh_int
-        # If the viewport is correct and the default camera is in use,
-        # then don't waste time resetting the view and projection matrices
-        if self._ctx.viewport == viewport and self._ctx.current_camera == self:
-            return
-
-        # If the viewport has changed while the default camera is active then the
-        # default needs to update itself.
-        # If it was another camera's viewport being used the default camera should not update.
-        if self._ctx.viewport != viewport and self._ctx.current_camera == self:
-            self.viewport = LBWH(*self._ctx.viewport)
-        else:
-            self._ctx.viewport = viewport
-
-        self._ctx.current_camera = self
-
-        self._ctx.view_matrix = Mat4()
-        self._ctx.projection_matrix = self._projection_matrix

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -8,9 +8,9 @@ from pyglet.math import Mat4, Vec2, Vec3
 from pyglet.window.key import F
 from typing_extensions import Self
 
+from arcade.camera.data_types import DEFAULT_FAR, DEFAULT_NEAR_ORTHO
 from arcade.types import LBWH, Point, Rect
 from arcade.window_commands import get_window
-from arcade.camera.data_types import DEFAULT_NEAR_ORTHO, DEFAULT_FAR
 
 if TYPE_CHECKING:
     from arcade.context import ArcadeContext
@@ -51,12 +51,14 @@ class DefaultProjector:
         setting the viewport to match the size of the active
         framebuffer sets the viewport to None.
         """
+
         # If another camera is active then the viewport was probably set
         # by camera.use()
         if self._ctx.current_camera != self or self._updating:
             return
         self._updating = True
 
+        if (
             self._ctx.viewport[2] != self._ctx.fbo.width
             or self._ctx.viewport[3] != self._ctx.fbo.height
         ):
@@ -106,7 +108,6 @@ class DefaultProjector:
     def height(self) -> int:
         if self._viewport is not None:
             return int(self._viewport.height)
-        return self._ctx.active_framebuffer.height
         return self._ctx.fbo.height
 
     def get_current_viewport(self) -> tuple[int, int, int, int]:

--- a/arcade/camera/default.py
+++ b/arcade/camera/default.py
@@ -51,11 +51,15 @@ class DefaultProjector:
         setting the viewport to match the size of the active
         framebuffer sets the viewport to None.
         """
+        # If another camera is active then the viewport was probably set
+        # by camera.use()
         if self._ctx.current_camera != self or self._updating:
             return
         self._updating = True
 
-        if self._ctx.viewport[2] != self.width or self._ctx.viewport[3] != self.height:
+            self._ctx.viewport[2] != self._ctx.fbo.width
+            or self._ctx.viewport[3] != self._ctx.fbo.height
+        ):
             self.viewport = LBWH(*self._ctx.viewport)
         else:
             self.viewport = None
@@ -96,18 +100,19 @@ class DefaultProjector:
     def width(self) -> int:
         if self._viewport is not None:
             return int(self._viewport.width)
-        return self._ctx.active_framebuffer.width
+        return self._ctx.fbo.width
 
     @property
     def height(self) -> int:
         if self._viewport is not None:
             return int(self._viewport.height)
         return self._ctx.active_framebuffer.height
+        return self._ctx.fbo.height
 
     def get_current_viewport(self) -> tuple[int, int, int, int]:
         if self._viewport is not None:
             return self._viewport.lbwh_int
-        return (0, 0, self._ctx.active_framebuffer.width, self._ctx.active_framebuffer.width)
+        return (0, 0, self._ctx.fbo.width, self._ctx.fbo.height)
 
     def use(self) -> None:
         """
@@ -117,7 +122,8 @@ class DefaultProjector:
         viewport = self.get_current_viewport()
 
         self._ctx.current_camera = self
-        self._ctx.viewport = viewport
+        if self._ctx.viewport != viewport:
+            self._ctx.viewport = viewport
         self._ctx.scissor = None if self._scissor is None else self._scissor.lbwh_int
 
         self._ctx.view_matrix = Mat4()

--- a/arcade/camera/viewport.py
+++ b/arcade/camera/viewport.py
@@ -38,11 +38,11 @@ class ViewportProjector:
         self._ctx: ArcadeContext = context or get_window().ctx
         self._viewport: Rect = viewport or LBWH(*self._ctx.viewport)
         self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
-            0.0, self.viewport.width, 0.0, self.viewport.height, DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+            0.0, self._viewport.width, 0.0, self._viewport.height, DEFAULT_NEAR_ORTHO, DEFAULT_FAR
         )
 
     @property
-    def viewport(self) -> Rect | None:
+    def viewport(self) -> Rect:
         """
         The viewport use to derive projection and view matrix.
         """

--- a/arcade/camera/viewport.py
+++ b/arcade/camera/viewport.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from pyglet.math import Mat4, Vec2, Vec3
+from typing_extensions import Self
+
+from arcade.types import LBWH, Point, Rect
+from arcade.window_commands import get_window
+from arcade.camera.data_types import DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+
+if TYPE_CHECKING:
+    from arcade.context import ArcadeContext
+
+__all__ = ["ViewportProjector"]
+
+
+class ViewportProjector:
+    """
+    A simple Projector which does not rely on any camera PoDs.
+
+    Does not have a way of moving, rotating, or zooming the camera.
+    perfect for something like UI or for mapping to an offscreen framebuffer.
+
+    Args:
+        viewport: The viewport to project to.
+        context: The window context to bind the camera to. Defaults to the currently active window.
+    """
+
+    def __init__(
+        self,
+        viewport: Rect | None = None,
+        *,
+        context: ArcadeContext | None = None,
+    ):
+        self._ctx: ArcadeContext = context or get_window().ctx
+        self._viewport: Rect = viewport or LBWH(*self._ctx.viewport)
+        self._projection_matrix: Mat4 = Mat4.orthogonal_projection(
+            0.0, self.viewport.width, 0.0, self.viewport.height, DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+        )
+
+    @property
+    def viewport(self) -> Rect | None:
+        """
+        The viewport use to derive projection and view matrix.
+        """
+        return self._viewport
+
+    @viewport.setter
+    def viewport(self, viewport: Rect) -> None:
+        self._viewport = viewport
+        self._projection_matrix = Mat4.orthogonal_projection(
+            0, viewport.width, 0, viewport.height, DEFAULT_NEAR_ORTHO, DEFAULT_FAR
+        )
+
+    def use(self) -> None:
+        """
+        Set the window's projection and view matrix.
+        Also sets the projector as the windows current camera.
+        """
+        self._ctx.current_camera = self
+
+        if self.viewport:
+            self._ctx.viewport = self.viewport.lbwh_int
+
+        self._ctx.view_matrix = Mat4()
+        self._ctx.projection_matrix = self._projection_matrix
+
+    @contextmanager
+    def activate(self) -> Generator[Self, None, None]:
+        """
+        The context manager version of the use method.
+
+        usable with the 'with' block. e.g. 'with ViewportProjector.activate() as cam: ...'
+        """
+        previous = self._ctx.current_camera
+        previous_viewport = self._ctx.viewport
+        try:
+            self.use()
+            yield self
+        finally:
+            self._ctx.viewport = previous_viewport
+            previous.use()
+
+    def project(self, world_coordinate: Point) -> Vec2:
+        """
+        Take a Vec2 or Vec3 of coordinates and return the related screen coordinate
+        """
+        x, y, *z = world_coordinate
+        return Vec2(x, y)
+
+    def unproject(self, screen_coordinate: Point) -> Vec3:
+        """
+        Map the screen pos to screen_coordinates.
+
+        Due to the nature of viewport projector this does not do anything.
+        """
+        x, y, *_z = screen_coordinate
+        z = 0.0 if not _z else _z[0]
+
+        return Vec3(x, y, z)

--- a/arcade/camera/viewport.py
+++ b/arcade/camera/viewport.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 from pyglet.math import Mat4, Vec2, Vec3
 from typing_extensions import Self
 
+from arcade.camera.data_types import DEFAULT_FAR, DEFAULT_NEAR_ORTHO
 from arcade.types import LBWH, Point, Rect
 from arcade.window_commands import get_window
-from arcade.camera.data_types import DEFAULT_NEAR_ORTHO, DEFAULT_FAR
 
 if TYPE_CHECKING:
     from arcade.context import ArcadeContext

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -373,6 +373,15 @@ class ArcadeContext(Context):
         return self._atlas
 
     @property
+    def active_framebuffer(self):
+        return self._active_framebuffer
+
+    @active_framebuffer.setter
+    def active_framebuffer(self, framebuffer: Framebuffer):
+        self._active_framebuffer = framebuffer
+        self._default_camera.update_viewport()
+
+    @property
     def viewport(self) -> tuple[int, int, int, int]:
         """
         Get or set the viewport for the currently active framebuffer.
@@ -393,8 +402,7 @@ class ArcadeContext(Context):
     @viewport.setter
     def viewport(self, value: tuple[int, int, int, int]):
         self.active_framebuffer.viewport = value
-        if self._default_camera == self.current_camera:
-            self._default_camera.use()
+        self._default_camera.update_viewport()
 
     @property
     def projection_matrix(self) -> Mat4:

--- a/arcade/context.py
+++ b/arcade/context.py
@@ -334,6 +334,8 @@ class ArcadeContext(Context):
         self.projection_matrix = Mat4.orthogonal_projection(
             0, self.window.width, 0, self.window.height, -100, 100
         )
+        self._default_camera: DefaultProjector = DefaultProjector(context=self)
+        self.current_camera = self._default_camera
         self.enable_only(self.BLEND)
         self.blend_func = self.BLEND_DEFAULT
         self.point_size = 1.0

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -221,7 +221,7 @@ class Context(ABC):
         # Tracking active program
         self.active_program: Program | ComputeShader | None = None
         # Tracking active framebuffer. On context creation the window is the default render target
-        self.active_framebuffer: Framebuffer = self._screen
+        self._active_framebuffer: Framebuffer = self._screen
         self._stats: ContextStats = ContextStats(warn_threshold=1000)
 
         self._primitive_restart_index = -1
@@ -327,7 +327,18 @@ class Context(ABC):
         """
         Get the currently active framebuffer (read only).
         """
-        return self.active_framebuffer
+        return self._active_framebuffer
+
+    @property
+    def active_framebuffer(self) -> Framebuffer:
+        """
+        Get the currently active framebuffer.
+        """
+        return self._active_framebuffer
+
+    @active_framebuffer.setter
+    def active_framebuffer(self, framebuffer: Framebuffer) -> None:
+        self._active_framebuffer = framebuffer
 
     def gc(self) -> int:
         """

--- a/tests/unit/camera/test_viewport_projector.py
+++ b/tests/unit/camera/test_viewport_projector.py
@@ -8,13 +8,13 @@ from arcade.types import Point, LBWH, Rect
 
 @pytest.mark.parametrize("wrld_pos", [Vec2(100, 150), Vec2(1280, 720), Vec3(500, 500, -10)])
 def test_viewport_projector_project(window: Window, wrld_pos: Point):
-    cam = camera.default.ViewportProjector()
+    cam = camera.ViewportProjector()
     assert cam.project(wrld_pos) == wrld_pos.xy
 
 
 @pytest.mark.parametrize("wrld_pos", [Vec2(100, 150), Vec2(1280, 720), Vec3(500, 500, -10)])
 def test_viewport_projector_unproject(window: Window, wrld_pos: Point):
-    cam = camera.default.ViewportProjector()
+    cam = camera.ViewportProjector()
     x, y, *z = wrld_pos
 
     assert cam.unproject(wrld_pos) == Vec3(x, y, 0.0 if not z else z[0])
@@ -24,7 +24,7 @@ def test_viewport_projector_unproject(window: Window, wrld_pos: Point):
     "viewport", [LBWH(0.0, 0.0, 100, 200), LBWH(100, 100, 20, 40), LBWH(300, 20, 20, 700)]
 )
 def test_viewport_projector_viewport(window: Window, viewport: Rect):
-    cam = camera.default.ViewportProjector()
+    cam = camera.ViewportProjector()
     assert cam.viewport.lbwh_int == window.ctx.viewport
     cam.viewport = viewport
     assert cam.viewport == viewport

--- a/tests/unit/draw/test_drawing_primitives.py
+++ b/tests/unit/draw/test_drawing_primitives.py
@@ -6,6 +6,7 @@ def test_draw_primitives(window):
     Render the screen.
     """
     window.background_color = arcade.color.WHITE
+    window.viewport = (0, 0, window.width, window.height)
     window.clear()
 
     # Draw a grid

--- a/tests/unit/draw/test_drawing_primitives.py
+++ b/tests/unit/draw/test_drawing_primitives.py
@@ -6,7 +6,6 @@ def test_draw_primitives(window):
     Render the screen.
     """
     window.background_color = arcade.color.WHITE
-    window.viewport = (0, 0, window.width, window.height)
     window.clear()
 
     # Draw a grid


### PR DESCRIPTION
The `DefaultProjector` was supposed to update itself to give a consistent unnoticeable behavior on the backend when switching between framebuffers. This has not been the case since the creation of the 3.0 Camera system.