### PR TITLE
Dependency Cleanup for WASM environments

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -192,10 +192,12 @@ from .physics_engines import PhysicsEngineSimple
 from .tilemap import load_tilemap
 from .tilemap import TileMap
 
-if sys.platform != "emscripten":
+try:
     from .pymunk_physics_engine import PymunkPhysicsEngine
     from .pymunk_physics_engine import PymunkPhysicsObject
     from .pymunk_physics_engine import PymunkException
+except ImportError:
+    pass
 
 from .version import VERSION
 

--- a/arcade/hitbox/__init__.py
+++ b/arcade/hitbox/__init__.py
@@ -1,7 +1,6 @@
 from PIL.Image import Image
 
 from arcade.types import Point2List
-from arcade.utils import is_pyodide
 
 from .base import HitBox, HitBoxAlgorithm, RotatableHitBox
 from .bounding_box import BoundingHitBoxAlgorithm
@@ -10,12 +9,15 @@ from .simple import SimpleHitBoxAlgorithm
 
 #: The simple hit box algorithm.
 algo_simple = SimpleHitBoxAlgorithm()
-#: The detailed hit box algorithm.
 
-if not is_pyodide():
+#: The detailed hit box algorithm. This depends on pymunk and will fallback to the simple algorithm.
+try:
     from .pymunk import PymunkHitBoxAlgorithm
-
     algo_detailed = PymunkHitBoxAlgorithm()
+except ImportError:
+    print("WARNING: Running without PyMunk. The detailed hitbox algorithm will fallback to simple")
+    algo_detailed = SimpleHitBoxAlgorithm()
+
 
 #: The bounding box hit box algorithm.
 algo_bounding_box = BoundingHitBoxAlgorithm()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
     "pyglet==3.0.dev1",
     "pillow~=12.0.0",
-    "pymunk~=7.2.0",
     "pytiled-parser~=2.2.9",
 ]
 dynamic = ["version"]
@@ -36,6 +35,9 @@ Source = "https://github.com/pythonarcade/arcade"
 Book = "https://learn.arcade.academy"
 
 [dependency-groups]
+extras = [
+    "pymunk~=7.2.0"
+]
 # Used for dev work
 dev = [
     "sphinx==8.1.3",               # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
@@ -62,8 +64,10 @@ dev = [
     "click==8.1.7",     # Temp fix until we bump typer
     "typer==0.12.5",    # Needed for make.py
     "wheel",
-    "bottle"            # Used for web testing playground
+    "bottle",            # Used for web testing playground
+    {include-group = "extras"}
 ]
+
 # Testing only
 testing_libraries = ["pytest", "pytest-mock", "pytest-cov", "pyyaml==6.0.1"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "pyglet==3.0.dev1",
-    "pillow~=12.0.0",
+    "pillow>=11.3.0",
     "pytiled-parser~=2.2.9",
 ]
 dynamic = ["version"]

--- a/webplayground/example.tpl
+++ b/webplayground/example.tpl
@@ -4,7 +4,7 @@
 <head>
     % title = name.split(".")[-1]
     <title>{{title}}</title>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.28.1/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.29.0/full/pyodide.js"></script>
 </head>
 
 <body>
@@ -13,9 +13,8 @@
             let pyodide = await loadPyodide();
             await pyodide.loadPackage("micropip");
             const micropip = pyodide.pyimport("micropip");
-            await pyodide.loadPackage("pillow"); // Arcade needs Pillow
-            await micropip.install("pyglet==3.0.dev1", pre=true)
-            await micropip.install("http://localhost:8000/static/{{arcade_wheel}}");
+            await pyodide.loadPackage("pillow");
+            await micropip.install("http://localhost:8000/static/{{arcade_wheel}}", pre=true);
 
             // We are importing like this because some example files have numbers in the name, and you can't use those in normal import statements
             pyodide.runPython(`

--- a/webplayground/server.py
+++ b/webplayground/server.py
@@ -61,7 +61,7 @@ def main():
 
     # Go to arcade and build a wheel
     os.chdir(path_arcade)
-    subprocess.run(["python", "-m", "build", "--wheel", "--outdir", "dist"])
+    subprocess.run(["uv", "build"])
     os.chdir(here)
     shutil.copy(path_arcade_wheel, f"./{arcade_wheel_filename}")
 


### PR DESCRIPTION
Some of this is likely temporary.

First off, pymunk has been made optional, and can be installed with `pip install arcade[extras]`. It will not be installed by default. Trying to use the PymunkPhysicsEngine will result in an error if it is not installed, and the detailed hitbox algorithm will fallback to the simple one with a warning printed to the console.

This change is largely because there is no sane way to install pymunk in WASM environments right now. PyPi doesn't support WASM wheels yet, and while pymunk does have a WASM wheel distributed on the GitHub release, installing the wheel directly from github doesn't work due to CORS problems, so as of right now if you want pymunk in a browser, you'll have to figure out hosting for the wheel and install it with micropip manually. If that is done, arcade should pick it up and it should work, but there's no sane way for us to handle the dependency automatically probably until the wheel can just be on pypi.

The other change which is less impactful, is that I've downgraded the minimum PIL version to 11.3.0, as there are no differences which impact Arcade between 11.3 and 12.0, and pyodide is still bundling 12.0. This can be bumped back up to 12.0 minimum when pyodide upgrades.