### PR TITLE
Disable WebGL Alpha Channel on the backing buffer

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -63,6 +63,12 @@ if os.environ.get("ARCADE_TEST"):
 else:
     pyglet.options.dpi_scaling = "stretch"
 
+# WebGL has an alpha channel in the backing buffer by default that is
+# 0.0 unless you explicitly clear the alpha channel to 1.0. Disabling
+# this channel causes it to behave more in line with how full OpenGL works.
+if sys.platform == "emscripten":
+    pyglet.options.pyodide.context_options["alpha"] = False
+
 # Env variable shortcut for headless mode
 headless: Final[bool] = bool(os.environ.get("ARCADE_HEADLESS"))
 if headless:


### PR DESCRIPTION
This PR depends on https://github.com/pyglet/pyglet/pull/1400 in Pyglet to be merged first, and will error without it.

WebGL by default has an alpha channel on the backing buffer which causes the content of the HTML/CSS behind the canvas element to bleed through when doing alpha blending. On desktop OpenGL/GLES the backing buffer is solid black and doesn't have an alpha channel.

This change makes the WebGL context function more in line with how desktop OpenGL does