### PR TITLE
Rework HitBox to support multiple named collision regions

### DIFF
--- a/arcade/cli/cli.py
+++ b/arcade/cli/cli.py
@@ -54,4 +54,8 @@ class CLI:
 def run_arcade_cli():
     cli = CLI()
     cli.register_command(InfoCommand)
+
+    from arcade.hitbox_editor.commands import HitBoxEditorCommand
+    cli.register_command(HitBoxEditorCommand)
+
     return cli.run()

--- a/arcade/examples/sprite_multi_hitbox.py
+++ b/arcade/examples/sprite_multi_hitbox.py
@@ -1,0 +1,200 @@
+"""
+Sprite Multi-Region Hit Boxes
+
+Demonstrates sprites with multiple hit box regions. The player sprite
+has a "body" region and a "shield" region extending to one side.
+Coins that touch any region of the player are collected.
+
+Hit box outlines are drawn for visual debugging. Use A/D to rotate
+the player and see both regions rotate together.
+
+If Python and Arcade are installed, this example can be run from the
+command line with:
+python -m arcade.examples.sprite_multi_hitbox
+"""
+
+import random
+import math
+import arcade
+from arcade.hitbox import HitBox
+
+WINDOW_WIDTH = 1280
+WINDOW_HEIGHT = 720
+WINDOW_TITLE = "Multi-Region Hit Box Example"
+
+PLAYER_SPEED = 5.0
+COIN_SPEED = 2.0
+COIN_COUNT = 20
+
+
+class GameView(arcade.View):
+
+    def __init__(self):
+        super().__init__()
+        self.player_sprite = None
+        self.player_list = None
+        self.coin_list = None
+        self.score = 0
+        self.score_display = None
+        self.background_color = arcade.csscolor.DARK_SLATE_GRAY
+
+        self.left_pressed = False
+        self.right_pressed = False
+        self.up_pressed = False
+        self.down_pressed = False
+
+    def setup(self):
+        self.player_list = arcade.SpriteList()
+        self.coin_list = arcade.SpriteList()
+        self.score = 0
+        self.score_display = arcade.Text(
+            text="Score: 0",
+            x=10, y=WINDOW_HEIGHT - 30,
+            color=arcade.color.WHITE, font_size=16,
+        )
+
+        # Create the player sprite
+        img = ":resources:images/animated_characters/female_person/femalePerson_idle.png"
+        self.player_sprite = arcade.Sprite(img, scale=0.5)
+        self.player_sprite.position = WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2
+
+        # Replace the default hitbox with a multi-region hitbox.
+        # "body" is a box around the torso, "shield" extends to the right.
+        # Collision detection automatically checks all regions.
+        self.player_sprite.hit_box = HitBox(
+            {
+                "body": [(-15, -48), (-15, 40), (15, 40), (15, -48)],
+                "shield": [(15, -30), (15, 30), (45, 30), (45, -30)],
+            },
+            position=self.player_sprite.position,
+            scale=self.player_sprite.scale,
+            angle=self.player_sprite.angle,
+        )
+
+        self.player_list.append(self.player_sprite)
+        self._spawn_coins(COIN_COUNT)
+
+    def _spawn_coins(self, count):
+        for _ in range(count):
+            coin = arcade.Sprite(":resources:images/items/coinGold.png", scale=0.4)
+
+            # Spawn along a random edge
+            side = random.randint(0, 3)
+            if side == 0:
+                coin.center_x = random.randrange(WINDOW_WIDTH)
+                coin.center_y = WINDOW_HEIGHT + 20
+            elif side == 1:
+                coin.center_x = random.randrange(WINDOW_WIDTH)
+                coin.center_y = -20
+            elif side == 2:
+                coin.center_x = -20
+                coin.center_y = random.randrange(WINDOW_HEIGHT)
+            else:
+                coin.center_x = WINDOW_WIDTH + 20
+                coin.center_y = random.randrange(WINDOW_HEIGHT)
+
+            # Aim toward the center with some randomness
+            target_x = WINDOW_WIDTH / 2 + random.randint(-200, 200)
+            target_y = WINDOW_HEIGHT / 2 + random.randint(-200, 200)
+            dx = target_x - coin.center_x
+            dy = target_y - coin.center_y
+            dist = math.hypot(dx, dy)
+            if dist > 0:
+                coin.change_x = (dx / dist) * COIN_SPEED
+                coin.change_y = (dy / dist) * COIN_SPEED
+
+            self.coin_list.append(coin)
+
+    def on_draw(self):
+        self.clear()
+
+        self.coin_list.draw()
+        self.player_list.draw()
+
+        # Debug: draw each hitbox region in a different color
+        player_hb = self.player_sprite.hit_box
+        for region_name in player_hb.region_names:
+            pts = player_hb.get_adjusted_points(region_name)
+            color = arcade.color.RED if region_name == "body" else arcade.color.CYAN
+            arcade.draw_line_strip(tuple(pts) + (pts[0],), color=color, line_width=2)
+
+        self.coin_list.draw_hit_boxes(color=arcade.color.YELLOW, line_thickness=1)
+        self.score_display.draw()
+
+        arcade.draw_text(
+            "Red = Body  |  Cyan = Shield  |  Arrow keys to move  |  A/D to rotate",
+            WINDOW_WIDTH / 2, 20,
+            arcade.color.WHITE, font_size=12, anchor_x="center",
+        )
+
+    def on_key_press(self, key, modifiers):
+        if key in (arcade.key.UP, arcade.key.W):
+            self.up_pressed = True
+        elif key in (arcade.key.DOWN, arcade.key.S):
+            self.down_pressed = True
+        elif key == arcade.key.LEFT:
+            self.left_pressed = True
+        elif key == arcade.key.RIGHT:
+            self.right_pressed = True
+
+    def on_key_release(self, key, modifiers):
+        if key in (arcade.key.UP, arcade.key.W):
+            self.up_pressed = False
+        elif key in (arcade.key.DOWN, arcade.key.S):
+            self.down_pressed = False
+        elif key == arcade.key.LEFT:
+            self.left_pressed = False
+        elif key == arcade.key.RIGHT:
+            self.right_pressed = False
+
+    def on_update(self, delta_time):
+        # Move the player
+        if self.up_pressed:
+            self.player_sprite.center_y += PLAYER_SPEED
+        if self.down_pressed:
+            self.player_sprite.center_y -= PLAYER_SPEED
+        if self.left_pressed:
+            self.player_sprite.center_x -= PLAYER_SPEED
+        if self.right_pressed:
+            self.player_sprite.center_x += PLAYER_SPEED
+
+        # Rotate with A/D
+        keys = self.window.keyboard
+        if keys[arcade.key.A]:
+            self.player_sprite.angle -= 3.0
+        if keys[arcade.key.D]:
+            self.player_sprite.angle += 3.0
+
+        # Move coins
+        self.coin_list.update()
+
+        # Standard collision check — automatically tests all hitbox regions
+        hit_list = arcade.check_for_collision_with_list(
+            self.player_sprite, self.coin_list
+        )
+        if hit_list:
+            for coin in hit_list:
+                coin.remove_from_sprite_lists()
+                self.score += 1
+            self.score_display.text = f"Score: {self.score}"
+
+        # Replace coins that left the screen
+        margin = 100
+        for coin in list(self.coin_list):
+            if (coin.center_x < -margin or coin.center_x > WINDOW_WIDTH + margin
+                    or coin.center_y < -margin or coin.center_y > WINDOW_HEIGHT + margin):
+                coin.remove_from_sprite_lists()
+        if len(self.coin_list) < COIN_COUNT:
+            self._spawn_coins(COIN_COUNT - len(self.coin_list))
+
+
+def main():
+    window = arcade.Window(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
+    game = GameView()
+    game.setup()
+    window.show_view(game)
+    arcade.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/arcade/gui/widgets/dropdown.py
+++ b/arcade/gui/widgets/dropdown.py
@@ -294,8 +294,7 @@ class UIDropdown(UILayout):
         overlay_w = self.width + scroll_bar_w
 
         overlay.rect = (
-            overlay.rect
-            .resize(overlay_w, visible_h)
+            overlay.rect.resize(overlay_w, visible_h)
             .align_top(self.bottom - 2)
             .align_left(self._default_button.left)
         )

--- a/arcade/gui/widgets/layout.py
+++ b/arcade/gui/widgets/layout.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Literal, TypeVar
 from types import EllipsisType
+from typing import Literal, TypeVar
 
 from typing_extensions import override
 

--- a/arcade/hitbox/__init__.py
+++ b/arcade/hitbox/__init__.py
@@ -2,7 +2,7 @@ from PIL.Image import Image
 
 from arcade.types import Point2List
 
-from .base import HitBox, HitBoxAlgorithm, RotatableHitBox
+from .base import HitBox, HitBoxAlgorithm
 from .bounding_box import BoundingHitBoxAlgorithm
 
 from .simple import SimpleHitBoxAlgorithm
@@ -13,7 +13,8 @@ algo_simple = SimpleHitBoxAlgorithm()
 #: The detailed hit box algorithm. This depends on pymunk and will fallback to the simple algorithm.
 try:
     from .pymunk import PymunkHitBoxAlgorithm
-    algo_detailed = PymunkHitBoxAlgorithm()
+
+    algo_detailed: HitBoxAlgorithm = PymunkHitBoxAlgorithm()
 except ImportError:
     print("WARNING: Running without PyMunk. The detailed hitbox algorithm will fallback to simple")
     algo_detailed = SimpleHitBoxAlgorithm()
@@ -58,7 +59,6 @@ def calculate_hit_box_points_detailed(
 __all__ = [
     "HitBoxAlgorithm",
     "HitBox",
-    "RotatableHitBox",
     "SimpleHitBoxAlgorithm",
     "PymunkHitBoxAlgorithm",
     "BoundingHitBoxAlgorithm",

--- a/arcade/hitbox/__init__.py
+++ b/arcade/hitbox/__init__.py
@@ -2,7 +2,7 @@ from PIL.Image import Image
 
 from arcade.types import Point2List
 
-from .base import HitBox, HitBoxAlgorithm
+from .base import HitBox, HitBoxAlgorithm, RawHitBox
 from .bounding_box import BoundingHitBoxAlgorithm
 
 from .simple import SimpleHitBoxAlgorithm
@@ -59,6 +59,7 @@ def calculate_hit_box_points_detailed(
 __all__ = [
     "HitBoxAlgorithm",
     "HitBox",
+    "RawHitBox",
     "SimpleHitBoxAlgorithm",
     "PymunkHitBoxAlgorithm",
     "BoundingHitBoxAlgorithm",

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -4,14 +4,21 @@ import gzip
 import json
 from math import cos, radians, sin
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 from PIL.Image import Image
 from typing_extensions import Self
 
 from arcade.types import EMPTY_POINT_LIST, Point2, Point2List
 
-__all__ = ["HitBoxAlgorithm", "HitBox"]
+__all__ = ["HitBoxAlgorithm", "HitBox", "RawHitBox"]
+
+
+class RawHitBox(TypedDict):
+    """Typed dictionary representing the serialized form of a :py:class:`HitBox`."""
+
+    version: int
+    regions: dict[str, Point2List]
 
 
 class HitBoxAlgorithm:
@@ -134,14 +141,21 @@ class HitBox:
 
         loaded = HitBox.load("hitbox.json")
 
-        # Dict round-trip
+        # Dict round-trip (see RawHitBox for the schema)
         data = box.to_dict()
         copy = HitBox.from_dict(data)
+
+    .. note::
+
+        All points are normalized to tuples of tuples on construction.
+        Any sequence type is accepted as input, but regions will always
+        store tuples internally.
 
     Args:
         points:
             Either a single ``Point2List`` (creates a ``"default"`` region)
             or a ``dict[str, Point2List]`` mapping region names to point lists.
+            Points are normalized to tuples on storage.
         position:
             The center around which the points will be offset.
         scale:
@@ -160,9 +174,11 @@ class HitBox:
         angle: float = 0.0,
     ):
         if isinstance(points, dict):
-            self._regions: dict[str, Point2List] = dict(points)
+            self._regions: dict[str, Point2List] = {
+                name: tuple(tuple(p) for p in pts) for name, pts in points.items()
+            }
         else:
-            self._regions = {self.DEFAULT_REGION: points}
+            self._regions = {self.DEFAULT_REGION: tuple(tuple(p) for p in points)}
 
         self._position = position
         self._scale = scale
@@ -205,7 +221,7 @@ class HitBox:
             name: The name for the new region.
             points: The polygon points for the region.
         """
-        self._regions[name] = points
+        self._regions[name] = tuple(tuple(p) for p in points)
         self._is_single_region = len(self._regions) == 1
         self._adjusted_cache_dirty = True
 
@@ -324,7 +340,7 @@ class HitBox:
             return (x + position_x, y + position_y)
 
         self._adjusted_regions = {
-            name: [_adjust_point(p) for p in pts] for name, pts in self._regions.items()
+            name: tuple(_adjust_point(p) for p in pts) for name, pts in self._regions.items()
         }
         self._adjusted_cache_dirty = False
 
@@ -352,39 +368,36 @@ class HitBox:
 
     # --- Serialization ---
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> RawHitBox:
         """
-        Serialize the hitbox shape to a dictionary.
+        Serialize the hitbox shape to a :py:class:`RawHitBox` dictionary.
 
         Only the region definitions (point data) are serialized.
         Position, scale, and angle are runtime state and are not included.
         """
         return {
             "version": 1,
-            "regions": {name: [list(p) for p in pts] for name, pts in self._regions.items()},
+            "regions": {name: pts for name, pts in self._regions.items()},
         }
 
     @classmethod
     def from_dict(
         cls,
-        data: dict,
+        data: RawHitBox,
         position: Point2 = (0.0, 0.0),
         scale: Point2 = (1.0, 1.0),
         angle: float = 0.0,
     ) -> HitBox:
         """
-        Create a HitBox from a serialized dictionary.
+        Create a HitBox from a :py:class:`RawHitBox` dictionary.
 
         Args:
-            data: The dictionary to deserialize from.
+            data: A :py:class:`RawHitBox` dictionary to deserialize from.
             position: The center offset.
             scale: The scaling factors.
             angle: The rotation angle in degrees.
         """
-        regions: dict[str, Point2List] = {
-            name: tuple(tuple(p) for p in pts) for name, pts in data["regions"].items()
-        }
-        return cls(points=regions, position=position, scale=scale, angle=angle)
+        return cls(points=data["regions"], position=position, scale=scale, angle=angle)
 
     def save(self, path: str | Path) -> None:
         """

--- a/arcade/hitbox/base.py
+++ b/arcade/hitbox/base.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import gzip
+import json
 from math import cos, radians, sin
+from pathlib import Path
 from typing import Any
 
 from PIL.Image import Image
@@ -8,7 +11,7 @@ from typing_extensions import Self
 
 from arcade.types import EMPTY_POINT_LIST, Point2, Point2List
 
-__all__ = ["HitBoxAlgorithm", "HitBox", "RotatableHitBox"]
+__all__ = ["HitBoxAlgorithm", "HitBox"]
 
 
 class HitBoxAlgorithm:
@@ -92,52 +95,134 @@ class HitBoxAlgorithm:
 
 class HitBox:
     """
-    A basic hit box class supporting scaling.
+    A hit box with support for multiple named regions, scaling, and rotation.
 
-    It includes support for rescaling as well as shorthand properties
-    for boundary values along the X and Y axes. For rotation support,
-    use :py:meth:`.create_rotatable` to create an instance of
-    :py:class:`RotatableHitBox`.
+    Each region is a named polygon (sequence of points). A hitbox with a
+    single region can be constructed by passing a ``Point2List`` directly,
+    which creates a region named ``"default"``. For multiple regions, pass
+    a ``dict[str, Point2List]``.
+
+    **Single-region construction** (backward compatible)::
+
+        box = HitBox(
+            [(-10, -10), (10, -10), (10, 10), (-10, 10)]
+        )
+
+    **Multi-region construction** with a dict::
+
+        box = HitBox({
+            "body": [(-10, -10), (10, -10), (10, 10), (-10, 10)],
+            "head": [(-5, 10), (5, 10), (5, 20), (-5, 20)],
+        })
+
+    **Rotation** (replaces the former ``RotatableHitBox`` class)::
+
+        box = HitBox(points, angle=45.0)
+        # Angle can be updated later:
+        box.angle = 90.0
+
+    **Region management**::
+
+        box.add_region("shield", shield_points)
+        box.has_region("shield")   # True
+        box.remove_region("shield")
+
+    **Serialization** to and from JSON files::
+
+        box.save("hitbox.json")       # plain JSON
+        box.save("hitbox.json.gz")    # gzip-compressed
+
+        loaded = HitBox.load("hitbox.json")
+
+        # Dict round-trip
+        data = box.to_dict()
+        copy = HitBox.from_dict(data)
 
     Args:
         points:
-            The unmodified points bounding the hit box
+            Either a single ``Point2List`` (creates a ``"default"`` region)
+            or a ``dict[str, Point2List]`` mapping region names to point lists.
         position:
-            The center around which the points will be offset
+            The center around which the points will be offset.
         scale:
-            The X and Y scaling factors to use when offsetting the points
+            The X and Y scaling factors.
+        angle:
+            The rotation angle in degrees (clockwise).
     """
+
+    DEFAULT_REGION = "default"
 
     def __init__(
         self,
-        points: Point2List,
+        points: Point2List | dict[str, Point2List],
         position: Point2 = (0.0, 0.0),
         scale: Point2 = (1.0, 1.0),
+        angle: float = 0.0,
     ):
-        self._points = points
+        if isinstance(points, dict):
+            self._regions: dict[str, Point2List] = dict(points)
+        else:
+            self._regions = {self.DEFAULT_REGION: points}
+
         self._position = position
         self._scale = scale
+        self._angle: float = angle
+        self._is_single_region: bool = len(self._regions) == 1
 
-        # This empty tuple will be replaced the first time
-        # get_adjusted_points is called
-        self._adjusted_points: Point2List = EMPTY_POINT_LIST
+        # Cached adjusted points per region
+        self._adjusted_regions: dict[str, Point2List] = {}
         self._adjusted_cache_dirty = True
 
     @property
     def points(self) -> Point2List:
         """
-        The raw, unadjusted points of this hit box.
+        The raw, unadjusted points of the default region.
 
-        These are the points as originally passed before offsetting, scaling,
-        and any operations subclasses may perform, such as rotation.
+        This is provided for backward compatibility. For multi-region
+        hitboxes, use :py:attr:`regions` instead.
         """
-        return self._points
+        return self._regions.get(self.DEFAULT_REGION, EMPTY_POINT_LIST)
+
+    @property
+    def regions(self) -> dict[str, Point2List]:
+        """All raw, unadjusted regions as a dict mapping names to point lists."""
+        return self._regions
+
+    @property
+    def region_names(self) -> tuple[str, ...]:
+        """The names of all regions in this hit box."""
+        return tuple(self._regions.keys())
+
+    def has_region(self, name: str) -> bool:
+        """Check if a region with the given name exists."""
+        return name in self._regions
+
+    def add_region(self, name: str, points: Point2List) -> None:
+        """
+        Add a named region to this hit box.
+
+        Args:
+            name: The name for the new region.
+            points: The polygon points for the region.
+        """
+        self._regions[name] = points
+        self._is_single_region = len(self._regions) == 1
+        self._adjusted_cache_dirty = True
+
+    def remove_region(self, name: str) -> None:
+        """
+        Remove a named region from this hit box.
+
+        Args:
+            name: The name of the region to remove.
+        """
+        del self._regions[name]
+        self._is_single_region = len(self._regions) == 1
+        self._adjusted_cache_dirty = True
 
     @property
     def position(self) -> Point2:
-        """
-        The center point used to offset the final adjusted positions.
-        """
+        """The center point used to offset the final adjusted positions."""
         return self._position
 
     @position.setter
@@ -145,45 +230,59 @@ class HitBox:
         self._position = position
         self._adjusted_cache_dirty = True
 
-    # Per Clepto's testing as of around May 2023, these are better
-    # left uncached because caching them is somehow slower than what
-    # we currently do. Any readers should feel free to retest /
-    # investigate further.
+    @property
+    def angle(self) -> float:
+        """The angle to rotate the raw points by in degrees."""
+        return self._angle
+
+    @angle.setter
+    def angle(self, angle: float):
+        self._angle = angle
+        self._adjusted_cache_dirty = True
+
     @property
     def left(self) -> float:
-        """
-        Calculates the leftmost adjusted x position of this hit box
-        """
-        points = self.get_adjusted_points()
-        x_points = [point[0] for point in points]
-        return min(x_points)
+        """Calculates the leftmost adjusted x position across all regions."""
+        self._recalculate_if_dirty()
+        min_x = float("inf")
+        for points in self._adjusted_regions.values():
+            for point in points:
+                if point[0] < min_x:
+                    min_x = point[0]
+        return min_x
 
     @property
     def right(self) -> float:
-        """
-        Calculates the rightmost adjusted x position of this hit box
-        """
-        points = self.get_adjusted_points()
-        x_points = [point[0] for point in points]
-        return max(x_points)
+        """Calculates the rightmost adjusted x position across all regions."""
+        self._recalculate_if_dirty()
+        max_x = float("-inf")
+        for points in self._adjusted_regions.values():
+            for point in points:
+                if point[0] > max_x:
+                    max_x = point[0]
+        return max_x
 
     @property
     def top(self) -> float:
-        """
-        Calculates the topmost adjusted y position of this hit box
-        """
-        points = self.get_adjusted_points()
-        y_points = [point[1] for point in points]
-        return max(y_points)
+        """Calculates the topmost adjusted y position across all regions."""
+        self._recalculate_if_dirty()
+        max_y = float("-inf")
+        for points in self._adjusted_regions.values():
+            for point in points:
+                if point[1] > max_y:
+                    max_y = point[1]
+        return max_y
 
     @property
     def bottom(self) -> float:
-        """
-        Calculates the bottommost adjusted y position of this hit box
-        """
-        points = self.get_adjusted_points()
-        y_points = [point[1] for point in points]
-        return min(y_points)
+        """Calculates the bottommost adjusted y position across all regions."""
+        self._recalculate_if_dirty()
+        min_y = float("inf")
+        for points in self._adjusted_regions.values():
+            for point in points:
+                if point[1] < min_y:
+                    min_y = point[1]
+        return min_y
 
     @property
     def scale(self) -> tuple[float, float]:
@@ -199,127 +298,138 @@ class HitBox:
         self._scale = scale
         self._adjusted_cache_dirty = True
 
-    def create_rotatable(
-        self,
-        angle: float = 0.0,
-    ) -> RotatableHitBox:
-        """
-        Create a rotatable instance of this hit box.
-
-        The internal ``PointList`` is transferred directly instead of
-        deep copied, so care should be taken if using a mutable internal
-        representation.
-
-        Args:
-            angle: The angle to rotate points by (0 by default)
-        """
-        return RotatableHitBox(
-            self._points, position=self._position, scale=self._scale, angle=angle
-        )
-
-    def get_adjusted_points(self) -> Point2List:
-        """
-        Return the positions of points, scaled and offset from the center.
-
-        Unlike the boundary helper properties (left, etc), this method will
-        only recalculate the values when necessary:
-
-        * The first time this method is called
-        * After properties affecting adjusted position were changed
-        """
+    def _recalculate_if_dirty(self) -> None:
+        """Recalculate all adjusted regions if the cache is dirty."""
         if not self._adjusted_cache_dirty:
-            return self._adjusted_points  # type: ignore
-
-        position_x, position_y = self._position
-        scale_x, scale_y = self._scale
-
-        def _adjust_point(point) -> Point2:
-            x, y = point
-
-            x *= scale_x
-            y *= scale_y
-
-            return (x + position_x, y + position_y)
-
-        self._adjusted_points = [_adjust_point(point) for point in self._points]
-        self._adjusted_cache_dirty = False
-        return self._adjusted_points
-
-
-class RotatableHitBox(HitBox):
-    """
-    A hit box with support for rotation.
-
-    Rotation is separated from the basic hitbox because it is much
-    slower than offsetting and scaling.
-
-    Args:
-        points:
-            The unmodified points bounding the hit box
-        position:
-            The translation to apply to the points
-        angle:
-            The angle to rotate the points by
-        scale:
-            The X and Y scaling factors
-    """
-
-    def __init__(
-        self,
-        points: Point2List,
-        *,
-        position: tuple[float, float] = (0.0, 0.0),
-        angle: float = 0.0,
-        scale: Point2 = (1.0, 1.0),
-    ):
-        super().__init__(points, position=position, scale=scale)
-        self._angle: float = angle
-
-    @property
-    def angle(self) -> float:
-        """
-        The angle to rotate the raw points by in degrees
-        """
-        return self._angle
-
-    @angle.setter
-    def angle(self, angle: float):
-        self._angle = angle
-        self._adjusted_cache_dirty = True
-
-    def get_adjusted_points(self) -> Point2List:
-        """
-        Return the offset, scaled, & rotated points of this hitbox.
-
-        As with :py:meth:`.HitBox.get_adjusted_points`, this method only
-        recalculates the adjusted values when necessary.
-        """
-        if not self._adjusted_cache_dirty:
-            return self._adjusted_points
+            return
 
         rad = radians(-self._angle)
         scale_x, scale_y = self._scale
         position_x, position_y = self._position
         rad_cos = cos(rad)
         rad_sin = sin(rad)
+        do_rotate = bool(rad)
 
-        def _adjust_point(point) -> Point2:
+        def _adjust_point(point: Point2) -> Point2:
             x, y = point
-
             x *= scale_x
             y *= scale_y
 
-            if rad:
+            if do_rotate:
                 rot_x = x * rad_cos - y * rad_sin
                 rot_y = x * rad_sin + y * rad_cos
                 x = rot_x
                 y = rot_y
 
-            return (
-                x + position_x,
-                y + position_y,
-            )
+            return (x + position_x, y + position_y)
 
-        self._adjusted_points = [_adjust_point(point) for point in self._points]
+        self._adjusted_regions = {
+            name: [_adjust_point(p) for p in pts] for name, pts in self._regions.items()
+        }
         self._adjusted_cache_dirty = False
-        return self._adjusted_points
+
+    def get_adjusted_points(self, region: str | None = None) -> Point2List:
+        """
+        Return the positions of points, scaled, rotated, and offset.
+
+        Args:
+            region:
+                The name of the region to get points for. If ``None``,
+                returns the default region's points (backward compatible).
+        """
+        self._recalculate_if_dirty()
+        name = region if region is not None else self.DEFAULT_REGION
+        return self._adjusted_regions.get(name, EMPTY_POINT_LIST)
+
+    def get_all_adjusted_polygons(self) -> list[Point2List]:
+        """
+        Return adjusted points for all regions as a list of polygons.
+
+        This is used by collision detection to check all regions.
+        """
+        self._recalculate_if_dirty()
+        return list(self._adjusted_regions.values())
+
+    # --- Serialization ---
+
+    def to_dict(self) -> dict:
+        """
+        Serialize the hitbox shape to a dictionary.
+
+        Only the region definitions (point data) are serialized.
+        Position, scale, and angle are runtime state and are not included.
+        """
+        return {
+            "version": 1,
+            "regions": {name: [list(p) for p in pts] for name, pts in self._regions.items()},
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict,
+        position: Point2 = (0.0, 0.0),
+        scale: Point2 = (1.0, 1.0),
+        angle: float = 0.0,
+    ) -> HitBox:
+        """
+        Create a HitBox from a serialized dictionary.
+
+        Args:
+            data: The dictionary to deserialize from.
+            position: The center offset.
+            scale: The scaling factors.
+            angle: The rotation angle in degrees.
+        """
+        regions: dict[str, Point2List] = {
+            name: tuple(tuple(p) for p in pts) for name, pts in data["regions"].items()
+        }
+        return cls(points=regions, position=position, scale=scale, angle=angle)
+
+    def save(self, path: str | Path) -> None:
+        """
+        Save the hitbox shape definition to a JSON file.
+
+        If the path ends with ``.gz``, the file will be gzip-compressed.
+
+        Args:
+            path: The file path to save to.
+        """
+        path = Path(path)
+        data_str = json.dumps(self.to_dict())
+        data_bytes = data_str.encode("utf-8")
+
+        if path.suffix == ".gz":
+            data_bytes = gzip.compress(data_bytes)
+
+        with open(path, mode="wb") as fd:
+            fd.write(data_bytes)
+
+    @classmethod
+    def load(
+        cls,
+        path: str | Path,
+        position: Point2 = (0.0, 0.0),
+        scale: Point2 = (1.0, 1.0),
+        angle: float = 0.0,
+    ) -> HitBox:
+        """
+        Load a hitbox shape definition from a JSON file.
+
+        If the path ends with ``.gz``, the file is assumed to be gzip-compressed.
+
+        Args:
+            path: The file path to load from.
+            position: The center offset.
+            scale: The scaling factors.
+            angle: The rotation angle in degrees.
+        """
+        path = Path(path)
+        if path.suffix == ".gz":
+            with gzip.open(path, mode="rb") as fd:
+                data = json.loads(fd.read())
+        else:
+            with open(path) as fd:
+                data = json.loads(fd.read())
+
+        return cls.from_dict(data, position=position, scale=scale, angle=angle)

--- a/arcade/hitbox_editor/__init__.py
+++ b/arcade/hitbox_editor/__init__.py
@@ -1,0 +1,32 @@
+"""HitBox Editor - A visual tool for creating and editing sprite hitbox regions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def run_editor(
+    texture_path: str | Path | None = None,
+    hitbox_path: str | Path | None = None,
+    width: int = 1280,
+    height: int = 720,
+) -> int:
+    """Launch the HitBox Editor application.
+
+    Args:
+        texture_path: Optional path to a texture image file to load on startup.
+        hitbox_path: Optional path to an existing hitbox JSON file to load.
+        width: Window width in pixels.
+        height: Window height in pixels.
+
+    Returns:
+        Exit code (0 for success).
+    """
+    import arcade
+    from arcade.hitbox_editor.app import HitBoxEditorView
+
+    window = arcade.Window(width, height, "HitBox Editor", resizable=True)
+    view = HitBoxEditorView(texture_path=texture_path, hitbox_path=hitbox_path)
+    window.show_view(view)
+    arcade.run()
+    return 0

--- a/arcade/hitbox_editor/app.py
+++ b/arcade/hitbox_editor/app.py
@@ -1,0 +1,448 @@
+"""Main application view for the HitBox Editor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import arcade
+from arcade.gui import UIView
+from arcade.gui.widgets.layout import UIAnchorLayout
+
+from arcade.hitbox_editor.canvas import CanvasRenderer
+from arcade.hitbox_editor.context_menu import ContextMenu
+from arcade.hitbox_editor.history import (
+    AddRegionCommand,
+    Clipboard,
+    CommandHistory,
+    CompositeCommand,
+    RemovePointCommand,
+    RemoveRegionCommand,
+)
+from arcade.hitbox_editor.panel import SidePanel
+from arcade.hitbox_editor.state import EditorState, ToolMode
+from arcade.hitbox_editor.tools import (
+    AddTool,
+    BaseTool,
+    DeleteTool,
+    SelectTool,
+    MOUSE_LEFT,
+    MOUSE_MIDDLE,
+    MOUSE_RIGHT,
+)
+
+PANEL_WIDTH = 300
+
+
+class HitBoxEditorView(UIView):
+    """The main view for the HitBox Editor application."""
+
+    def __init__(
+        self,
+        texture_path: str | Path | None = None,
+        hitbox_path: str | Path | None = None,
+    ) -> None:
+        super().__init__()
+        self.background_color = (30, 30, 35, 255)
+
+        # State
+        self.state = EditorState()
+        self.state.history = CommandHistory()
+        self.state.clipboard = Clipboard()
+
+        # Tools
+        self._tools: dict[ToolMode, BaseTool] = {
+            ToolMode.ADD: AddTool(),
+            ToolMode.SELECT: SelectTool(),
+            ToolMode.DELETE: DeleteTool(),
+        }
+
+        # Canvas
+        self.canvas = CanvasRenderer(self.state, self.window)
+
+        # Context menu state
+        self._context_menu: ContextMenu | None = None
+
+        # Track space key for pan-drag
+        self._space_held = False
+
+        # Build side panel
+        self._panel = SidePanel(
+            state=self.state,
+            on_load_texture=self._on_load_texture,
+            on_load_hitbox=self._on_load_hitbox,
+            on_save_json=self._on_save_json,
+            on_tool_change=self._on_tool_change,
+            on_region_select=self._on_region_select,
+            on_region_add=self._on_region_add,
+            on_region_remove=self._on_region_remove,
+        )
+
+        # Layout: anchor panel to right
+        anchor = self.add_widget(UIAnchorLayout())
+        anchor.add(self._panel, anchor_x="right", anchor_y="top")
+
+        # Load initial files if provided
+        if texture_path is not None:
+            self.state.load_texture(texture_path)
+            self.canvas.fit_texture(PANEL_WIDTH)
+        if hitbox_path is not None:
+            self.state.load_hitbox(hitbox_path)
+
+        self._refresh_panel()
+
+    def on_show_view(self) -> None:
+        super().on_show_view()
+        # Re-attach canvas to current window
+        self.canvas.window = self.window
+
+    def on_draw_before_ui(self) -> None:
+        """Draw the canvas (texture + polygons) before GUI elements."""
+        self.canvas.draw(PANEL_WIDTH)
+
+    def on_draw_after_ui(self) -> None:
+        """Draw status text overlaid on the top-right of the canvas area."""
+        self.window.default_camera.use()
+        text = self._build_status_text()
+        canvas_right = self.window.width - PANEL_WIDTH - 8
+        top = self.window.height - 8
+        arcade.draw_text(
+            text,
+            canvas_right, top,
+            color=(200, 200, 200, 200),
+            font_size=10,
+            anchor_x="right",
+            anchor_y="top",
+        )
+
+    def _in_canvas(self, x: float) -> bool:
+        """Check if x coordinate is in the canvas area (not the panel)."""
+        return x < self.window.width - PANEL_WIDTH
+
+    @property
+    def _active_tool(self) -> BaseTool:
+        return self._tools[self.state.tool_mode]
+
+    # --- Mouse events ---
+
+    def on_mouse_press(self, x: int, y: int, button: int, modifiers: int) -> None:
+        # Dismiss context menu on any click
+        if self._context_menu is not None:
+            self._dismiss_context_menu()
+            return
+
+        if not self._in_canvas(x):
+            return  # Let UIManager handle panel clicks
+
+        if button == MOUSE_RIGHT:
+            wx, wy = self.canvas.screen_to_world(x, y)
+            self._show_context_menu(x, y, wx, wy)
+            return
+
+        if button == MOUSE_LEFT and not self._space_held:
+            wx, wy = self.canvas.screen_to_world(x, y)
+            self._update_pick_threshold()
+            self._active_tool.on_press(self.state, wx, wy, button, modifiers)
+            self._refresh_panel()
+
+    def on_mouse_release(self, x: int, y: int, button: int, modifiers: int) -> None:
+        if button == MOUSE_LEFT and self._in_canvas(x):
+            wx, wy = self.canvas.screen_to_world(x, y)
+            self._active_tool.on_release(self.state, wx, wy, button, modifiers)
+            self._refresh_panel()
+
+    def on_mouse_drag(
+        self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int
+    ) -> None:
+        # Pan with middle mouse button or left+space
+        if (buttons & MOUSE_MIDDLE) or (buttons & MOUSE_LEFT and self._space_held):
+            self.canvas.pan(dx, dy)
+            return
+
+        if (buttons & MOUSE_LEFT) and self._in_canvas(x):
+            # Convert screen delta to world delta for the tool
+            # We need world-space delta, not screen-space delta
+            wx1, wy1 = self.canvas.screen_to_world(x - dx, y - dy)
+            wx2, wy2 = self.canvas.screen_to_world(x, y)
+            world_dx = wx2 - wx1
+            world_dy = wy2 - wy1
+            self._active_tool.on_drag(self.state, wx2, wy2, world_dx, world_dy)
+
+    def on_mouse_scroll(
+        self, x: int, y: int, scroll_x: int, scroll_y: int
+    ) -> None:
+        if self._in_canvas(x):
+            factor = 1.1 if scroll_y > 0 else 1 / 1.1
+            self.canvas.zoom_at(factor, x, y)
+
+    def on_mouse_motion(self, x: int, y: int, dx: int, dy: int) -> None:
+        if self._in_canvas(x):
+            wx, wy = self.canvas.screen_to_world(x, y)
+            self.state.cursor_world = (wx, wy)
+
+    # --- Keyboard events ---
+
+    def on_key_press(self, symbol: int, modifiers: int) -> None:
+        ctrl = modifiers & arcade.key.MOD_CTRL
+        shift = modifiers & arcade.key.MOD_SHIFT
+
+        if symbol == arcade.key.SPACE:
+            self._space_held = True
+            return
+
+        # Tool switching: 1/2/3
+        if symbol == arcade.key.KEY_1:
+            self._on_tool_change("add")
+        elif symbol == arcade.key.KEY_2:
+            self._on_tool_change("select")
+        elif symbol == arcade.key.KEY_3:
+            self._on_tool_change("delete")
+
+        # Fit view
+        elif symbol == arcade.key.F:
+            self.canvas.fit_texture(PANEL_WIDTH)
+
+        # Undo/Redo
+        elif symbol == arcade.key.Z and ctrl and shift:
+            self._do_redo()
+        elif symbol == arcade.key.Z and ctrl:
+            self._do_undo()
+        elif symbol == arcade.key.Y and ctrl:
+            self._do_redo()
+
+        # Copy/Cut/Paste
+        elif symbol == arcade.key.C and ctrl:
+            self._do_copy()
+        elif symbol == arcade.key.X and ctrl:
+            self._do_cut()
+        elif symbol == arcade.key.V and ctrl:
+            self._do_paste()
+
+        # Select all
+        elif symbol == arcade.key.A and ctrl:
+            self._do_select_all()
+
+        # Delete selected
+        elif symbol in (arcade.key.DELETE, arcade.key.BACKSPACE):
+            self._do_delete_selected()
+
+        # Save
+        elif symbol == arcade.key.S and ctrl:
+            self._on_save_json()
+
+        self._refresh_panel()
+
+    def on_key_release(self, symbol: int, modifiers: int) -> None:
+        if symbol == arcade.key.SPACE:
+            self._space_held = False
+
+    def _update_pick_threshold(self) -> None:
+        """Update point pick threshold based on current zoom level."""
+        # 10 pixels in screen space, converted to world units
+        self.state.pick_threshold = 10.0 / max(self.canvas.zoom, 0.01)
+
+    # --- Actions ---
+
+    def _do_undo(self) -> None:
+        if self.state.history:
+            self.state.history.undo(self.state)
+
+    def _do_redo(self) -> None:
+        if self.state.history:
+            self.state.history.redo(self.state)
+
+    def _do_copy(self) -> None:
+        if self.state.clipboard:
+            self.state.clipboard.copy(self.state)
+
+    def _do_cut(self) -> None:
+        if self.state.clipboard:
+            self.state.clipboard.cut(self.state)
+
+    def _do_paste(self) -> None:
+        if self.state.clipboard:
+            self.state.clipboard.paste(self.state)
+
+    def _do_select_all(self) -> None:
+        if self.state.active_region and self.state.active_region in self.state.regions:
+            self.state.selected_points.clear()
+            for i in range(len(self.state.regions[self.state.active_region])):
+                self.state.selected_points.add((self.state.active_region, i))
+
+    def _do_delete_selected(self) -> None:
+        if not self.state.selected_points or self.state.history is None:
+            return
+        removals = []
+        for region_name, index in sorted(self.state.selected_points, reverse=True):
+            if region_name in self.state.regions and index < len(
+                self.state.regions[region_name]
+            ):
+                point = self.state.regions[region_name][index]
+                removals.append(RemovePointCommand(region_name, index, point))
+
+        if removals:
+            cmd = CompositeCommand(removals, "Delete selected")
+            self.state.history.execute(cmd, self.state)
+            self.state.selected_points.clear()
+
+    # --- Context menu ---
+
+    def _show_context_menu(
+        self, screen_x: float, screen_y: float, world_x: float, world_y: float
+    ) -> None:
+        """Show a context menu at the given screen position."""
+        self._dismiss_context_menu()
+
+        # If right-clicking near a point, select it first
+        self._update_pick_threshold()
+        nearest = self.state.find_nearest_point(
+            world_x, world_y, self.state.pick_threshold
+        )
+        if nearest is not None:
+            key = (nearest[0], nearest[1])
+            if key not in self.state.selected_points:
+                self.state.selected_points.clear()
+                self.state.selected_points.add(key)
+                self.state.active_region = nearest[0]
+
+        self._context_menu = ContextMenu(
+            state=self.state,
+            ui_manager=self.ui,
+            x=screen_x,
+            y=screen_y,
+            on_dismiss=self._dismiss_context_menu,
+            world_x=world_x,
+            world_y=world_y,
+        )
+        self.ui.add(self._context_menu, layer=10)
+
+    def _dismiss_context_menu(self) -> None:
+        """Remove the context menu."""
+        if self._context_menu is not None:
+            self.ui.remove(self._context_menu)
+            self._context_menu = None
+        self._refresh_panel()
+
+    # --- Panel callbacks ---
+
+    def _on_load_texture(self) -> None:
+        path = _open_file_dialog(
+            "Open Texture",
+            [("Image files", "*.png *.jpg *.jpeg *.bmp *.gif"), ("All files", "*.*")],
+        )
+        if path:
+            self.state.load_texture(path)
+            self.canvas.fit_texture(PANEL_WIDTH)
+            self._refresh_panel()
+
+    def _on_load_hitbox(self) -> None:
+        path = _open_file_dialog(
+            "Open HitBox",
+            [("JSON files", "*.json *.json.gz"), ("All files", "*.*")],
+        )
+        if path:
+            self.state.load_hitbox(path)
+            self._refresh_panel()
+
+    def _on_save_json(self) -> None:
+        if not self.state.regions:
+            return
+        path = _save_file_dialog(
+            "Save HitBox",
+            [("JSON files", "*.json"), ("Compressed JSON", "*.json.gz"), ("All files", "*.*")],
+            default_extension=".json",
+        )
+        if path:
+            self.state.to_hitbox().save(path)
+
+    def _on_tool_change(self, tool_name: str) -> None:
+        mode = ToolMode(tool_name)
+        self.state.tool_mode = mode
+        self._refresh_panel()
+
+    def _on_region_select(self, name: str) -> None:
+        self.state.active_region = name
+        self.state.selected_points.clear()
+        self._refresh_panel()
+
+    def _on_region_add(self, name: str) -> None:
+        if name in self.state.regions or self.state.history is None:
+            return
+        cmd = AddRegionCommand(name)
+        self.state.history.execute(cmd, self.state)
+        self._refresh_panel()
+
+    def _on_region_remove(self) -> None:
+        if self.state.active_region is None or self.state.history is None:
+            return
+        name = self.state.active_region
+        points = list(self.state.regions.get(name, []))
+        cmd = RemoveRegionCommand(name, points)
+        self.state.history.execute(cmd, self.state)
+        self._refresh_panel()
+
+    def _refresh_panel(self) -> None:
+        """Refresh all dynamic panel elements."""
+        self._panel.refresh_region_list()
+        self._panel.refresh_tool_buttons()
+
+    def _build_status_text(self) -> str:
+        """Build the status text string."""
+        parts = []
+        cx, cy = self.state.cursor_world
+        parts.append(f"({cx:.1f}, {cy:.1f})")
+
+        if self.state.active_region:
+            pts = len(self.state.regions.get(self.state.active_region, []))
+            parts.append(f"Region: {self.state.active_region} ({pts} pts)")
+
+        sel = len(self.state.selected_points)
+        if sel:
+            parts.append(f"Selected: {sel}")
+
+        parts.append(f"Tool: {self.state.tool_mode.value}")
+        parts.append(f"Zoom: {self.canvas.zoom:.1f}x")
+
+        return " | ".join(parts)
+
+
+def _open_file_dialog(
+    title: str, filetypes: list[tuple[str, str]]
+) -> str | None:
+    """Open a file dialog using tkinter (stdlib)."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        path = filedialog.askopenfilename(title=title, filetypes=filetypes)
+        root.destroy()
+        return path if path else None
+    except Exception:
+        return None
+
+
+def _save_file_dialog(
+    title: str,
+    filetypes: list[tuple[str, str]],
+    default_extension: str = ".json",
+) -> str | None:
+    """Open a save file dialog using tkinter (stdlib)."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        path = filedialog.asksaveasfilename(
+            title=title,
+            filetypes=filetypes,
+            defaultextension=default_extension,
+        )
+        root.destroy()
+        return path if path else None
+    except Exception:
+        return None

--- a/arcade/hitbox_editor/canvas.py
+++ b/arcade/hitbox_editor/canvas.py
@@ -1,0 +1,257 @@
+"""Canvas rendering for the HitBox Editor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import arcade
+from arcade import LBWH, XYWH
+from arcade.camera import Camera2D
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.state import EditorState, ToolMode
+
+# Color palette for different regions
+REGION_COLORS = [
+    (255, 50, 50, 200),    # Red
+    (50, 255, 50, 200),    # Green
+    (50, 50, 255, 200),    # Blue
+    (255, 255, 50, 200),   # Yellow
+    (255, 50, 255, 200),   # Magenta
+    (50, 255, 255, 200),   # Cyan
+    (255, 128, 0, 200),    # Orange
+    (128, 0, 255, 200),    # Purple
+    (0, 255, 128, 200),    # Spring green
+    (255, 128, 128, 200),  # Light red
+]
+
+HANDLE_RADIUS = 5.0
+SELECTED_HANDLE_RADIUS = 7.0
+HANDLE_COLOR = (255, 255, 255, 220)
+SELECTED_HANDLE_COLOR = (255, 255, 0, 255)
+PREVIEW_LINE_COLOR = (200, 200, 200, 120)
+CHECKER_COLOR_A = (80, 80, 80, 255)
+CHECKER_COLOR_B = (60, 60, 60, 255)
+
+
+class CanvasRenderer:
+    """Handles rendering the texture, polygons, and handles on the canvas."""
+
+    def __init__(self, state: EditorState, window: arcade.Window) -> None:
+        self.state = state
+        self.window = window
+        self.camera = Camera2D()
+        self._zoom_level: float = 1.0
+
+    @property
+    def zoom(self) -> float:
+        return self._zoom_level
+
+    def screen_to_world(self, sx: float, sy: float) -> tuple[float, float]:
+        """Convert screen coordinates to world coordinates."""
+        result = self.camera.unproject((sx, sy))
+        return (result.x, result.y)
+
+    def pan(self, dx: float, dy: float) -> None:
+        """Pan the camera by screen-space delta."""
+        # Convert screen delta to world delta (inverse of zoom)
+        world_dx = -dx / self._zoom_level
+        world_dy = -dy / self._zoom_level
+        pos = self.camera.position
+        self.camera.position = (pos[0] + world_dx, pos[1] + world_dy)
+
+    def zoom_at(self, factor: float, screen_x: float, screen_y: float) -> None:
+        """Zoom toward/away from screen point."""
+        # Get world pos before zoom
+        before = self.camera.unproject((screen_x, screen_y))
+
+        # Apply zoom
+        self._zoom_level *= factor
+        self._zoom_level = max(0.05, min(50.0, self._zoom_level))
+        self.camera.zoom = self._zoom_level
+
+        # Get world pos after zoom
+        after = self.camera.unproject((screen_x, screen_y))
+
+        # Adjust position to keep the world point under the cursor
+        pos = self.camera.position
+        self.camera.position = (
+            pos[0] + (before.x - after.x),
+            pos[1] + (before.y - after.y),
+        )
+
+    def fit_texture(self, panel_width: int = 300) -> None:
+        """Reset camera to fit the texture in the canvas area."""
+        tex = self.state.texture
+        if tex is None:
+            self.camera.position = (0.0, 0.0)
+            self._zoom_level = 1.0
+            self.camera.zoom = 1.0
+            return
+
+        canvas_width = self.window.width - panel_width
+        canvas_height = self.window.height
+
+        if canvas_width <= 0 or canvas_height <= 0:
+            return
+
+        # Calculate zoom to fit texture with some padding
+        padding = 0.9  # 90% of available space
+        zoom_x = (canvas_width * padding) / tex.width
+        zoom_y = (canvas_height * padding) / tex.height
+        self._zoom_level = min(zoom_x, zoom_y)
+        self.camera.zoom = self._zoom_level
+
+        # Center camera on texture center, offset for the panel
+        # The panel takes up the right side, so shift camera left slightly
+        panel_world_offset = (panel_width / 2.0) / self._zoom_level
+        self.camera.position = (panel_world_offset, 0.0)
+
+    def draw(self, panel_width: int = 300) -> None:
+        """Draw the full canvas: background, texture, regions, handles."""
+        self.camera.use()
+
+        self._draw_checkerboard(panel_width)
+
+        if self.state.texture is not None:
+            self._draw_texture()
+
+        self._draw_regions()
+        self._draw_selection_rect()
+        self._draw_preview_line()
+
+    def _draw_checkerboard(self, panel_width: int) -> None:
+        """Draw a checkerboard pattern behind the texture area."""
+        tex = self.state.texture
+        if tex is None:
+            return
+
+        half_w = tex.width / 2
+        half_h = tex.height / 2
+        checker_size = 16.0
+
+        y = -half_h
+        row = 0
+        while y < half_h:
+            x = -half_w
+            col = 0
+            while x < half_w:
+                w = min(checker_size, half_w - x)
+                h = min(checker_size, half_h - y)
+                color = CHECKER_COLOR_A if (row + col) % 2 == 0 else CHECKER_COLOR_B
+                arcade.draw_rect_filled(LBWH(x, y, w, h), color)
+                x += checker_size
+                col += 1
+            y += checker_size
+            row += 1
+
+    def _draw_texture(self) -> None:
+        """Draw the loaded texture centered at origin."""
+        tex = self.state.texture
+        if tex is None:
+            return
+        rect = XYWH(0, 0, tex.width, tex.height)
+        arcade.draw_texture_rect(tex, rect)
+
+    def _draw_regions(self) -> None:
+        """Draw all hitbox regions as colored polygons with handles."""
+        region_names = list(self.state.regions.keys())
+        zoom = self._zoom_level
+
+        for idx, name in enumerate(region_names):
+            points = self.state.regions[name]
+            if not points:
+                continue
+
+            color = REGION_COLORS[idx % len(REGION_COLORS)]
+            is_active = name == self.state.active_region
+
+            # Draw faint fill for active region
+            if is_active and len(points) >= 3:
+                fill_color = (color[0], color[1], color[2], 45)
+                arcade.draw_polygon_filled(points, fill_color)
+
+            # Draw polygon outline
+            if len(points) >= 2:
+                line_width = 1.5
+                if len(points) >= 3:
+                    arcade.draw_polygon_outline(points, color, line_width)
+                else:
+                    arcade.draw_line(
+                        points[0][0], points[0][1],
+                        points[1][0], points[1][1],
+                        color, line_width,
+                    )
+
+            # Draw point handles
+            for i, (px, py) in enumerate(points):
+                key = (name, i)
+                if key in self.state.selected_points:
+                    # Selected point: filled circle + white outline ring + crosshair
+                    arcade.draw_circle_filled(
+                        px, py,
+                        SELECTED_HANDLE_RADIUS / zoom,
+                        SELECTED_HANDLE_COLOR,
+                    )
+                    arcade.draw_circle_outline(
+                        px, py,
+                        (SELECTED_HANDLE_RADIUS + 3) / zoom,
+                        (255, 255, 255, 255),
+                        2 / zoom,
+                    )
+                    # Small crosshair through selected point
+                    cross_len = 8.0 / zoom
+                    arcade.draw_line(
+                        px - cross_len, py, px + cross_len, py,
+                        (255, 255, 255, 150), 1.0,
+                    )
+                    arcade.draw_line(
+                        px, py - cross_len, px, py + cross_len,
+                        (255, 255, 255, 150), 1.0,
+                    )
+                else:
+                    arcade.draw_circle_filled(
+                        px, py,
+                        HANDLE_RADIUS / zoom,
+                        HANDLE_COLOR,
+                    )
+
+    def _draw_selection_rect(self) -> None:
+        """Draw the drag-to-select rectangle if active."""
+        rect = self.state.selection_rect
+        if rect is None:
+            return
+
+        x1, y1, x2, y2 = rect
+        cx = (x1 + x2) / 2
+        cy = (y1 + y2) / 2
+        w = abs(x2 - x1)
+        h = abs(y2 - y1)
+        if w < 0.1 or h < 0.1:
+            return
+
+        r = XYWH(cx, cy, w, h)
+        arcade.draw_rect_filled(r, (100, 150, 255, 30))
+        arcade.draw_rect_outline(r, (100, 150, 255, 180), 1.5)
+
+    def _draw_preview_line(self) -> None:
+        """Draw a preview line from the last point to the cursor in ADD mode."""
+        from arcade.hitbox_editor.state import ToolMode
+
+        if self.state.tool_mode != ToolMode.ADD:
+            return
+        if self.state.active_region is None:
+            return
+
+        points = self.state.regions.get(self.state.active_region, [])
+        if not points:
+            return
+
+        cx, cy = self.state.cursor_world
+        last = points[-1]
+        arcade.draw_line(last[0], last[1], cx, cy, PREVIEW_LINE_COLOR, 1.0)
+
+        # Also draw line from cursor back to first point (to show closing)
+        if len(points) >= 2:
+            first = points[0]
+            arcade.draw_line(cx, cy, first[0], first[1], PREVIEW_LINE_COLOR, 1.0)

--- a/arcade/hitbox_editor/commands.py
+++ b/arcade/hitbox_editor/commands.py
@@ -1,0 +1,53 @@
+"""CLI command for launching the HitBox Editor."""
+
+from __future__ import annotations
+
+import argparse
+
+from arcade.cli.commands.base import BaseCommand
+
+
+class HitBoxEditorCommand(BaseCommand):
+    """CLI command to launch the HitBox Editor."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="hitbox-editor",
+            description="Launch the visual HitBox Editor for creating and editing sprite hitbox regions.",
+            help="Visual editor for creating and editing sprite hitbox regions",
+        )
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "texture",
+            nargs="?",
+            default=None,
+            help="Path to a texture image file to load on startup",
+        )
+        parser.add_argument(
+            "--hitbox",
+            default=None,
+            help="Path to an existing hitbox JSON file to load",
+        )
+        parser.add_argument(
+            "--width",
+            type=int,
+            default=1280,
+            help="Window width in pixels (default: 1280)",
+        )
+        parser.add_argument(
+            "--height",
+            type=int,
+            default=720,
+            help="Window height in pixels (default: 720)",
+        )
+
+    def handle(self, args: argparse.Namespace) -> int:
+        from arcade.hitbox_editor import run_editor
+
+        return run_editor(
+            texture_path=args.texture,
+            hitbox_path=args.hitbox,
+            width=args.width,
+            height=args.height,
+        )

--- a/arcade/hitbox_editor/context_menu.py
+++ b/arcade/hitbox_editor/context_menu.py
@@ -1,0 +1,182 @@
+"""Right-click context menu for the HitBox Editor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import arcade
+from arcade.gui import UIManager
+from arcade.gui.widgets import UIWidget
+from arcade.gui.widgets.buttons import UIFlatButton
+from arcade.gui.widgets.layout import UIBoxLayout
+from arcade.types import Color
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.state import EditorState
+
+
+class ContextMenuItem(UIFlatButton):
+    """A single item in the context menu."""
+
+    def __init__(
+        self,
+        text: str,
+        callback: Callable[[], None],
+        enabled: bool = True,
+        width: float = 200,
+        height: float = 28,
+    ) -> None:
+        super().__init__(text=text, width=width, height=height)
+        self._callback = callback
+        self._enabled = enabled
+        if not enabled:
+            self.disabled = True
+
+    def on_click(self, event) -> None:
+        if self._enabled:
+            self._callback()
+
+
+class ContextMenuSeparator(UIWidget):
+    """A visual separator line in the context menu."""
+
+    def __init__(self, width: float = 200) -> None:
+        super().__init__(width=width, height=6)
+
+    def do_render(self, surface) -> None:
+        self.prepare_render(surface)
+        arcade.draw_line(
+            4, self.content_height / 2,
+            self.content_width - 4, self.content_height / 2,
+            (100, 100, 100, 180), 1,
+        )
+
+
+class ContextMenu(UIBoxLayout):
+    """A right-click context menu shown as an overlay."""
+
+    def __init__(
+        self,
+        state: EditorState,
+        ui_manager: UIManager,
+        x: float,
+        y: float,
+        on_dismiss: Callable[[], None],
+        world_x: float = 0.0,
+        world_y: float = 0.0,
+    ) -> None:
+        super().__init__(vertical=True, space_between=1)
+        self._state = state
+        self._ui_manager = ui_manager
+        self._on_dismiss = on_dismiss
+        self._world_x = world_x
+        self._world_y = world_y
+
+        self._build_items()
+
+        # Position at click location
+        self.rect = self.rect.move(x, y)
+
+    def _build_items(self) -> None:
+        """Build context menu items based on current state."""
+        state = self._state
+        has_selection = len(state.selected_points) > 0
+        has_clipboard = state.clipboard is not None and state.clipboard.has_content()
+        has_active = state.active_region is not None
+        can_undo = state.history is not None and state.history.can_undo()
+        can_redo = state.history is not None and state.history.can_redo()
+
+        # Add point here
+        self.add(ContextMenuItem(
+            "Add Point Here",
+            self._add_point_here,
+            enabled=has_active,
+        ))
+
+        self.add(ContextMenuSeparator())
+
+        # Edit operations
+        self.add(ContextMenuItem("Cut        Ctrl+X", self._cut, enabled=has_selection))
+        self.add(ContextMenuItem("Copy       Ctrl+C", self._copy, enabled=has_selection))
+        self.add(ContextMenuItem("Paste      Ctrl+V", self._paste, enabled=has_clipboard and has_active))
+
+        self.add(ContextMenuSeparator())
+
+        # Undo/Redo
+        self.add(ContextMenuItem("Undo       Ctrl+Z", self._undo, enabled=can_undo))
+        self.add(ContextMenuItem("Redo  Ctrl+Shift+Z", self._redo, enabled=can_redo))
+
+        self.add(ContextMenuSeparator())
+
+        # Selection
+        self.add(ContextMenuItem("Select All   Ctrl+A", self._select_all, enabled=has_active))
+        self.add(ContextMenuItem("Delete Selected", self._delete_selected, enabled=has_selection))
+
+    def _dismiss(self) -> None:
+        self._on_dismiss()
+
+    def _add_point_here(self) -> None:
+        from arcade.hitbox_editor.history import AddPointCommand
+
+        state = self._state
+        if state.active_region is not None and state.history is not None:
+            points = state.regions.get(state.active_region, [])
+            cmd = AddPointCommand(
+                state.active_region, len(points), (self._world_x, self._world_y)
+            )
+            state.history.execute(cmd, state)
+        self._dismiss()
+
+    def _cut(self) -> None:
+        if self._state.clipboard:
+            self._state.clipboard.cut(self._state)
+        self._dismiss()
+
+    def _copy(self) -> None:
+        if self._state.clipboard:
+            self._state.clipboard.copy(self._state)
+        self._dismiss()
+
+    def _paste(self) -> None:
+        if self._state.clipboard:
+            self._state.clipboard.paste(self._state)
+        self._dismiss()
+
+    def _undo(self) -> None:
+        if self._state.history:
+            self._state.history.undo(self._state)
+        self._dismiss()
+
+    def _redo(self) -> None:
+        if self._state.history:
+            self._state.history.redo(self._state)
+        self._dismiss()
+
+    def _select_all(self) -> None:
+        state = self._state
+        if state.active_region and state.active_region in state.regions:
+            state.selected_points.clear()
+            for i in range(len(state.regions[state.active_region])):
+                state.selected_points.add((state.active_region, i))
+        self._dismiss()
+
+    def _delete_selected(self) -> None:
+        from arcade.hitbox_editor.history import CompositeCommand, RemovePointCommand
+
+        state = self._state
+        if not state.selected_points or state.history is None:
+            self._dismiss()
+            return
+
+        removals = []
+        for region_name, index in sorted(state.selected_points, reverse=True):
+            if region_name in state.regions and index < len(state.regions[region_name]):
+                point = state.regions[region_name][index]
+                removals.append(RemovePointCommand(region_name, index, point))
+
+        if removals:
+            cmd = CompositeCommand(removals, "Delete selected points")
+            state.history.execute(cmd, state)
+            state.selected_points.clear()
+
+        self._dismiss()

--- a/arcade/hitbox_editor/history.py
+++ b/arcade/hitbox_editor/history.py
@@ -1,0 +1,324 @@
+"""Undo/redo command pattern and clipboard for the HitBox Editor."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.state import EditorState
+
+
+class Command(ABC):
+    """Base class for undoable editor commands."""
+
+    @abstractmethod
+    def execute(self, state: EditorState) -> None:
+        ...
+
+    @abstractmethod
+    def undo(self, state: EditorState) -> None:
+        ...
+
+    @abstractmethod
+    def description(self) -> str:
+        ...
+
+
+class CommandHistory:
+    """Manages undo/redo stacks of commands."""
+
+    def __init__(self, max_history: int = 100) -> None:
+        self._undo_stack: list[Command] = []
+        self._redo_stack: list[Command] = []
+        self.max_history = max_history
+
+    def execute(self, command: Command, state: EditorState) -> None:
+        """Execute a command and push it onto the undo stack."""
+        command.execute(state)
+        self._undo_stack.append(command)
+        if len(self._undo_stack) > self.max_history:
+            self._undo_stack.pop(0)
+        self._redo_stack.clear()
+
+    def undo(self, state: EditorState) -> None:
+        """Undo the last command."""
+        if not self._undo_stack:
+            return
+        command = self._undo_stack.pop()
+        command.undo(state)
+        self._redo_stack.append(command)
+
+    def redo(self, state: EditorState) -> None:
+        """Redo the last undone command."""
+        if not self._redo_stack:
+            return
+        command = self._redo_stack.pop()
+        command.execute(state)
+        self._undo_stack.append(command)
+
+    def can_undo(self) -> bool:
+        return len(self._undo_stack) > 0
+
+    def can_redo(self) -> bool:
+        return len(self._redo_stack) > 0
+
+
+# --- Command implementations ---
+
+
+class AddPointCommand(Command):
+    """Add a point to a region at a given index."""
+
+    def __init__(self, region: str, index: int, point: tuple[float, float]) -> None:
+        self.region = region
+        self.index = index
+        self.point = point
+
+    def execute(self, state: EditorState) -> None:
+        state.regions[self.region].insert(self.index, self.point)
+
+    def undo(self, state: EditorState) -> None:
+        state.regions[self.region].pop(self.index)
+
+    def description(self) -> str:
+        return "Add point"
+
+
+class RemovePointCommand(Command):
+    """Remove a point from a region at a given index."""
+
+    def __init__(self, region: str, index: int, point: tuple[float, float]) -> None:
+        self.region = region
+        self.index = index
+        self.point = point
+
+    def execute(self, state: EditorState) -> None:
+        state.regions[self.region].pop(self.index)
+        # Clean up selection
+        state.selected_points.discard((self.region, self.index))
+
+    def undo(self, state: EditorState) -> None:
+        state.regions[self.region].insert(self.index, self.point)
+
+    def description(self) -> str:
+        return "Remove point"
+
+
+class MovePointCommand(Command):
+    """Move a point from old_pos to new_pos."""
+
+    def __init__(
+        self,
+        region: str,
+        index: int,
+        old_pos: tuple[float, float],
+        new_pos: tuple[float, float],
+    ) -> None:
+        self.region = region
+        self.index = index
+        self.old_pos = old_pos
+        self.new_pos = new_pos
+
+    def execute(self, state: EditorState) -> None:
+        state.regions[self.region][self.index] = self.new_pos
+
+    def undo(self, state: EditorState) -> None:
+        state.regions[self.region][self.index] = self.old_pos
+
+    def description(self) -> str:
+        return "Move point"
+
+
+class MoveMultiplePointsCommand(Command):
+    """Move multiple points by a delta."""
+
+    def __init__(
+        self,
+        moves: list[tuple[str, int, tuple[float, float], tuple[float, float]]],
+    ) -> None:
+        # Each entry: (region, index, old_pos, new_pos)
+        self.moves = moves
+
+    def execute(self, state: EditorState) -> None:
+        for region, index, _, new_pos in self.moves:
+            state.regions[region][index] = new_pos
+
+    def undo(self, state: EditorState) -> None:
+        for region, index, old_pos, _ in self.moves:
+            state.regions[region][index] = old_pos
+
+    def description(self) -> str:
+        return f"Move {len(self.moves)} points"
+
+
+class AddRegionCommand(Command):
+    """Add a new empty region."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def execute(self, state: EditorState) -> None:
+        state.regions[self.name] = []
+        state.active_region = self.name
+
+    def undo(self, state: EditorState) -> None:
+        del state.regions[self.name]
+        if state.active_region == self.name:
+            state.active_region = next(iter(state.regions), None)
+
+    def description(self) -> str:
+        return f"Add region '{self.name}'"
+
+
+class RemoveRegionCommand(Command):
+    """Remove a region, saving its points for undo."""
+
+    def __init__(self, name: str, points: list[tuple[float, float]]) -> None:
+        self.name = name
+        self.points = points
+
+    def execute(self, state: EditorState) -> None:
+        del state.regions[self.name]
+        # Remove any selected points in this region
+        state.selected_points = {
+            (r, i) for r, i in state.selected_points if r != self.name
+        }
+        if state.active_region == self.name:
+            state.active_region = next(iter(state.regions), None)
+
+    def undo(self, state: EditorState) -> None:
+        state.regions[self.name] = list(self.points)
+        state.active_region = self.name
+
+    def description(self) -> str:
+        return f"Remove region '{self.name}'"
+
+
+class RenameRegionCommand(Command):
+    """Rename a region."""
+
+    def __init__(self, old_name: str, new_name: str) -> None:
+        self.old_name = old_name
+        self.new_name = new_name
+
+    def execute(self, state: EditorState) -> None:
+        state.regions[self.new_name] = state.regions.pop(self.old_name)
+        # Update selection references
+        state.selected_points = {
+            (self.new_name if r == self.old_name else r, i)
+            for r, i in state.selected_points
+        }
+        if state.active_region == self.old_name:
+            state.active_region = self.new_name
+
+    def undo(self, state: EditorState) -> None:
+        state.regions[self.old_name] = state.regions.pop(self.new_name)
+        state.selected_points = {
+            (self.old_name if r == self.new_name else r, i)
+            for r, i in state.selected_points
+        }
+        if state.active_region == self.new_name:
+            state.active_region = self.old_name
+
+    def description(self) -> str:
+        return f"Rename region '{self.old_name}' to '{self.new_name}'"
+
+
+class PastePointsCommand(Command):
+    """Insert multiple points into a region."""
+
+    def __init__(
+        self, region: str, index: int, points: list[tuple[float, float]]
+    ) -> None:
+        self.region = region
+        self.index = index
+        self.points = points
+
+    def execute(self, state: EditorState) -> None:
+        for i, pt in enumerate(self.points):
+            state.regions[self.region].insert(self.index + i, pt)
+
+    def undo(self, state: EditorState) -> None:
+        for _ in self.points:
+            state.regions[self.region].pop(self.index)
+
+    def description(self) -> str:
+        return f"Paste {len(self.points)} points"
+
+
+class CompositeCommand(Command):
+    """Execute multiple commands as a single undoable operation."""
+
+    def __init__(self, commands: list[Command], desc: str = "Multiple actions") -> None:
+        self.commands = commands
+        self._desc = desc
+
+    def execute(self, state: EditorState) -> None:
+        for cmd in self.commands:
+            cmd.execute(state)
+
+    def undo(self, state: EditorState) -> None:
+        for cmd in reversed(self.commands):
+            cmd.undo(state)
+
+    def description(self) -> str:
+        return self._desc
+
+
+class Clipboard:
+    """Clipboard for copy/cut/paste of points."""
+
+    def __init__(self) -> None:
+        self.points: list[tuple[float, float]] = []
+        self.source_region: str | None = None
+
+    def copy(self, state: EditorState) -> None:
+        """Copy selected points to the clipboard."""
+        if not state.selected_points:
+            return
+        self.points = []
+        self.source_region = None
+        for region_name, index in sorted(state.selected_points):
+            if region_name in state.regions and index < len(state.regions[region_name]):
+                self.points.append(state.regions[region_name][index])
+                self.source_region = region_name
+
+    def cut(self, state: EditorState) -> None:
+        """Copy selected points and remove them (undoable)."""
+        if not state.selected_points or state.history is None:
+            return
+        self.copy(state)
+
+        # Build removal commands in reverse index order to maintain indices
+        removals: list[Command] = []
+        for region_name, index in sorted(state.selected_points, reverse=True):
+            if region_name in state.regions and index < len(state.regions[region_name]):
+                point = state.regions[region_name][index]
+                removals.append(RemovePointCommand(region_name, index, point))
+
+        if removals:
+            composite = CompositeCommand(removals, "Cut points")
+            state.history.execute(composite, state)
+            state.selected_points.clear()
+
+    def paste(self, state: EditorState) -> None:
+        """Paste clipboard points into the active region (undoable)."""
+        if not self.points or state.active_region is None or state.history is None:
+            return
+        if state.active_region not in state.regions:
+            return
+
+        # Offset pasted points slightly to distinguish from originals
+        offset_points = [(x + 5.0, y + 5.0) for x, y in self.points]
+        insert_index = len(state.regions[state.active_region])
+        cmd = PastePointsCommand(state.active_region, insert_index, offset_points)
+        state.history.execute(cmd, state)
+
+        # Select the pasted points
+        state.selected_points.clear()
+        for i in range(len(offset_points)):
+            state.selected_points.add((state.active_region, insert_index + i))
+
+    def has_content(self) -> bool:
+        return len(self.points) > 0

--- a/arcade/hitbox_editor/panel.py
+++ b/arcade/hitbox_editor/panel.py
@@ -1,0 +1,181 @@
+"""Side panel UI for the HitBox Editor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import arcade
+from arcade.gui.widgets import UIWidget, UISpace
+from arcade.gui.widgets.buttons import UIFlatButton
+from arcade.gui.widgets.layout import UIBoxLayout
+from arcade.gui.widgets.text import UIInputText, UILabel
+from arcade.hitbox_editor.canvas import REGION_COLORS
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.state import EditorState, ToolMode
+
+
+PANEL_BG_COLOR = (40, 40, 45, 240)
+SECTION_LABEL_COLOR = (180, 180, 180, 255)
+ACTIVE_BUTTON_BG = (70, 130, 180, 255)
+INACTIVE_BUTTON_BG = (50, 50, 55, 255)
+
+
+class SidePanel(UIBoxLayout):
+    """Side panel with controls for the hitbox editor."""
+
+    def __init__(
+        self,
+        state: EditorState,
+        on_load_texture: Callable[[], None],
+        on_load_hitbox: Callable[[], None],
+        on_save_json: Callable[[], None],
+        on_tool_change: Callable[[str], None],
+        on_region_select: Callable[[str], None],
+        on_region_add: Callable[[str], None],
+        on_region_remove: Callable[[], None],
+        width: float = 300,
+    ) -> None:
+        super().__init__(
+            vertical=True,
+            space_between=4,
+            size_hint=(None, 1.0),
+        )
+        self.rect = self.rect.resize(width=width)
+        self.with_background(color=PANEL_BG_COLOR)
+        self.with_padding(all=8)
+
+        self._state = state
+        self._on_load_texture = on_load_texture
+        self._on_load_hitbox = on_load_hitbox
+        self._on_save_json = on_save_json
+        self._on_tool_change = on_tool_change
+        self._on_region_select = on_region_select
+        self._on_region_add = on_region_add
+        self._on_region_remove = on_region_remove
+
+        # References to dynamic widgets
+        self._region_list_container: UIBoxLayout | None = None
+        self._tool_buttons: dict[str, UIFlatButton] = {}
+        self._region_name_input: UIInputText | None = None
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        """Build the full panel UI."""
+        # --- File section ---
+        self.add(UILabel(text="FILE", font_size=10, text_color=SECTION_LABEL_COLOR))
+
+        file_row = UIBoxLayout(vertical=False, space_between=4, size_hint=(1.0, None))
+        file_row.rect = file_row.rect.resize(height=32)
+
+        load_tex_btn = UIFlatButton(text="Load Texture", width=136, height=32)
+        load_tex_btn.on_click = lambda _: self._on_load_texture()
+        file_row.add(load_tex_btn)
+
+        load_hb_btn = UIFlatButton(text="Load HitBox", width=136, height=32)
+        load_hb_btn.on_click = lambda _: self._on_load_hitbox()
+        file_row.add(load_hb_btn)
+
+        self.add(file_row)
+        self.add(UISpace(height=8))
+
+        # --- Tool section ---
+        self.add(UILabel(text="TOOL", font_size=10, text_color=SECTION_LABEL_COLOR))
+
+        tool_row = UIBoxLayout(vertical=False, space_between=4, size_hint=(1.0, None))
+        tool_row.rect = tool_row.rect.resize(height=32)
+
+        for tool_name in ("add", "select", "delete"):
+            btn = UIFlatButton(text=tool_name.capitalize(), width=90, height=32)
+            btn.on_click = lambda _, t=tool_name: self._on_tool_change(t)
+            self._tool_buttons[tool_name] = btn
+            tool_row.add(btn)
+
+        self.add(tool_row)
+        self.add(UISpace(height=8))
+
+        # --- Export section ---
+        self.add(UILabel(text="EXPORT", font_size=10, text_color=SECTION_LABEL_COLOR))
+
+        save_btn = UIFlatButton(text="Save JSON", width=280, height=32)
+        save_btn.on_click = lambda _: self._on_save_json()
+        self.add(save_btn)
+        self.add(UISpace(height=8))
+
+        # --- Region section ---
+        self.add(UILabel(text="REGIONS", font_size=10, text_color=SECTION_LABEL_COLOR))
+
+        # Add region controls (above the list so they stay in a fixed position)
+        add_region_row = UIBoxLayout(vertical=False, space_between=4, size_hint=(1.0, None))
+        add_region_row.rect = add_region_row.rect.resize(height=32)
+
+        self._region_name_input = UIInputText(width=170, height=32, text="")
+        add_region_row.add(self._region_name_input)
+
+        add_btn = UIFlatButton(text="+", width=40, height=32)
+        add_btn.on_click = lambda _: self._handle_add_region()
+        add_region_row.add(add_btn)
+
+        remove_btn = UIFlatButton(text="-", width=40, height=32)
+        remove_btn.on_click = lambda _: self._on_region_remove()
+        add_region_row.add(remove_btn)
+
+        self.add(add_region_row)
+
+        # Region list (grows downward as the last section, nothing below to overlap)
+        self._region_list_container = UIBoxLayout(
+            vertical=True, space_between=2, size_hint=(1.0, None)
+        )
+        self.add(self._region_list_container)
+
+    def _handle_add_region(self) -> None:
+        """Handle adding a new region from the input field."""
+        if self._region_name_input is None:
+            return
+        name = self._region_name_input.text.strip()
+        if name:
+            self._on_region_add(name)
+            self._region_name_input.text = ""
+
+    def refresh_region_list(self) -> None:
+        """Rebuild the region list buttons."""
+        if self._region_list_container is None:
+            return
+
+        self._region_list_container.clear()
+
+        for idx, name in enumerate(self._state.regions):
+            is_active = name == self._state.active_region
+            point_count = len(self._state.regions[name])
+            region_color = REGION_COLORS[idx % len(REGION_COLORS)]
+
+            if is_active:
+                label = f"> {name} ({point_count} pts)"
+            else:
+                label = f"  {name} ({point_count} pts)"
+
+            btn = UIFlatButton(
+                text=label,
+                width=280,
+                height=28,
+            )
+            if is_active:
+                btn.with_background(color=ACTIVE_BUTTON_BG)
+                btn.with_border(width=3, color=region_color)
+            btn.on_click = lambda _, n=name: self._on_region_select(n)
+            self._region_list_container.add(btn)
+
+    def refresh_tool_buttons(self) -> None:
+        """Update tool button highlighting based on current tool mode."""
+        active_border = (200, 200, 255, 255)
+        current = self._state.tool_mode.value
+        for tool_name, btn in self._tool_buttons.items():
+            if tool_name == current:
+                btn.with_background(color=ACTIVE_BUTTON_BG)
+                btn.with_border(width=2, color=active_border)
+            else:
+                btn.with_background(color=INACTIVE_BUTTON_BG)
+                btn.with_border(width=0, color=(0, 0, 0, 0))
+
+

--- a/arcade/hitbox_editor/state.py
+++ b/arcade/hitbox_editor/state.py
@@ -1,0 +1,148 @@
+"""Editor state model for the HitBox Editor."""
+
+from __future__ import annotations
+
+import enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import arcade
+from arcade.hitbox import HitBox
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.history import Clipboard, CommandHistory
+
+
+class ToolMode(enum.Enum):
+    ADD = "add"
+    SELECT = "select"
+    DELETE = "delete"
+
+
+class EditorState:
+    """Central data model for the hitbox editor.
+
+    All mutations should go through the CommandHistory so they can be undone.
+    """
+
+    def __init__(self) -> None:
+        self.regions: dict[str, list[tuple[float, float]]] = {}
+        self.active_region: str | None = None
+        self.selected_points: set[tuple[str, int]] = set()
+        self.tool_mode: ToolMode = ToolMode.ADD
+        self.texture: arcade.Texture | None = None
+        self.texture_path: Path | None = None
+
+        # These are set after construction to avoid circular imports
+        self.history: CommandHistory | None = None
+        self.clipboard: Clipboard | None = None
+
+        # Cursor position in world coordinates (for preview drawing)
+        self.cursor_world: tuple[float, float] = (0.0, 0.0)
+
+        # Point pick threshold in world units (adjusted for zoom by the view)
+        self.pick_threshold: float = 15.0
+
+        # Selection rectangle in world coords (x1, y1, x2, y2) while drag-selecting
+        self.selection_rect: tuple[float, float, float, float] | None = None
+
+    def load_texture(self, path: str | Path) -> None:
+        """Load a texture from a file path."""
+        path = Path(path)
+        self.texture = arcade.load_texture(str(path))
+        self.texture_path = path
+
+    def load_hitbox(self, path: str | Path) -> None:
+        """Load hitbox regions from a JSON file."""
+        hb = HitBox.load(path)
+        self.regions = {
+            name: [tuple(p) for p in pts]
+            for name, pts in hb.regions.items()
+        }
+        if self.regions:
+            self.active_region = next(iter(self.regions))
+        else:
+            self.active_region = None
+        self.selected_points.clear()
+
+    def to_hitbox(self) -> HitBox:
+        """Convert current state to a HitBox instance."""
+        return HitBox({name: list(pts) for name, pts in self.regions.items()})
+
+    def find_points_in_rect(
+        self, x1: float, y1: float, x2: float, y2: float
+    ) -> set[tuple[str, int]]:
+        """Find all points within the given rectangle.
+
+        Returns set of (region_name, point_index) tuples.
+        """
+        min_x, max_x = min(x1, x2), max(x1, x2)
+        min_y, max_y = min(y1, y2), max(y1, y2)
+
+        result: set[tuple[str, int]] = set()
+        for region_name, points in self.regions.items():
+            for i, (px, py) in enumerate(points):
+                if min_x <= px <= max_x and min_y <= py <= max_y:
+                    result.add((region_name, i))
+        return result
+
+    def find_nearest_point(
+        self, x: float, y: float, threshold: float
+    ) -> tuple[str, int] | None:
+        """Find the nearest point within threshold distance.
+
+        Returns (region_name, point_index) or None.
+        """
+        best: tuple[str, int] | None = None
+        best_dist = threshold * threshold  # compare squared distances
+
+        for region_name, points in self.regions.items():
+            for i, (px, py) in enumerate(points):
+                dist_sq = (px - x) ** 2 + (py - y) ** 2
+                if dist_sq < best_dist:
+                    best_dist = dist_sq
+                    best = (region_name, i)
+
+        return best
+
+    def find_nearest_edge(
+        self, x: float, y: float, threshold: float
+    ) -> tuple[str, int] | None:
+        """Find the nearest edge within threshold distance.
+
+        Returns (region_name, insert_index) where insert_index is the index
+        at which a new point should be inserted, or None.
+        """
+        best: tuple[str, int] | None = None
+        best_dist = threshold * threshold
+
+        for region_name, points in self.regions.items():
+            n = len(points)
+            if n < 2:
+                continue
+            for i in range(n):
+                ax, ay = points[i]
+                bx, by = points[(i + 1) % n]
+                dist_sq = _point_to_segment_dist_sq(x, y, ax, ay, bx, by)
+                if dist_sq < best_dist:
+                    best_dist = dist_sq
+                    best = (region_name, (i + 1) % n if (i + 1) < n else n)
+
+        return best
+
+
+def _point_to_segment_dist_sq(
+    px: float, py: float,
+    ax: float, ay: float,
+    bx: float, by: float,
+) -> float:
+    """Squared distance from point (px, py) to segment (ax, ay)-(bx, by)."""
+    dx, dy = bx - ax, by - ay
+    len_sq = dx * dx + dy * dy
+    if len_sq == 0:
+        return (px - ax) ** 2 + (py - ay) ** 2
+
+    t = max(0.0, min(1.0, ((px - ax) * dx + (py - ay) * dy) / len_sq))
+    proj_x = ax + t * dx
+    proj_y = ay + t * dy
+    return (px - proj_x) ** 2 + (py - proj_y) ** 2

--- a/arcade/hitbox_editor/tools.py
+++ b/arcade/hitbox_editor/tools.py
@@ -1,0 +1,301 @@
+"""Tool implementations for the HitBox Editor."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from arcade.hitbox_editor.history import (
+    AddPointCommand,
+    MoveMultiplePointsCommand,
+    MovePointCommand,
+    RemovePointCommand,
+)
+
+if TYPE_CHECKING:
+    from arcade.hitbox_editor.state import EditorState
+
+# Mouse buttons
+MOUSE_LEFT = 1
+MOUSE_RIGHT = 4
+MOUSE_MIDDLE = 2
+
+# Modifier keys
+MOD_SHIFT = 1
+
+
+class BaseTool(ABC):
+    """Base class for editor tools."""
+
+    @abstractmethod
+    def on_press(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def on_drag(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        dx: float,
+        dy: float,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def on_release(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        ...
+
+
+class AddTool(BaseTool):
+    """Tool for adding points to the active region."""
+
+    def on_press(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        if button != MOUSE_LEFT:
+            return
+        if state.active_region is None or state.history is None:
+            return
+        if state.active_region not in state.regions:
+            return
+
+        point = (wx, wy)
+        points = state.regions[state.active_region]
+
+        # Check if click is near an existing edge - if so, insert there
+        if len(points) >= 2:
+            edge = state.find_nearest_edge(wx, wy, threshold=state.pick_threshold)
+            if edge is not None and edge[0] == state.active_region:
+                cmd = AddPointCommand(state.active_region, edge[1], point)
+                state.history.execute(cmd, state)
+                return
+
+        # Otherwise append to end
+        cmd = AddPointCommand(state.active_region, len(points), point)
+        state.history.execute(cmd, state)
+
+    def on_drag(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        dx: float,
+        dy: float,
+    ) -> None:
+        pass
+
+    def on_release(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        pass
+
+
+class SelectTool(BaseTool):
+    """Tool for selecting and moving points.
+
+    Supports click-to-select, shift+click multi-select, drag-to-move,
+    and drag-on-empty-space to draw a selection rectangle.
+    """
+
+    def __init__(self) -> None:
+        # Track drag state for move command batching
+        self._dragging = False
+        self._drag_start_positions: dict[tuple[str, int], tuple[float, float]] = {}
+        # Track drag-to-select rectangle state
+        self._rect_selecting = False
+        self._rect_start: tuple[float, float] = (0.0, 0.0)
+        self._shift_held = False
+
+    def on_press(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        if button != MOUSE_LEFT:
+            return
+
+        self._shift_held = bool(modifiers & MOD_SHIFT)
+        nearest = state.find_nearest_point(wx, wy, threshold=state.pick_threshold)
+
+        if nearest is None:
+            # Click on empty space — start a selection rectangle
+            if not self._shift_held:
+                state.selected_points.clear()
+            self._rect_selecting = True
+            self._rect_start = (wx, wy)
+            state.selection_rect = (wx, wy, wx, wy)
+            return
+
+        region_name, index = nearest
+
+        if self._shift_held:
+            # Toggle point in selection
+            key = (region_name, index)
+            if key in state.selected_points:
+                state.selected_points.discard(key)
+            else:
+                state.selected_points.add(key)
+        else:
+            # If clicking on an already-selected point, keep multi-select for drag
+            key = (region_name, index)
+            if key not in state.selected_points:
+                state.selected_points.clear()
+                state.selected_points.add(key)
+
+        # Set active region to match clicked point
+        state.active_region = region_name
+
+        # Record start positions for drag-to-move
+        if state.selected_points:
+            self._dragging = True
+            self._drag_start_positions = {}
+            for r, i in state.selected_points:
+                if r in state.regions and i < len(state.regions[r]):
+                    self._drag_start_positions[(r, i)] = state.regions[r][i]
+
+    def on_drag(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        dx: float,
+        dy: float,
+    ) -> None:
+        # Selection rectangle drag
+        if self._rect_selecting:
+            sx, sy = self._rect_start
+            state.selection_rect = (sx, sy, wx, wy)
+            return
+
+        # Point move drag
+        if not self._dragging or not state.selected_points:
+            return
+
+        for r, i in state.selected_points:
+            if r in state.regions and i < len(state.regions[r]):
+                old_x, old_y = state.regions[r][i]
+                state.regions[r][i] = (old_x + dx, old_y + dy)
+
+    def on_release(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        if button != MOUSE_LEFT:
+            return
+
+        # Finish selection rectangle
+        if self._rect_selecting:
+            sx, sy = self._rect_start
+            selected = state.find_points_in_rect(sx, sy, wx, wy)
+            if self._shift_held:
+                state.selected_points |= selected
+            else:
+                state.selected_points = selected
+            state.selection_rect = None
+            self._rect_selecting = False
+            return
+
+        # Finish point move
+        if not self._dragging or state.history is None:
+            self._dragging = False
+            return
+
+        moves: list[tuple[str, int, tuple[float, float], tuple[float, float]]] = []
+        for (r, i), old_pos in self._drag_start_positions.items():
+            if r in state.regions and i < len(state.regions[r]):
+                new_pos = state.regions[r][i]
+                if old_pos != new_pos:
+                    moves.append((r, i, old_pos, new_pos))
+
+        if moves:
+            if len(moves) == 1:
+                r, i, old_pos, new_pos = moves[0]
+                cmd = MovePointCommand(r, i, old_pos, new_pos)
+            else:
+                cmd = MoveMultiplePointsCommand(moves)
+            # Don't re-execute - points are already moved. Push directly to undo stack.
+            state.history._undo_stack.append(cmd)
+            if len(state.history._undo_stack) > state.history.max_history:
+                state.history._undo_stack.pop(0)
+            state.history._redo_stack.clear()
+
+        self._dragging = False
+        self._drag_start_positions.clear()
+
+
+class DeleteTool(BaseTool):
+    """Tool for deleting points."""
+
+    def on_press(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        if button != MOUSE_LEFT:
+            return
+        if state.history is None:
+            return
+
+        nearest = state.find_nearest_point(wx, wy, threshold=state.pick_threshold)
+        if nearest is None:
+            return
+
+        region_name, index = nearest
+        point = state.regions[region_name][index]
+        cmd = RemovePointCommand(region_name, index, point)
+        state.history.execute(cmd, state)
+
+    def on_drag(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        dx: float,
+        dy: float,
+    ) -> None:
+        pass
+
+    def on_release(
+        self,
+        state: EditorState,
+        wx: float,
+        wy: float,
+        button: int,
+        modifiers: int,
+    ) -> None:
+        pass

--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -22,9 +22,17 @@ LOG = logging.getLogger(__name__)
 class PymunkPhysicsObject:
     """Object that holds pymunk body/shape for a sprite."""
 
-    def __init__(self, body: pymunk.Body | None = None, shape: pymunk.Shape | None = None):
+    def __init__(
+        self,
+        body: pymunk.Body | None = None,
+        shape: pymunk.Shape | None = None,
+        shapes: list[pymunk.Shape] | None = None,
+    ):
         self.body: pymunk.Body | None = body
         self.shape: pymunk.Shape | None = shape
+        self.shapes: list[pymunk.Shape] = (
+            shapes if shapes is not None else ([shape] if shape is not None else [])
+        )
 
 
 class PymunkException(Exception):
@@ -318,30 +326,33 @@ class PymunkPhysicsEngine:
         if body_type == self.DYNAMIC:
             body.velocity_func = velocity_callback
 
-        # Set the physics shape to the sprite's hitbox
-        poly = sprite.hit_box.points
-        scaled_poly = [[x * sprite.scale_x for x in z] for z in poly]
-        shape = pymunk.Poly(body, scaled_poly, radius=radius)  # type: ignore
+        # Set the physics shapes to the sprite's hitbox regions
+        shapes: list[pymunk.Shape] = []
+        for region_points in sprite.hit_box.regions.values():
+            scaled_poly = [[x * sprite.scale_x for x in z] for z in region_points]
+            shape = pymunk.Poly(body, scaled_poly, radius=radius)  # type: ignore
 
-        # Set collision type, used in collision callbacks
-        if collision_type:
-            shape.collision_type = collision_type_id
+            # Set collision type, used in collision callbacks
+            if collision_type:
+                shape.collision_type = collision_type_id
 
-        # How bouncy is the shape?
-        if elasticity is not None:
-            shape.elasticity = elasticity
+            # How bouncy is the shape?
+            if elasticity is not None:
+                shape.elasticity = elasticity
 
-        # Set shapes friction
-        shape.friction = friction
+            # Set shapes friction
+            shape.friction = friction
+
+            shapes.append(shape)
 
         # Create physics object and add to list
-        physics_object = PymunkPhysicsObject(body, shape)
+        physics_object = PymunkPhysicsObject(body, shape=shapes[0], shapes=shapes)
         self.sprites[sprite] = physics_object
         if body_type != self.STATIC:
             self.non_static_sprite_list.append(sprite)
 
-        # Add body and shape to pymunk engine
-        self.space.add(body, shape)
+        # Add body and shapes to pymunk engine
+        self.space.add(body, *shapes)
 
         # Register physics engine with sprite, so we can remove from physics engine
         # if we tell the sprite to go away.
@@ -431,7 +442,8 @@ class PymunkPhysicsEngine:
         """Remove a sprite from the physics engine."""
         physics_object = self.sprites[sprite]
         self.space.remove(physics_object.body)  # type: ignore
-        self.space.remove(physics_object.shape)  # type: ignore
+        for s in physics_object.shapes:
+            self.space.remove(s)
         self.sprites.pop(sprite)
         if sprite in self.non_static_sprite_list:
             self.non_static_sprite_list.remove(sprite)
@@ -454,7 +466,7 @@ class PymunkPhysicsEngine:
             A sprite for the ``shape``; ``None`` if no sprite is known.
         """
         for sprite in self.sprites:
-            if self.sprites[sprite].shape is shape:
+            if shape in self.sprites[sprite].shapes:
                 return sprite
         return None
 
@@ -601,23 +613,35 @@ class PymunkPhysicsEngine:
             sprite: The Sprite to update
         """
         physics_object = self.sprites[sprite]
-        old_shape = physics_object.shape
-        assert old_shape is not None, """
-        Tried to update the shape for a Sprite which does not currently have a shape
+        old_shapes = physics_object.shapes
+        assert old_shapes, """
+        Tried to update the shape for a Sprite which does not currently have shapes
         """
 
-        # Set the physics shape to the sprite's hitbox
-        poly = sprite.hit_box.points
-        scaled_poly = [[x * sprite.scale_x for x in z] for z in poly]
-        shape = pymunk.Poly(physics_object.body, scaled_poly, radius=old_shape.radius)  # type: ignore
+        # Preserve properties from the first old shape
+        old_shape = old_shapes[0]
+        collision_type = old_shape.collision_type
+        elasticity = old_shape.elasticity
+        friction = old_shape.friction
+        radius = old_shape.radius
 
-        shape.collision_type = old_shape.collision_type
-        shape.elasticity = old_shape.elasticity
-        shape.friction = old_shape.friction
+        # Remove all old shapes
+        for s in old_shapes:
+            self.space.remove(s)
 
-        self.space.remove(old_shape)
-        self.space.add(shape)
-        physics_object.shape = shape
+        # Create new shapes from all hitbox regions
+        new_shapes: list[pymunk.Shape] = []
+        for region_points in sprite.hit_box.regions.values():
+            scaled_poly = [[x * sprite.scale_x for x in z] for z in region_points]
+            shape = pymunk.Poly(physics_object.body, scaled_poly, radius=radius)  # type: ignore
+            shape.collision_type = collision_type
+            shape.elasticity = elasticity
+            shape.friction = friction
+            new_shapes.append(shape)
+
+        self.space.add(*new_shapes)
+        physics_object.shape = new_shapes[0]
+        physics_object.shapes = new_shapes
 
     def resync_sprites(self) -> None:
         """

--- a/arcade/sprite/base.py
+++ b/arcade/sprite/base.py
@@ -8,7 +8,7 @@ from arcade.color import BLACK, WHITE
 from arcade.exceptions import ReplacementWarning, warning
 from arcade.hitbox import HitBox
 from arcade.texture import Texture
-from arcade.types import LRBT, AsFloat, Color, Point, Point2, Point2List, Rect, RGBOrA255
+from arcade.types import LRBT, AsFloat, Color, Point, Point2, Rect, RGBOrA255
 from arcade.utils import copy_dunders_unimplemented
 
 if TYPE_CHECKING:
@@ -787,10 +787,10 @@ class BasicSprite:
                 How thick the box should be
         """
         converted_color = Color.from_iterable(color)
-        points: Point2List = self.hit_box.get_adjusted_points()
-        # NOTE: This is a COPY operation. We don't want to modify the points.
-        points = tuple(points) + tuple(points[:-1])
-        arcade.draw_line_strip(points, color=converted_color, line_width=line_thickness)
+        for polygon in self.hit_box.get_all_adjusted_polygons():
+            # NOTE: This is a COPY operation. We don't want to modify the points.
+            points = tuple(polygon) + tuple(polygon[:-1])
+            arcade.draw_line_strip(points, color=converted_color, line_width=line_thickness)
 
     # ---- Shortcut Methods ----
 
@@ -812,7 +812,10 @@ class BasicSprite:
         from arcade.geometry import is_point_in_polygon
 
         x, y = point
-        return is_point_in_polygon(x, y, self.hit_box.get_adjusted_points())
+        return any(
+            is_point_in_polygon(x, y, polygon)
+            for polygon in self.hit_box.get_all_adjusted_polygons()
+        )
 
     def collides_with_sprite(self, other: BasicSprite) -> bool:
         """Will check if a sprite is overlapping (colliding) another Sprite.

--- a/arcade/sprite/sprite.py
+++ b/arcade/sprite/sprite.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import arcade
 from arcade import Texture
-from arcade.hitbox import HitBox, RotatableHitBox
+from arcade.hitbox import HitBox
 from arcade.texture import get_default_texture
 from arcade.types import PathOrTexture, Point2
 
@@ -141,7 +141,12 @@ class Sprite(BasicSprite, PymunkMixin):
         self.guid: str | None = None
         """A unique id for debugging purposes."""
 
-        self._hit_box: RotatableHitBox = self._hit_box.create_rotatable(angle=self._angle)
+        self._hit_box = HitBox(
+            self._texture.hit_box_points,
+            self._position,
+            self._scale,
+            angle=self._angle,
+        )
 
         self._width = self._texture.width * self._scale[0]
         self._height = self._texture.height * self._scale[1]
@@ -225,13 +230,8 @@ class Sprite(BasicSprite, PymunkMixin):
         return self._hit_box
 
     @hit_box.setter
-    def hit_box(self, hit_box: HitBox | RotatableHitBox) -> None:
-        if type(hit_box) is HitBox:
-            self._hit_box = hit_box.create_rotatable(self.angle)
-        else:
-            # Mypy doesn't seem to understand the type check above
-            # It still thinks hit_box can be a union here
-            self._hit_box = hit_box  # type: ignore
+    def hit_box(self, hit_box: HitBox) -> None:
+        self._hit_box = hit_box
 
     @property
     def texture(self) -> Texture:
@@ -251,11 +251,11 @@ class Sprite(BasicSprite, PymunkMixin):
 
         # If sprite is using default texture, update the hit box
         if self._texture is get_default_texture():
-            self.hit_box = RotatableHitBox(
+            self.hit_box = HitBox(
                 texture.hit_box_points,
                 position=self._position,
-                angle=self.angle,
                 scale=self._scale,
+                angle=self.angle,
             )
 
         self._texture = texture
@@ -425,9 +425,9 @@ class Sprite(BasicSprite, PymunkMixin):
         """
         Update the sprite's hit box to match the current texture's hit box.
         """
-        self.hit_box = RotatableHitBox(
+        self.hit_box = HitBox(
             self.texture.hit_box_points,
             position=self._position,
-            angle=self.angle,
             scale=self._scale,
+            angle=self.angle,
         )

--- a/arcade/sprite_list/collision.py
+++ b/arcade/sprite_list/collision.py
@@ -120,9 +120,9 @@ def _check_for_collision(sprite1: BasicSprite, sprite2: BasicSprite) -> bool:
     if distance > radius_sum_sq:
         return False
 
-    return are_polygons_intersecting(
-        sprite1.hit_box.get_adjusted_points(), sprite2.hit_box.get_adjusted_points()
-    )
+    polys1 = sprite1.hit_box.get_all_adjusted_polygons()
+    polys2 = sprite2.hit_box.get_all_adjusted_polygons()
+    return any(are_polygons_intersecting(p1, p2) for p1 in polys1 for p2 in polys2)
 
 
 def _get_nearby_sprites(
@@ -283,7 +283,10 @@ def get_sprites_at_point(point: Point, sprite_list: SpriteSequence[SpriteType]) 
     return [
         s
         for s in sprites_to_check
-        if is_point_in_polygon(point[0], point[1], s.hit_box.get_adjusted_points())
+        if any(
+            is_point_in_polygon(point[0], point[1], polygon)
+            for polygon in s.hit_box.get_all_adjusted_polygons()
+        )
     ]
 
 
@@ -346,5 +349,8 @@ def get_sprites_in_rect(rect: Rect, sprite_list: SpriteSequence[SpriteType]) -> 
     return [
         s
         for s in sprites_to_check
-        if are_polygons_intersecting(rect_points, s.hit_box.get_adjusted_points())
+        if any(
+            are_polygons_intersecting(rect_points, polygon)
+            for polygon in s.hit_box.get_all_adjusted_polygons()
+        )
     ]

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -989,12 +989,12 @@ class SpriteList(SpriteSequence[SpriteType]):
         # TODO: Make this faster in the future
         # NOTE: This will be easier when/if we change to triangles
         for sprite in self.sprite_list:
-            adjusted_points = sprite.hit_box.get_adjusted_points()
-            for i in range(len(adjusted_points) - 1):
-                points.append(adjusted_points[i])
-                points.append(adjusted_points[i + 1])
-            points.append(adjusted_points[-1])
-            points.append(adjusted_points[0])
+            for adjusted_points in sprite.hit_box.get_all_adjusted_polygons():
+                for i in range(len(adjusted_points) - 1):
+                    points.append(adjusted_points[i])
+                    points.append(adjusted_points[i + 1])
+                points.append(adjusted_points[-1])
+                points.append(adjusted_points[0])
 
         arcade.draw_lines(points, color=converted_color, line_width=line_thickness)
 

--- a/arcade/tilemap/tilemap.py
+++ b/arcade/tilemap/tilemap.py
@@ -31,7 +31,7 @@ from arcade import (
     get_window,
     hexagon,
 )
-from arcade.hitbox import HitBoxAlgorithm, RotatableHitBox
+from arcade.hitbox import HitBox, HitBoxAlgorithm
 from arcade.types import RGBA255
 from arcade.types import Color as ArcadeColor
 
@@ -617,11 +617,11 @@ class TileMap:
                 if tile.flipped_diagonally:
                     points = [(point[1], point[0]) for point in points]
 
-                my_sprite.hit_box = RotatableHitBox(
+                my_sprite.hit_box = HitBox(
                     cast(list[Point2], points),
                     position=my_sprite.position,
-                    angle=my_sprite.angle,
                     scale=my_sprite.scale,
+                    angle=my_sprite.angle,
                 )
 
         if tile.animation:

--- a/tests/unit/gui/test_layout_size_hint_warning.py
+++ b/tests/unit/gui/test_layout_size_hint_warning.py
@@ -1,4 +1,5 @@
 """Tests that layouts warn when explicit width/height conflicts with active size_hint."""
+
 import warnings
 
 import pytest

--- a/tests/unit/gui/test_uidropdown.py
+++ b/tests/unit/gui/test_uidropdown.py
@@ -164,7 +164,9 @@ def test_dropdown_value_setter_updates_button_text(ui):
 
 
 def test_dropdown_few_options_no_scrolling(ui):
-    dropdown = UIDropdown(options=["Apple", "Banana", "Cherry"], width=200, height=30, max_height=200)
+    dropdown = UIDropdown(
+        options=["Apple", "Banana", "Cherry"], width=200, height=30, max_height=200
+    )
     anchor = ui.add(UIAnchorLayout())
     anchor.add(dropdown, anchor_x="center", anchor_y="center")
     ui.execute_layout()

--- a/tests/unit/hitbox/test_hitbox.py
+++ b/tests/unit/hitbox/test_hitbox.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pytest
 from arcade import hitbox
 
-points = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
-rot_90 = [(0.0, 0.0), (10.0, 0), (10.0, -10.0), (0.0, -10.0)]
+points = ((0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0))
+rot_90 = ((0.0, 0.0), (10.0, 0), (10.0, -10.0), (0.0, -10.0))
 
 
 def test_module():
@@ -34,14 +34,14 @@ def test_scale():
     hb = hitbox.HitBox(points)
     hb.scale = (2.0, 2.0)
     assert hb.scale == (2.0, 2.0)
-    assert hb.get_adjusted_points() == [(0.0, 0.0), (0.0, 20.0), (20.0, 20.0), (20.0, 0.0)]
+    assert hb.get_adjusted_points() == ((0.0, 0.0), (0.0, 20.0), (20.0, 20.0), (20.0, 0.0))
 
 
 def test_position():
     hb = hitbox.HitBox(points)
     hb.position = (10.0, 10.0)
     assert hb.position == (10.0, 10.0)
-    assert hb.get_adjusted_points() == [(10.0, 10.0), (10.0, 20.0), (20.0, 20.0), (20.0, 10.0)]
+    assert hb.get_adjusted_points() == ((10.0, 10.0), (10.0, 20.0), (20.0, 20.0), (20.0, 10.0))
 
 
 def test_rotation():
@@ -74,8 +74,8 @@ def test_multi_region_create():
     assert hb.has_region("body")
     assert hb.has_region("head")
     assert not hb.has_region("default")
-    assert hb.regions["body"] == body_pts
-    assert hb.regions["head"] == head_pts
+    assert hb.regions["body"] == tuple(tuple(p) for p in body_pts)
+    assert hb.regions["head"] == tuple(tuple(p) for p in head_pts)
 
 
 def test_multi_region_adjusted():
@@ -84,8 +84,8 @@ def test_multi_region_adjusted():
     hb = hitbox.HitBox({"body": body_pts, "head": head_pts}, position=(5.0, 5.0))
     body_adj = hb.get_adjusted_points("body")
     head_adj = hb.get_adjusted_points("head")
-    assert body_adj == [(5.0, 5.0), (5.0, 15.0), (15.0, 15.0), (15.0, 5.0)]
-    assert head_adj == [(7.0, 15.0), (7.0, 20.0), (13.0, 20.0), (13.0, 15.0)]
+    assert body_adj == ((5.0, 5.0), (5.0, 15.0), (15.0, 15.0), (15.0, 5.0))
+    assert head_adj == ((7.0, 15.0), (7.0, 20.0), (13.0, 20.0), (13.0, 15.0))
 
 
 def test_multi_region_boundaries():
@@ -134,7 +134,7 @@ def test_single_region_fast_path():
     hb = hitbox.HitBox(points)
     polys = hb.get_all_adjusted_polygons()
     assert len(polys) == 1
-    assert polys[0] == list(points)
+    assert polys[0] == points
 
 
 # --- Serialization tests ---
@@ -167,7 +167,7 @@ def test_from_dict():
     }
     hb = hitbox.HitBox.from_dict(d)
     assert hb.points == ((0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0))
-    assert hb.get_adjusted_points() == [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    assert hb.get_adjusted_points() == ((0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0))
 
 
 def test_roundtrip_dict():

--- a/tests/unit/hitbox/test_hitbox.py
+++ b/tests/unit/hitbox/test_hitbox.py
@@ -1,3 +1,7 @@
+import json
+import tempfile
+from pathlib import Path
+
 import pytest
 from arcade import hitbox
 
@@ -19,6 +23,7 @@ def test_create():
     assert hb.get_adjusted_points() == points
     assert hb.position == (0.0, 0.0)
     assert hb.scale == (1.0, 1.0)
+    assert hb.angle == 0.0
     assert hb.bottom == 0.0
     assert hb.top == 10.0
     assert hb.left == 0.0
@@ -39,14 +44,170 @@ def test_position():
     assert hb.get_adjusted_points() == [(10.0, 10.0), (10.0, 20.0), (20.0, 20.0), (20.0, 10.0)]
 
 
-def test_create_rotatable():
-    hb = hitbox.HitBox(points)
-    rot = hb.create_rotatable()
-    assert rot.angle == 0.0
-    assert rot.position == (0.0, 0.0)
-    rot.angle = 90.0
-    assert rot.angle == 90.0
+def test_rotation():
+    hb = hitbox.HitBox(points, angle=0.0)
+    assert hb.angle == 0.0
+    assert hb.position == (0.0, 0.0)
+    hb.angle = 90.0
+    assert hb.angle == 90.0
 
-    rot_p = rot.get_adjusted_points()
+    rot_p = hb.get_adjusted_points()
     for i, (a, b) in enumerate(zip(rot_90, rot_p)):
         assert a == pytest.approx(b, abs=1e-6), f"[{i}] {a} != {b}"
+
+
+def test_angle_constructor():
+    hb = hitbox.HitBox(points, angle=90.0)
+    rot_p = hb.get_adjusted_points()
+    for i, (a, b) in enumerate(zip(rot_90, rot_p)):
+        assert a == pytest.approx(b, abs=1e-6), f"[{i}] {a} != {b}"
+
+
+# --- Multi-region tests ---
+
+
+def test_multi_region_create():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+    assert hb.region_names == ("body", "head")
+    assert hb.has_region("body")
+    assert hb.has_region("head")
+    assert not hb.has_region("default")
+    assert hb.regions["body"] == body_pts
+    assert hb.regions["head"] == head_pts
+
+
+def test_multi_region_adjusted():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts}, position=(5.0, 5.0))
+    body_adj = hb.get_adjusted_points("body")
+    head_adj = hb.get_adjusted_points("head")
+    assert body_adj == [(5.0, 5.0), (5.0, 15.0), (15.0, 15.0), (15.0, 5.0)]
+    assert head_adj == [(7.0, 15.0), (7.0, 20.0), (13.0, 20.0), (13.0, 15.0)]
+
+
+def test_multi_region_boundaries():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+    # Boundaries span all regions
+    assert hb.left == 0.0
+    assert hb.right == 10.0
+    assert hb.bottom == 0.0
+    assert hb.top == 15.0
+
+
+def test_get_all_adjusted_polygons():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+    all_polys = hb.get_all_adjusted_polygons()
+    assert len(all_polys) == 2
+
+
+def test_add_remove_region():
+    hb = hitbox.HitBox(points)
+    assert hb.has_region("default")
+    assert len(hb.region_names) == 1
+
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb.add_region("head", head_pts)
+    assert hb.has_region("head")
+    assert len(hb.region_names) == 2
+    assert hb.top == 15.0
+
+    hb.remove_region("head")
+    assert not hb.has_region("head")
+    assert len(hb.region_names) == 1
+    assert hb.top == 10.0
+
+
+def test_default_region_points():
+    hb = hitbox.HitBox(points)
+    assert hb.points == points
+    assert hb.get_adjusted_points() == hb.get_adjusted_points("default")
+
+
+def test_single_region_fast_path():
+    hb = hitbox.HitBox(points)
+    polys = hb.get_all_adjusted_polygons()
+    assert len(polys) == 1
+    assert polys[0] == list(points)
+
+
+# --- Serialization tests ---
+
+
+def test_to_dict_single_region():
+    hb = hitbox.HitBox(points)
+    d = hb.to_dict()
+    assert d["version"] == 1
+    assert "default" in d["regions"]
+    assert len(d["regions"]) == 1
+
+
+def test_to_dict_multi_region():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+    d = hb.to_dict()
+    assert d["version"] == 1
+    assert "body" in d["regions"]
+    assert "head" in d["regions"]
+
+
+def test_from_dict():
+    d = {
+        "version": 1,
+        "regions": {
+            "default": [[0.0, 0.0], [0.0, 10.0], [10.0, 10.0], [10.0, 0.0]],
+        },
+    }
+    hb = hitbox.HitBox.from_dict(d)
+    assert hb.points == ((0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0))
+    assert hb.get_adjusted_points() == [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+
+
+def test_roundtrip_dict():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+    d = hb.to_dict()
+    hb2 = hitbox.HitBox.from_dict(d, position=(5.0, 5.0))
+    assert hb2.has_region("body")
+    assert hb2.has_region("head")
+    assert hb2.position == (5.0, 5.0)
+
+
+def test_save_load_json():
+    body_pts = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
+    head_pts = [(2.0, 10.0), (2.0, 15.0), (8.0, 15.0), (8.0, 10.0)]
+    hb = hitbox.HitBox({"body": body_pts, "head": head_pts})
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        hb.save(path)
+        hb2 = hitbox.HitBox.load(path, position=(1.0, 2.0))
+        assert hb2.has_region("body")
+        assert hb2.has_region("head")
+        assert hb2.position == (1.0, 2.0)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_save_load_gzip():
+    hb = hitbox.HitBox(points)
+
+    with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        hb.save(path)
+        hb2 = hitbox.HitBox.load(path)
+        assert hb2.points == ((0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0))
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests/unit/sprite/test_sprite_hitbox.py
+++ b/tests/unit/sprite/test_sprite_hitbox.py
@@ -15,27 +15,27 @@ def test_1():
     print()
     hitbox = my_sprite.hit_box.get_adjusted_points()
     print(f"Hitbox: {my_sprite.scale} -> {my_sprite.hit_box.points} -> {hitbox}")
-    assert hitbox == [(90.0, 90.0), (90.0, 110.0), (110.0, 110.0), (110.0, 90.0)]
+    assert hitbox == ((90.0, 90.0), (90.0, 110.0), (110.0, 110.0), (110.0, 90.0))
 
     my_sprite.scale = 0.5, 0.5
     hitbox = my_sprite.hit_box.get_adjusted_points()
     print(f"Hitbox: {my_sprite.scale} -> {my_sprite.hit_box.points} -> {hitbox}")
-    assert hitbox == [(95.0, 95.0), (95.0, 105.0), (105.0, 105.0), (105.0, 95.0)]
+    assert hitbox == ((95.0, 95.0), (95.0, 105.0), (105.0, 105.0), (105.0, 95.0))
 
     my_sprite.scale = 1.0
     hitbox = my_sprite.hit_box.get_adjusted_points()
     print(f"Hitbox: {my_sprite.scale} -> {my_sprite.hit_box.points} -> {hitbox}")
-    assert hitbox == [(90.0, 90.0), (90.0, 110.0), (110.0, 110.0), (110.0, 90.0)]
+    assert hitbox == ((90.0, 90.0), (90.0, 110.0), (110.0, 110.0), (110.0, 90.0))
 
     my_sprite.scale = 2.0
     hitbox = my_sprite.hit_box.get_adjusted_points()
     print(f"Hitbox: {my_sprite.scale} -> {my_sprite.hit_box.points} -> {hitbox}")
-    assert hitbox == [(80.0, 80.0), (80.0, 120.0), (120.0, 120.0), (120.0, 80.0)]
+    assert hitbox == ((80.0, 80.0), (80.0, 120.0), (120.0, 120.0), (120.0, 80.0))
 
     my_sprite.scale = 2.0
     hitbox = my_sprite.hit_box.get_adjusted_points()
     print(f"Hitbox: {my_sprite.scale} -> {my_sprite.hit_box.points} -> {hitbox}")
-    assert hitbox == [(80.0, 80.0), (80.0, 120.0), (120.0, 120.0), (120.0, 80.0)]
+    assert hitbox == ((80.0, 80.0), (80.0, 120.0), (120.0, 120.0), (120.0, 80.0))
 
 
 def test_2():

--- a/tests/unit/test_hexagon.py
+++ b/tests/unit/test_hexagon.py
@@ -92,7 +92,9 @@ def test_hex_round():
     a = HexTile(0.0, 0.0, 0.0)
     b = HexTile(1.0, -1.0, 0.0)
     c = HexTile(0.0, -1.0, 1.0)
-    assert HexTile(5, -10, 5) == round(HexTile(0.0, 0.0, 0.0).lerp_between(HexTile(10.0, -20.0, 10.0), 0.5))
+    assert HexTile(5, -10, 5) == round(
+        HexTile(0.0, 0.0, 0.0).lerp_between(HexTile(10.0, -20.0, 10.0), 0.5)
+    )
     assert round(a) == round(a.lerp_between(b, 0.499))
     assert round(b) == round(a.lerp_between(b, 0.501))
 

--- a/webplayground/local_scripts/example_test.py
+++ b/webplayground/local_scripts/example_test.py
@@ -24,7 +24,7 @@ class MyWindow(arcade.Window):
             arcade.color.WHITE,
             font_size=30,
             anchor_x="center",
-            anchor_y="center"
+            anchor_y="center",
         )
         arcade.draw_text(
             "Edit this file and refresh to see changes",
@@ -33,11 +33,10 @@ class MyWindow(arcade.Window):
             arcade.color.WHITE,
             font_size=16,
             anchor_x="center",
-            anchor_y="center"
+            anchor_y="center",
         )
 
 
 if __name__ == "__main__":
     window = MyWindow()
     arcade.run()
-


### PR DESCRIPTION
## Summary
- Replaces the single-polygon HitBox with a multi-region system where each HitBox can contain named `Point2List` regions (e.g. separate head/body/feet hitboxes), while maintaining backward compatibility with the single-region API
- Adds per-region collision channel/mask filtering using bitmasks. Each region has a `channel` (what it is) and `mask` (what it collides with). Collision requires bidirectional agreement: `(A.channel & B.mask) != 0 AND (B.channel & A.mask) != 0`
- Provides `channels()` utility to convert 1-based channel numbers to bitmasks (e.g. `channels(1, 3)` = `0b101`)
- Introduces `RawHitBoxRegion` TypedDict and bumps serialization to v2 format (with v1 backward compat), supporting `channel` and `mask` fields per region
- Merges `RotatableHitBox` into `HitBox` and adds JSON serialization support (with optional gzip compression)
- Updates collision detection, pymunk physics engine, sprite lists, and tilemap to work with multi-region hitboxes
- Normalizes all points to tuples of tuples internally for immutability and consistency, while still accepting any valid sequence as input
- Updates `sprite_multi_hitbox` example to demonstrate channel-based collision filtering (body catches coins on channel 1, shield catches gems on channel 2)
- Expanded test coverage including 15 new channel/mask tests

## Test plan
- [ ] Run hitbox unit tests (`tests/unit/hitbox/test_hitbox.py`) — all 34 pass
- [ ] Run GUI tests to verify formatting fixes don't break anything
- [ ] Verify pymunk physics engine works with multi-region hitboxes
- [ ] Test the `sprite_multi_hitbox` example (coins only hit body, gems only hit shield)
- [ ] Confirm backward compatibility with single-region hitbox usage
- [ ] Confirm v1 serialization format loads correctly in v2 code

🤖 Generated with [Claude Code](https://claude.com/claude-code)