### PR TITLE
Angle negation for Pymunk physics engine

### DIFF
--- a/arcade/pymunk_physics_engine.py
+++ b/arcade/pymunk_physics_engine.py
@@ -266,7 +266,7 @@ class PymunkPhysicsEngine:
 
         # Set the body's position
         body.position = pymunk.Vec2d(sprite.center_x, sprite.center_y)
-        body.angle = math.radians(sprite.angle)
+        body.angle = math.radians(-sprite.angle)
 
         # Callback used if we need custom gravity, damping, velocity, etc.
         def velocity_callback(
@@ -514,7 +514,7 @@ class PymunkPhysicsEngine:
             raise PymunkException(
                 "Tried to set a rotation, but this physics object has no 'body' set."
             )
-        physics_object.body.angle = math.radians(rotation)
+        physics_object.body.angle = math.radians(-rotation)
 
     def set_velocity(self, sprite: Sprite, velocity: tuple[float, float]) -> None:
         """Directly set the velocity of a sprite known to the engine.


### PR DESCRIPTION
# Background

As mention in https://github.com/pythonarcade/arcade/issues/1887, arcade should auto-handling the negation with built-in PymunkPhysicsEngine

# Solution detail

In both the `add_sprite` and `set_rotation` methods of `arcade/pymunk_physics_engine.py`, the conversion from sprite angle to physics body angle now uses `math.radians(-sprite.angle)` instead of `math.radians(sprite.angle)`, ensuring consistent and correct rotational behavior between the sprite and its physics representation.
