### PR TITLE
Update pyglet to 3.0.dev3

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -20,6 +20,7 @@ if is_pyodide():
 
 import pyglet.config
 import pyglet.window.mouse
+from pyglet.config import GraphicsAPI
 from pyglet.display.base import Screen, ScreenMode
 from pyglet.event import EVENT_HANDLE_STATE, EVENT_UNHANDLED
 from pyglet.window import MouseCursor
@@ -211,15 +212,21 @@ class Window(pyglet.window.Window):
         self._pixel_perfect: bool = pixel_perfect
         """If True, ignore OS DPI scaling and use a 1:1 pixel ratio."""
 
+        _GL_API_MAP = {
+            "opengl": GraphicsAPI.OPENGL,
+            "opengles": GraphicsAPI.OPENGL_ES_3,
+        }
+
         config = None
         # Attempt to make window with antialiasing
         if gl_api == "opengl" or gl_api == "opengles":
+            graphics_api = _GL_API_MAP[gl_api]
             if antialiasing:
                 try:
-                    config = pyglet.config.OpenGLConfig(
+                    config = pyglet.config.OpenGLUserConfig(
                         major_version=gl_version[0],
                         minor_version=gl_version[1],
-                        opengl_api=gl_api.replace("open", ""),  # type: ignore  # pending: upstream fix
+                        api=graphics_api,
                         double_buffer=True,
                         sample_buffers=1,
                         samples=samples,
@@ -236,10 +243,10 @@ class Window(pyglet.window.Window):
                     antialiasing = False
             # If we still don't have a config
             if not config:
-                config = pyglet.config.OpenGLConfig(
+                config = pyglet.config.OpenGLUserConfig(
                     major_version=gl_version[0],
                     minor_version=gl_version[1],
-                    opengl_api=gl_api.replace("open", ""),  # type: ignore  # pending: upstream fix
+                    api=graphics_api,
                     double_buffer=True,
                     depth_size=24,
                     stencil_size=8,

--- a/arcade/examples/gui/exp_controller_inventory.py
+++ b/arcade/examples/gui/exp_controller_inventory.py
@@ -18,7 +18,7 @@ python -m arcade.examples.gui.exp_controller_inventory
 
 import pyglet.font
 from pyglet.event import EVENT_HANDLED
-from pyglet.gl import GL_NEAREST
+from pyglet.graphics.api.gl import GL_NEAREST
 from pyglet.input import Controller
 
 import arcade

--- a/arcade/examples/gui/exp_controller_inventory.py
+++ b/arcade/examples/gui/exp_controller_inventory.py
@@ -18,10 +18,10 @@ python -m arcade.examples.gui.exp_controller_inventory
 
 import pyglet.font
 from pyglet.event import EVENT_HANDLED
-from pyglet.graphics.api.gl import GL_NEAREST
 from pyglet.input import Controller
 
 import arcade
+from arcade.gl.enums import NEAREST
 from arcade import Rect
 from arcade.examples.gui.exp_controller_support_grid import (
     ControllerIndicator,
@@ -412,8 +412,8 @@ class MyView(UIView, ControllerView):
 
 if __name__ == "__main__":
     # pixelate the font
-    pyglet.font.base.Font.texture_min_filter = GL_NEAREST  # type: ignore
-    pyglet.font.base.Font.texture_mag_filter = GL_NEAREST  # type: ignore
+    pyglet.font.base.Font.texture_min_filter = NEAREST  # type: ignore
+    pyglet.font.base.Font.texture_mag_filter = NEAREST  # type: ignore
 
     load_kenney_fonts()
 

--- a/arcade/future/video/video_player.py
+++ b/arcade/future/video/video_player.py
@@ -25,7 +25,7 @@ class VideoPlayer:
     def __init__(self, path: str | Path, loop: bool = False):
         self.player = pyglet.media.VideoPlayer()
         self.player.loop = loop
-        self.player.queue(pyglet.media.load(str(arcade.resources.resolve(path))))
+        self.player.queue(pyglet.media.load_video(str(arcade.resources.resolve(path))))
         self.player.play()
 
         self.ctx = arcade.get_window().ctx

--- a/arcade/gl/backends/opengl/context.py
+++ b/arcade/gl/backends/opengl/context.py
@@ -534,7 +534,7 @@ class OpenGLInfo(Info):
             value = c_int()
             gl.glGetIntegerv(enum, value)
             return value.value
-        except pyglet.gl.lib.GLException:
+        except gl.lib.GLException:
             return default
 
     def get_float(self, enum, default=0.0) -> float:

--- a/arcade/gl/context.py
+++ b/arcade/gl/context.py
@@ -597,7 +597,7 @@ class Context(ABC):
 
         These enums can be accessed in the ``arcade.gl``
         module or simply as attributes of the context object.
-        The raw enums from ``pyglet.gl`` can also be used.
+        The raw enums from ``pyglet.graphics.api.gl`` can also be used.
 
         Example::
 

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -73,7 +73,7 @@ class Sound:
             raise FileNotFoundError(f"The sound file '{file_name}' is not a file or can't be read.")
         self.file_name = str(file_name)
 
-        self.source: Source = media.load(self.file_name, streaming=streaming)
+        self.source: Source = media.load_audio(self.file_name, streaming=streaming)
         """
         The :py:class:`pyglet.media.Source` object that holds the audio data.
         """

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,6 +52,13 @@ from util.doc_helpers.real_filesystem import copy_media
 # 2. The commit: https://github.com/pyglet/pyglet/commit/97076c3a33a7d368cc9c9e44ca67769b6a16a905
 sys.is_pyglet_doc_run = True
 
+# pyglet 3.0.dev3 LibraryMock lacks __iter__/__bool__, causing crashes
+# when ffmpeg codec init calls get_input_extensions() during doc builds.
+# Patch before any pyglet imports trigger media codec loading.
+import pyglet.lib  # noqa: E402
+pyglet.lib.LibraryMock.__bool__ = lambda self: False
+pyglet.lib.LibraryMock.__iter__ = lambda self: iter([])
+
 # --- Pre-processing Tasks
 
 # Report our diagnostic info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "pillow>=11.3.0",
     "pytiled-parser~=2.2.9",
-    "pyglet==3.0.dev2",
+    "pyglet==3.0.dev3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pillow>=11.3.0",
+    "pillow>=12.2.0",
     "pytiled-parser~=2.2.9",
     "pyglet==3.0.dev3",
 ]
@@ -40,8 +40,8 @@ extras = [
 ]
 # Used for dev work
 dev = [
-    "sphinx==8.1.3",               # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
-    "sphinx_rtd_theme==3.0.2",     # Nov 2024
+    "sphinx==9.1.0",               # April 2026
+    "sphinx_rtd_theme==3.1.0",     # April 2026
     "sphinx-rtd-dark-mode==1.3.0",
     "sphinx-autobuild==2024.10.3", # April 2024 | Due to this, Python 3.10+ is required to serve docs
     "sphinx-copybutton==0.5.2",    # April 2023

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pillow>=12.2.0",
+    "pillow>=11.3.0",
     "pytiled-parser~=2.2.9",
     "pyglet==3.0.dev3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ extras = [
 ]
 # Used for dev work
 dev = [
-    "sphinx==9.1.0",               # April 2026
-    "sphinx_rtd_theme==3.1.0",     # April 2026
+    "sphinx==8.1.3",               # April 2024 | Updated 2024-07-15, 7.4+ is broken with sphinx-autobuild
+    "sphinx_rtd_theme==3.0.2",     # Nov 2024
     "sphinx-rtd-dark-mode==1.3.0",
     "sphinx-autobuild==2024.10.3", # April 2024 | Due to this, Python 3.10+ is required to serve docs
     "sphinx-copybutton==0.5.2",    # April 2023


### PR DESCRIPTION
## Summary
- Updates pyglet dependency from `3.0.dev2` to `3.0.dev3` (released April 18, 2026)
- Adapts to breaking API changes:
  - `pyglet.config.OpenGLConfig` → `pyglet.config.OpenGLUserConfig` with new `api` parameter using `GraphicsAPI` enum (replaces string-based `opengl_api`)
  - `pyglet.media.load()` split into `pyglet.media.load_audio()` / `pyglet.media.load_video()`
  - `pyglet.gl` module relocated to `pyglet.graphics.api.gl`

## Test plan
- [x] Full test suite: 1175 passed, 4 failed (all 4 pre-existing — 3 HiDPI pixel scaling, 1 encoding issue)
- [x] No new test failures introduced by this update
- [ ] Verify on non-HiDPI display for pixel-perfect tests
- [ ] Test sound loading/playback
- [ ] Test video playback (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)