### PR TITLE
Fix caret behavior on input field activation

### DIFF
--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -590,7 +590,11 @@ class UIInputText(UIStyledWidget[UIInputTextStyle], UIInteractiveWidget):
     def _on_active_changed(self):
         """Handle the active state change of the input
         text field to care about loosing active state."""
-        if not self._active:
+        if self._active:
+            self.trigger_full_render()
+            self.caret.on_activate()
+            self.caret.position = len(self.doc.text)
+        else:
             self.deactivate()
 
     def _apply_style(self):

--- a/arcade/gui/widgets/text.py
+++ b/arcade/gui/widgets/text.py
@@ -584,7 +584,7 @@ class UIInputText(UIStyledWidget[UIInputTextStyle], UIInteractiveWidget):
     def _on_focus_change(self):
         if self.focused:
             self.activate()
-        elif self.active:
+        elif self._active:
             self.deactivate()
 
     def _on_active_changed(self):


### PR DESCRIPTION
## Summary

Fix UIInputText caret not activating when switching between input fields.

## Description

`_on_active_changed` only handled deactivation (`_active` → `False`), ignoring activation (`_active` → `True`). This meant `caret.on_activate()` was never called through the Property callback path.

The normal activation path is: click → `on_click` → `activate()`. But `UIInteractiveWidget.on_event` calls `_grap_active()` on mouse **press**, setting `widget._active = True` before `on_click` fires on mouse **release**. When `activate()` runs, its `if self._active: return` guard bails out immediately — `caret.on_activate()` is never reached.

The caret appears to work on first use because pyglet's `Caret` constructor defaults `_active = True`. After the first `deactivate()` sets `caret._active = False`, no code path restores it.

The fix adds the activation case to `_on_active_changed`, so the caret is properly activated whenever the widget's `_active` property becomes `True`, regardless of whether it was set by `activate()` or `_grap_active()`.

## Test plan

- Place two or more `UIInputText` widgets on screen
- Click between them repeatedly — caret should remain visible and blinking in the focused field
