### PR TITLE
Turn off confusing view source link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -264,6 +264,7 @@ pygments_style = "default"  # will use "sphinx" or the theme's default
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "sphinx_rtd_theme"
+html_show_sourcelink = False # pending: better solution to #2859
 
 # See sphinx-rtd-theme docs for details on each option:
 # https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html


### PR DESCRIPTION
**TL;DR:**  Turn off `.rst` source link mentioned in #2859

## What's fixed?

<table>
<tr><th></th><th>Live</th><th>This PR</th></tr>
<tr><th>Page view</th><td> 
<img width="1256" height="862" alt="image" src="https://github.com/user-attachments/assets/fbf30a44-bef1-4bb8-852f-0d5c47a58ebe" />
</td><td><img width="1254" height="863" alt="image" src="https://github.com/user-attachments/assets/c0459d09-d6a4-4236-ba10-0e61c030c1a5" /></td>
</tr>
<tr><th>Problem?</th><td><img width="1256" height="862" alt="image" src="https://github.com/user-attachments/assets/ec8cc3a6-14e3-4641-9b3f-c14a96100504" />
</td><td><center>None</center></td></tr>
</table>

## How's it fixed?

[`html_show_sourcelink = False`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_show_sourcelink) in `conf.py`. 

This is the simplest, most durable approach::
1. Turning it off is the simplest fix
    - pyglet does this
    - NumPy does it with extra steps via a link to their GitHub repo `README.md`
2. Hide it at the bottom of the page in tiny gray font (PyMunk)

What I've tested on Chrome:
- [x] Building doc locally
- [x] Viewing it in desktop, tablet, and mobile preview modes
- [x] Click-to-copy on code examples still works  