### PR TITLE
Fix SpriteList.insert() not rendering inserted sprite until next list sync

### DIFF
--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -756,6 +756,10 @@ class SpriteList(SpriteSequence[SpriteType]):
         if self.spatial_hash is not None:
             self.spatial_hash.add(sprite)
 
+        if self._initialized:
+            if sprite.texture is None:
+                raise ValueError("Sprite must have a texture when added to a SpriteList")
+
     def reverse(self) -> None:
         """Reverses the current list in-place"""
         # Reverse the sprites and index buffer

--- a/arcade/sprite_list/sprite_list.py
+++ b/arcade/sprite_list/sprite_list.py
@@ -751,6 +751,7 @@ class SpriteList(SpriteSequence[SpriteType]):
         self._grow_index_buffer()
         self._sprite_index_data.insert(index, slot)
         self._sprite_index_data.pop()
+        self._sprite_index_changed = True
 
         if self.spatial_hash is not None:
             self.spatial_hash.add(sprite)

--- a/tests/unit/spritelist/test_spritelist.py
+++ b/tests/unit/spritelist/test_spritelist.py
@@ -121,6 +121,20 @@ def test_it_can_insert_in_a_spritelist():
     assert spritelist._sprite_index_changed is True
 
 
+def test_insert_requires_texture_when_initialized(ctx):
+    """insert() into an initialized list should validate the texture, like append()"""
+    spritelist = make_named_sprites(1)
+    # Force initialization (as a draw would do)
+    spritelist.draw()
+
+    sprite = arcade.SpriteSolidColor(16, 16, color=arcade.color.RED)
+    # Bypass the texture setter to simulate a textureless sprite
+    sprite._texture = None
+
+    with pytest.raises(ValueError):
+        spritelist.insert(0, sprite)
+
+
 def test_it_can_reverse_a_spritelist():
     spritelist = make_named_sprites(3)
     spritelist.reverse()

--- a/tests/unit/spritelist/test_spritelist.py
+++ b/tests/unit/spritelist/test_spritelist.py
@@ -116,6 +116,9 @@ def test_it_can_insert_in_a_spritelist():
     assert [spritelist.sprite_slot[s] for s in spritelist] == [0, 2, 1]
     # Index buffer should refer to the slots in the same order
     assert list(spritelist._sprite_index_data[:3]) == [0, 2, 1]
+    # insert() must flag the index buffer as changed so the sprite is
+    # actually uploaded to the GPU and rendered on the next draw (#2863)
+    assert spritelist._sprite_index_changed is True
 
 
 def test_it_can_reverse_a_spritelist():


### PR DESCRIPTION
## Summary

Fixes #2863.

### Primary fix: inserted sprites not rendered

`SpriteList.insert()` updated the CPU-side index data (`_sprite_index_data`) but never set `self._sprite_index_changed = True`. Every other mutating method (`append`, `remove`, `pop`, `swap`, `reverse`, `sort`, `clear`) sets it.

Because `_write_sprite_buffers_to_gpu()` only uploads the index buffer when that flag is set, a sprite added via `insert()` was fully present in the list (updated, collides, removable) but **never rendered** — it silently appeared only when some later unrelated operation set the flag and forced a full sync. This produced hard-to-diagnose intermittent "invisible sprite" bugs.

Fix: set `self._sprite_index_changed = True` at the end of `insert()`, mirroring `append()`.

### Secondary: texture validation consistency

`append()` raises `ValueError` when a textureless sprite is added to an initialized list, but `insert()` did not. Added the same guard to `insert()` so the two entry points behave identically.

Note: this is validation-only. The atlas registration itself is already handled by `_update_all()` for both `append()` and `insert()`, so there was no atlas/rendering bug there.

## Verification

- Reproduced the original bug with the offscreen render/pixel-readback script from the issue; the inserted sprite is now drawn on the very next `draw()`.
- Added a regression assertion to `test_it_can_insert_in_a_spritelist` confirming the index-changed flag is set.
- Added `test_insert_requires_texture_when_initialized` covering the validation guard.
- `pytest tests/unit/spritelist/test_spritelist.py` passes (19 passed); `ruff` clean.