### PR TITLE
Fix typo on front page (s/craft craft/craft/)

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ The Python Arcade Library
 
 Arcade is an easy-to-learn Python library for creating 2D games and more. The
 friendly API caters to both beginners and experts alike. Do you want to craft
-craft your take on a 2D classic, or explore the full power of shaders? It's up to you.
+your take on a 2D classic, or explore the full power of shaders? It's up to you.
 
 What will you make?
 


### PR DESCRIPTION
Fixed repeated word. Ty to @DigiDuncan for passing along the report.