### PR TITLE
fix(math): rotate_around_point offsets from the rotation center

### DIFF
--- a/arcade/math.py
+++ b/arcade/math.py
@@ -421,7 +421,7 @@ def rotate_around_point(source: Point2, target: Point2, angle: float):
     dx = diff_x * c - diff_y * s
     dy = diff_x * s + diff_y * c
 
-    return target[0] + dx, target[1] + dy
+    return source[0] + dx, source[1] + dy
 
 
 def get_angle_degrees(x1: float, y1: float, x2: float, y2: float) -> float:

--- a/tests/unit/test_math.py
+++ b/tests/unit/test_math.py
@@ -87,3 +87,16 @@ def test_rand_vec_spread_deg():
 def test_rand_vec_magnitude():
     """Smoke test"""
     rand_vec_magnitude(30.5, 3.3, 4.4)
+
+
+def test_rotate_around_point():
+    """The result is offset from the rotation center, not from the target."""
+    from arcade.math import rotate_around_point
+
+    x, y = rotate_around_point((3.0, 0.0), (5.0, 0.0), 90.0)
+    assert x == approx(3.0)
+    assert y == approx(2.0)
+
+    # A full turn and a zero-length radius both leave the target where it is.
+    assert rotate_around_point((3.0, 0.0), (5.0, 0.0), 360.0) == (5.0, 0.0)
+    assert rotate_around_point((3.0, 0.0), (3.0, 0.0), 90.0) == (3.0, 0.0)


### PR DESCRIPTION
Closes #2753

`rotate_around_point` computed the rotated displacement vector correctly but added it to the target point instead of the source (the rotation center), so the result came out displaced by the source-to-target vector: rotating `(5, 0)` around `(3, 0)` by 90 degrees returned `(5, 2)` instead of `(3, 2)`.

Added a regression test in `tests/unit/test_math.py` (fails on `development`, passes with the fix) that also covers the full-turn and zero-radius early returns.
