### PR TITLE
Fix AnimatedWalkingSprite.update_animation clobbering scale_y

### DIFF
--- a/arcade/sprite/animated.py
+++ b/arcade/sprite/animated.py
@@ -357,4 +357,4 @@ class AnimatedWalkingSprite(Sprite):
             logger.warning("Error, no texture set")
         else:
             self.width = self._texture.width * self.scale_x
-            self.height = self._texture.height * self.scale_x
+            self.height = self._texture.height * self.scale_y

--- a/tests/unit/sprite/test_sprite_animated_walking.py
+++ b/tests/unit/sprite/test_sprite_animated_walking.py
@@ -5,6 +5,23 @@ COIN_SCALE = 0.5
 frame_count = 0
 
 
+def test_update_animation_preserves_scale_y():
+    # update_animation must size height from scale_y, not scale_x, so a
+    # non-uniform scale is preserved (regression: scale_y was clobbered).
+    texture = arcade.Texture.create_empty("test-scale", (10, 20))
+    sprite = arcade.AnimatedWalkingSprite(scale=(2.0, 3.0))
+    sprite.stand_right_textures = [texture]
+    sprite.texture = texture
+    sprite.change_x = 0
+    sprite.change_y = 0
+
+    sprite.update_animation()
+
+    assert tuple(sprite.scale) == (2.0, 3.0)
+    assert sprite.width == 20.0
+    assert sprite.height == 60.0
+
+
 def test_sprite_animated_old(window: arcade.Window):
     global frame_count
     frame_count = 0


### PR DESCRIPTION
## Summary

`AnimatedWalkingSprite.update_animation` sizes the sprite from the texture, but the height line uses `scale_x` instead of `scale_y`:

```python
self.width  = self._texture.width  * self.scale_x
self.height = self._texture.height * self.scale_x   # should be scale_y
```

The inherited `height` setter derives `scale_y` from the value assigned (`self._scale = self._scale[0], value / self._texture.height`), so assigning `texture.height * scale_x` forces `scale_y := scale_x`. Every animation update therefore both mis-sizes the sprite and silently corrupts a non-uniform scale.

Repro (arcade 3.3.3):

```python
tex = arcade.Texture.create_empty("t", (10, 20))
spr = arcade.AnimatedWalkingSprite(scale=(2.0, 3.0))
spr.stand_right_textures = [tex]; spr.texture = tex
spr.change_x = spr.change_y = 0
spr.update_animation()
# before: spr.scale == (2.0, 2.0), spr.height == 40.0   <- scale_y clobbered 3.0 -> 2.0
# after:  spr.scale == (2.0, 3.0), spr.height == 60.0
```

## Fix

Use `scale_y` for the height. The `width` line one above already correctly uses `scale_x`, matching the base-class texture setters (`sprite/base.py`, `sprite/sprite.py`) which use `_scale[0]` for width and `_scale[1]` for height.

```python
self.height = self._texture.height * self.scale_y
```

## Test

Added `test_update_animation_preserves_scale_y` in `tests/unit/sprite/test_sprite_animated_walking.py` — it constructs an `AnimatedWalkingSprite(scale=(2.0, 3.0))`, runs `update_animation`, and asserts the scale and dimensions are preserved. It fails on `development` (scale becomes `(2.0, 2.0)`, height `40.0`) and passes with this change. `ruff format --check` clean and the change adds no new `ruff check` findings.

`AnimatedWalkingSprite` is soft-deprecated in its docstring, but it is still exported in `arcade.__all__` and is the sprite used in the platformer tutorial (`platformer_part_twelve`), so the silent scale corruption still affects users following the docs.
