### PR TITLE
fix: handle D-pad actions in input manager

### DIFF
--- a/arcade/input/manager.py
+++ b/arcade/input/manager.py
@@ -135,10 +135,12 @@ class InputManager:
 
         self.controller = None
         self.controller_deadzone = controller_deadzone
+        self._dpad_state = pyglet.math.Vec2()
         if controller:
             self.controller = controller
             if not self.controller.device.is_open:
                 self.controller.open()
+            self._dpad_state = self.controller.dpad
 
             self.controller.push_handlers(
                 self.on_button_press,
@@ -276,6 +278,7 @@ class InputManager:
 
         self.controller = controller
         self.controller.open()
+        self._dpad_state = controller.dpad
         self.controller.push_handlers(
             self.on_button_press,
             self.on_button_release,
@@ -305,6 +308,7 @@ class InputManager:
         )
         self.controller.close()
         self.controller = None
+        self._dpad_state = pyglet.math.Vec2()
 
         if self._allow_keyboard:
             self.active_device = InputDevice.KEYBOARD
@@ -657,6 +661,24 @@ class InputManager:
 
     def on_dpad_motion(self, controller: Controller, motion: pyglet.math.Vec2):
         self.active_device = InputDevice.CONTROLLER
+
+        previous = self._dpad_state
+        direction_states = {
+            inputs.ControllerButtons.DPAD_LEFT.value: (previous.x < 0, motion.x < 0),
+            inputs.ControllerButtons.DPAD_RIGHT.value: (previous.x > 0, motion.x > 0),
+            inputs.ControllerButtons.DPAD_UP.value: (previous.y > 0, motion.y > 0),
+            inputs.ControllerButtons.DPAD_DOWN.value: (previous.y < 0, motion.y < 0),
+        }
+
+        for button_name, (was_pressed, is_pressed) in direction_states.items():
+            if was_pressed == is_pressed:
+                continue
+
+            state = ActionState.PRESSED if is_pressed else ActionState.RELEASED
+            for action_name in tuple(self.controller_buttons_to_actions.get(button_name, set())):
+                self.dispatch_action(action_name, state)
+
+        self._dpad_state = motion
 
     def handle_trigger_motion(self, trigger_name: str, value: float):
         self.active_device = InputDevice.CONTROLLER

--- a/tests/unit/test_input_manager.py
+++ b/tests/unit/test_input_manager.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock, call
+
+from pyglet.math import Vec2
+
+from arcade.input.inputs import ControllerButtons
+from arcade.input.manager import ActionState, InputDevice, InputManager
+
+
+def make_input_manager() -> tuple[InputManager, Mock]:
+    manager = object.__new__(InputManager)
+    manager.active_device = None
+    manager._dpad_state = Vec2()
+    manager.controller_buttons_to_actions = {
+        ControllerButtons.DPAD_LEFT.value: {"left"},
+        ControllerButtons.DPAD_RIGHT.value: {"right"},
+        ControllerButtons.DPAD_UP.value: {"up"},
+        ControllerButtons.DPAD_DOWN.value: {"down"},
+    }
+    dispatch_action = Mock()
+    manager.dispatch_action = dispatch_action
+    return manager, dispatch_action
+
+
+def test_dpad_motion_dispatches_pressed_actions():
+    manager, dispatch_action = make_input_manager()
+
+    manager.on_dpad_motion(Mock(), Vec2(-1, 1))
+
+    assert manager.active_device == InputDevice.CONTROLLER
+    assert dispatch_action.call_args_list == [
+        call("left", ActionState.PRESSED),
+        call("up", ActionState.PRESSED),
+    ]
+
+
+def test_dpad_motion_dispatches_direction_changes():
+    manager, dispatch_action = make_input_manager()
+    manager._dpad_state = Vec2(-1, 1)
+
+    manager.on_dpad_motion(Mock(), Vec2(1, 0))
+
+    assert dispatch_action.call_args_list == [
+        call("left", ActionState.RELEASED),
+        call("right", ActionState.PRESSED),
+        call("up", ActionState.RELEASED),
+    ]
+
+
+def test_dpad_motion_ignores_unchanged_directions():
+    manager, dispatch_action = make_input_manager()
+    manager._dpad_state = Vec2(0, -1)
+
+    manager.on_dpad_motion(Mock(), Vec2(0, -1))
+
+    dispatch_action.assert_not_called()


### PR DESCRIPTION
## Summary

I updated `InputManager` to translate D-pad vector transitions into the corresponding configured action press and release events. The manager now tracks the previous D-pad state so unchanged directions do not emit duplicate actions, including when moving between cardinal and diagonal directions.

I also added focused regression tests for presses, releases, direction changes, and unchanged input.

## Validation

- `xvfb-run --auto-servernum uv run pytest -q tests/unit/test_input_manager.py`
- `uv run pyright arcade/input/manager.py`
- `uv run ruff format --check arcade/input/manager.py tests/unit/test_input_manager.py`
- `uv run ruff check --ignore E501 arcade/input/manager.py tests/unit/test_input_manager.py`
- `git diff --check origin/development...HEAD`

I did not run the full test suite locally; GitHub Actions can cover the broader matrix.

Fixes #2871
