### PR TITLE
Fix rotate_around_point to rotate about the source point

### DIFF
--- a/arcade/math.py
+++ b/arcade/math.py
@@ -421,7 +421,7 @@ def rotate_around_point(source: Point2, target: Point2, angle: float):
     dx = diff_x * c - diff_y * s
     dy = diff_x * s + diff_y * c
 
-    return target[0] + dx, target[1] + dy
+    return source[0] + dx, source[1] + dy
 
 
 def get_angle_degrees(x1: float, y1: float, x2: float, y2: float) -> float:

--- a/tests/unit/test_math.py
+++ b/tests/unit/test_math.py
@@ -5,6 +5,8 @@ Can run these tests individually with:
 python -m pytest tests/unit/test_utils.py
 """
 
+import math
+
 import arcade
 from pytest import approx
 from arcade.math import *
@@ -87,3 +89,22 @@ def test_rand_vec_spread_deg():
 def test_rand_vec_magnitude():
     """Smoke test"""
     rand_vec_magnitude(30.5, 3.3, 4.4)
+
+
+def test_rotate_around_point_preserves_distance_from_source():
+    """The rotated point must keep its distance from the center of rotation (source)."""
+    source = (2.0, 3.0)
+    target = (5.0, 7.0)  # distance 5 from source
+    for angle in (30.0, 90.0, 170.0, 250.0):
+        rx, ry = rotate_around_point(source, target, angle)
+        dist = math.hypot(rx - source[0], ry - source[1])
+        assert dist == approx(5.0)
+
+
+def test_rotate_around_point_180_reflects_through_source():
+    """A 180 degree rotation reflects the target through the source (direction-independent)."""
+    source = (2.0, 3.0)
+    target = (5.0, 3.0)
+    rx, ry = rotate_around_point(source, target, 180.0)
+    assert rx == approx(2.0 * source[0] - target[0])
+    assert ry == approx(2.0 * source[1] - target[1])


### PR DESCRIPTION
## Summary

`arcade.math.rotate_around_point(source, target, angle)` rotates `target` around `source`, but it adds the rotated offset back to `target` instead of to the center of rotation `source`. As a result the returned point is placed incorrectly and its distance from the center is not preserved.

## Reproduction

```python
from arcade.math import rotate_around_point

# Rotate (1, 0) around the origin by 90 degrees.
print(rotate_around_point((0.0, 0.0), (1.0, 0.0), 90.0))
# actual:   (1.0, 1.0)   -> distance sqrt(2) from the center
# expected: (0.0, 1.0)   -> distance 1.0 from the center
```

Any rotation where the source and target differ lands on the wrong point.

## Fix

The offset `(dx, dy)` is the rotated `source -> target` vector, so it must be added to the center of rotation `source`, not to `target`:

```diff
-    return target[0] + dx, target[1] + dy
+    return source[0] + dx, source[1] + dy
```

## Tests

Added two regression tests in `tests/unit/test_math.py` that are independent of the clockwise/counter-clockwise convention:

- the rotated point keeps its distance from `source` for several angles, and
- a 180 degree rotation reflects `target` through `source`.

Both fail on the previous behavior and pass with the fix.
