### PR TITLE
Fix broken links and typo under Community Locations > Other Locations

### DIFF
--- a/doc/community/community_locations.rst
+++ b/doc/community/community_locations.rst
@@ -36,5 +36,5 @@ Other Locations
 Arcade has a presence on the platforms below, but they're not very active as
 of Summer 2024:
 
-* `r/pythonarcadde <Reddit>`_ on Reddit
-* `@ArcadeLibrary <Twitter>`_ on x.com (formerly Twitter)
+* `r/pythonarcade <https://www.reddit.com/r/pythonarcade/>`_ on Reddit
+* `@ArcadeLibrary <https://x.com/ArcadeLibrary>`_ on x.com (formerly Twitter)


### PR DESCRIPTION
Changes:
* Fix broken community links on the community locations page
* Fix typo in subreddit name

Tests:
- [x] Build the doc locally
- [x] View in-browser to verify it works