### PR TITLE
Bump typer from 0.27.1 to 0.27.2 in the dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "ruff",
     "mypy",
     "pyright==1.1.387",
-    "typer==0.27.1",    # Needed for make.py; older typer incompatible with security-patched click
+    "typer==0.27.2",    # Needed for make.py; older typer incompatible with security-patched click
     "wheel",
     "bottle",            # Used for web testing playground
     {include-group = "extras"},


### PR DESCRIPTION
Fixes #2773

- 0.27.2 is the current latest release (2026-08-28). There are no breaking changes since the pinned 0.27.1: the last breaking release was 0.27.0, which is already below the current pin.
- Verified make.py under 0.27.2: `--help` output is byte-identical to 0.27.1, every command registers, and the boolean `--check` flags parse correctly.
- No changes were needed in make.py.